### PR TITLE
realtime_kit: Port to GDBus

### DIFF
--- a/include/realtime_kit.hpp
+++ b/include/realtime_kit.hpp
@@ -1,7 +1,7 @@
 #ifndef REALTIMEKIT_HPP
 #define REALTIMEKIT_HPP
 
-#include <dbus-1.0/dbus/dbus.h>
+#include <giomm/dbusproxy.h>
 #include <iostream>
 
 #define RTKIT_SERVICE_NAME "org.freedesktop.RealtimeKit1"
@@ -19,7 +19,8 @@ class RealtimeKit {
  private:
   std::string log_tag;
 
-  DBusConnection* bus;
+  Glib::RefPtr<Gio::DBus::Proxy> proxy;
+  Glib::RefPtr<Gio::DBus::Proxy> properties_proxy;
 
   long long get_int_property(const char* propname);
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -104,7 +104,6 @@ pulseeffects_deps = [
 	dependency('boost', version: '>=1.65', modules:['system','filesystem']),
 	dependency('sndfile'),
 	dependency('threads'),
-	dependency('dbus-1'),
 	dependency('gstreamer-audio-1.0')
 ]
 

--- a/src/realtime_kit.cpp
+++ b/src/realtime_kit.cpp
@@ -8,23 +8,23 @@
 RealtimeKit::RealtimeKit(const std::string& tag) {
   log_tag = tag + "rtkit: ";
 
-  DBusError error;
-
-  dbus_error_init(&error);
-
-  if (!(bus = dbus_bus_get_private(DBUS_BUS_SYSTEM, &error))) {
+  try {
+    proxy = Gio::DBus::Proxy::create_for_bus_sync(Gio::DBus::BusType::BUS_TYPE_SYSTEM,
+                                                  RTKIT_SERVICE_NAME,
+                                                  RTKIT_OBJECT_PATH,
+                                                  "org.freedesktop.RealtimeKit1");
+    properties_proxy = Gio::DBus::Proxy::create_for_bus_sync(Gio::DBus::BusType::BUS_TYPE_SYSTEM,
+                                                             RTKIT_SERVICE_NAME,
+                                                             RTKIT_OBJECT_PATH,
+                                                             "org.freedesktop.DBus.Properties");
+  } catch (const Glib::Error& err) {
     util::warning(log_tag +
-                  "Failed to connect to system bus: " + error.message);
+                  "Failed to connect to system bus: " + err.what().c_str());
   }
-
-  dbus_connection_set_exit_on_disconnect(bus, false);
-
-  dbus_error_free(&error);
 }
 
 RealtimeKit::~RealtimeKit() {
-  dbus_connection_close(bus);
-  dbus_connection_unref(bus);
+  // Glib::object_unref(proxy);
 }
 
 /*
@@ -32,55 +32,34 @@ RealtimeKit::~RealtimeKit() {
 */
 
 long long RealtimeKit::get_int_property(const char* propname) {
-  DBusMessage *m = NULL, *r = NULL;
-  DBusMessageIter iter, subiter;
-  DBusError error;
-  int current_type;
+  Glib::VariantBase reply_body;
   long long propval = 0;
   const char* interfacestr = "org.freedesktop.RealtimeKit1";
 
-  dbus_error_init(&error);
+  Glib::VariantContainerBase args = Glib::VariantContainerBase::create_tuple(std::vector<Glib::VariantBase>({
+    Glib::Variant<Glib::ustring>::create(interfacestr),
+    Glib::Variant<Glib::ustring>::create(propname)
+  }));
 
-  m = dbus_message_new_method_call(RTKIT_SERVICE_NAME, RTKIT_OBJECT_PATH,
-                                   "org.freedesktop.DBus.Properties", "Get");
+  try {
+    reply_body = properties_proxy->call_sync("Get", args);
 
-  dbus_message_append_args(m, DBUS_TYPE_STRING, &interfacestr, DBUS_TYPE_STRING,
-                           &propname, DBUS_TYPE_INVALID);
+    // The rtkit reply is encoded as a tuple containing `@v <@x 123456>` instead of just plain @x or @i
+    if (reply_body.get_type_string() == "(v)") {
+      Glib::VariantBase child = Glib::VariantBase::cast_dynamic<Glib::Variant<std::tuple<Glib::VariantBase>>>(reply_body).get_child<Glib::VariantBase>(0);
 
-  if (!(r = dbus_connection_send_with_reply_and_block(bus, m, -1, &error))) {
-    util::warning(log_tag + error.name + " : " + error.message);
-  }
-
-  dbus_message_iter_init(r, &iter);
-
-  while ((current_type = dbus_message_iter_get_arg_type(&iter)) !=
-         DBUS_TYPE_INVALID) {
-    if (current_type == DBUS_TYPE_VARIANT) {
-      dbus_message_iter_recurse(&iter, &subiter);
-
-      while ((current_type = dbus_message_iter_get_arg_type(&subiter)) !=
-             DBUS_TYPE_INVALID) {
-        if (current_type == DBUS_TYPE_INT32) {
-          dbus_int32_t i32;
-
-          dbus_message_iter_get_basic(&subiter, &i32);
-
-          propval = i32;
-        }
-
-        if (current_type == DBUS_TYPE_INT64) {
-          dbus_int32_t i64;
-
-          dbus_message_iter_get_basic(&subiter, &i64);
-
-          propval = i64;
-        }
-
-        dbus_message_iter_next(&subiter);
+      if (child.get_type_string() == "i") {
+        propval = *(const gint32*) Glib::VariantBase::cast_dynamic<Glib::Variant<gint32>>(child).get_data();
+      } else if (child.get_type_string() == "x") {
+        propval = *(const gint64*) Glib::VariantBase::cast_dynamic<Glib::Variant<gint64>>(child).get_data();
+      } else {
+        util::warning(log_tag + " Expected value of type i or x but received " + child.get_type_string());
       }
+    } else {
+      util::warning(log_tag + " Expected value of type (v) but received " + reply_body.get_type_string());
     }
-
-    dbus_message_iter_next(&iter);
+  } catch (const Glib::Error& err) {
+    util::warning(log_tag + err.what().c_str());
   }
 
   return propval;
@@ -90,42 +69,27 @@ void RealtimeKit::make_realtime(const std::string& source_name,
                                 const int& priority) {
 #if defined(__linux__)
 
-  DBusMessage *m = nullptr, *r = nullptr;
-  dbus_uint64_t u64;
-  dbus_uint32_t u32;
-  DBusError error;
+  guint64 u64;
+  guint32 u32;
 
   pid_t thread = (pid_t)syscall(SYS_gettid);
 
-  u64 = (dbus_uint64_t)thread;
-  u32 = (dbus_uint32_t)priority;
+  u64 = (guint64)thread;
+  u32 = (guint32)priority;
 
-  m = dbus_message_new_method_call(RTKIT_SERVICE_NAME, RTKIT_OBJECT_PATH,
-                                   "org.freedesktop.RealtimeKit1",
-                                   "MakeThreadRealtime");
+  Glib::VariantContainerBase args = Glib::VariantContainerBase::create_tuple(std::vector<Glib::VariantBase>({
+    Glib::Variant<guint64>::create(u64),
+    Glib::Variant<guint32>::create(u32)
+  }));
 
-  dbus_message_append_args(m, DBUS_TYPE_UINT64, &u64, DBUS_TYPE_UINT32, &u32,
-                           DBUS_TYPE_INVALID);
-
-  dbus_error_init(&error);
-
-  if (!(r = dbus_connection_send_with_reply_and_block(bus, m, -1, &error))) {
-    util::warning(log_tag + error.name + " : " + error.message);
-  } else {
+  try {
+    proxy->call_sync("MakeThreadRealtime", args);
     util::debug(log_tag + "changed " + source_name +
                 " thread real-time priority value to " +
                 std::to_string(priority));
+  } catch (const Glib::Error& err) {
+    util::warning(log_tag + err.what().c_str());
   }
-
-  if (m) {
-    dbus_message_unref(m);
-  }
-
-  if (r) {
-    dbus_message_unref(r);
-  }
-
-  dbus_error_free(&error);
 
 #endif
 }
@@ -134,41 +98,26 @@ void RealtimeKit::make_high_priority(const std::string& source_name,
                                      const int& nice_value) {
 #if defined(__linux__)
 
-  DBusMessage *m = nullptr, *r = nullptr;
-  dbus_uint64_t u64;
-  dbus_int32_t u32;
-  DBusError error;
+  guint64 u64;
+  gint32 i32;
 
   pid_t thread = (pid_t)syscall(SYS_gettid);
 
-  u64 = (dbus_uint64_t)thread;
-  u32 = (dbus_int32_t)nice_value;
+  u64 = (guint64)thread;
+  i32 = (gint32)nice_value;
 
-  m = dbus_message_new_method_call(RTKIT_SERVICE_NAME, RTKIT_OBJECT_PATH,
-                                   "org.freedesktop.RealtimeKit1",
-                                   "MakeThreadHighPriority");
+  Glib::VariantContainerBase args = Glib::VariantContainerBase::create_tuple(std::vector<Glib::VariantBase>({
+    Glib::Variant<guint64>::create(u64),
+    Glib::Variant<gint32>::create(i32)
+  }));
 
-  dbus_message_append_args(m, DBUS_TYPE_UINT64, &u64, DBUS_TYPE_INT32, &u32,
-                           DBUS_TYPE_INVALID);
-
-  dbus_error_init(&error);
-
-  if (!(r = dbus_connection_send_with_reply_and_block(bus, m, -1, &error))) {
-    util::warning(log_tag + error.name + " : " + error.message);
-  } else {
+  try {
+    proxy->call_sync("MakeThreadHighPriority", args);
     util::debug(log_tag + "changed " + source_name + " thread nice value to " +
                 std::to_string(nice_value));
+  } catch (const Glib::Error& err) {
+    util::warning(log_tag + err.what().c_str());
   }
-
-  if (m) {
-    dbus_message_unref(m);
-  }
-
-  if (r) {
-    dbus_message_unref(r);
-  }
-
-  dbus_error_free(&error);
 
 #endif
 }


### PR DESCRIPTION
There is no need to use libdbus, GLib contains its own implementation.

Builds but I did not test this yet.

Also this is mostly 1:1 port to low-level GDBus API, in the future, it could be simplified using higher-level APIs.

### Relevant docs
- https://dbus.freedesktop.org/doc/dbus-specification.html#basic-types
- https://dbus.freedesktop.org/doc/api/html/group__DBusConnection.html
- https://developer.gnome.org/gio/stable/GDBusConnection.html
- https://developer.gnome.org/glibmm/2.53/classGio_1_1DBus_1_1Connection.html