### PR TITLE
Update AppStream screenshots

### DIFF
--- a/data/com.github.wwmm.easyeffects.appdata.xml.in
+++ b/data/com.github.wwmm.easyeffects.appdata.xml.in
@@ -17,26 +17,15 @@
   <url type="homepage">https://github.com/wwmm/easyeffects</url>
   <url type="bugtracker">https://github.com/wwmm/easyeffects/issues</url>
   <url type="help">https://github.com/wwmm/easyeffects/blob/master/README.md</url>
-  <screenshots>
+  <screenshots>    
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/wwmm/easyeffects/master/images/appdata-screenshot-01.png</image>
-      <caption>Set the volume and turn on/off effects</caption>
+      <image>https://raw.githubusercontent.com/wwmm/easyeffects/master/images/easyeffects_players.png</image>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/wwmm/easyeffects/master/images/appdata-screenshot-02.png</image>
-      <caption>Includes an equalizer with built-in presets</caption>
+      <image>https://raw.githubusercontent.com/wwmm/easyeffects/master/images/easyeffects_plugins.png</image>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/wwmm/easyeffects/master/images/appdata-screenshot-03.png</image>
-      <caption>Input Limiter</caption>
-    </screenshot>
-    <screenshot>
-      <image>https://raw.githubusercontent.com/wwmm/easyeffects/master/images/appdata-screenshot-04.png</image>
-      <caption>Compressor</caption>
-    </screenshot>
-    <screenshot>
-      <image>https://raw.githubusercontent.com/wwmm/easyeffects/master/images/appdata-screenshot-05.png</image>
-      <caption>Calibration</caption>
+      <image>https://raw.githubusercontent.com/wwmm/easyeffects/master/images/convolver.png</image>
     </screenshot>
   </screenshots>
   <releases>


### PR DESCRIPTION
This updates the AppStream screenshots to the ones used in the [readme](https://github.com/wwmm/easyeffects/blob/master/README.md), which should be reflected in most Linux GUI software managers. The [Flatpak](https://github.com/flathub/flathub/pull/2429) will also benefit from this.

I'll try to revisit the captions if I or anyone has ideas for screenshot captions.

[AppStream screenshot documentation](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#qsr-app-screenshots-info).
`appstreamcli validate --pedantic` complains about the lack of captions, but those are optional (a pedantic complaint).
[I used this tool to help](https://www.freedesktop.org/software/appstream/metainfocreator/#/guiapp).

As a side note, what do you think of the AppStream description? I noticed a typo ("tools" > "tool"), is everything else in the description still accurate, or is there a better place to source a description?