### PR TITLE
LSP MBC interface fixed

### DIFF
--- a/data/ui/multiband_compressor.ui
+++ b/data/ui/multiband_compressor.ui
@@ -9,122 +9,120 @@
         <property name="orientation">vertical</property>
 
         <child>
-            <object class="GtkGrid">
+            <object class="GtkBox">
                 <property name="halign">center</property>
                 <property name="valign">center</property>
-                <property name="row-spacing">24</property>
-                <property name="column-spacing">24</property>
+                <property name="spacing">24</property>
 
                 <child>
-                    <object class="GtkGrid">
+                    <object class="GtkBox">
                         <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="row-spacing">6</property>
-                        <property name="column-spacing">24</property>
+                        <property name="valign">start</property>
+                        <property name="spacing">24</property>
+                        <property name="orientation">vertical</property>
 
                         <child>
-                            <object class="GtkToggleButton" id="bypass">
+                            <object class="GtkGrid">
                                 <property name="halign">center</property>
-                                <property name="label" translatable="yes">Bypass</property>
+                                <property name="valign">start</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">24</property>
 
-                                <layout>
-                                    <property name="column">1</property>
-                                    <property name="row">1</property>
-                                </layout>
+                                <child>
+                                    <object class="GtkToggleButton" id="bypass">
+                                        <property name="halign">center</property>
+                                        <property name="label" translatable="yes">Bypass</property>
+
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="label" translatable="yes">Operating Mode</property>
+
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkComboBoxText" id="compressor_mode">
+                                        <property name="halign">center</property>
+                                        <items>
+                                            <item translatable="yes">Classic</item>
+                                            <item translatable="yes">Modern</item>
+                                        </items>
+
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="label" translatable="yes">Sidechain Boost</property>
+
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkComboBoxText" id="envelope_boost">
+                                        <property name="halign">center</property>
+                                        <items>
+                                            <item translatable="yes">None</item>
+                                            <item translatable="yes">Pink BT</item>
+                                            <item translatable="yes">Pink MT</item>
+                                            <item translatable="yes">Brown BT</item>
+                                            <item translatable="yes">Brown MT</item>
+                                        </items>
+
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
                             </object>
                         </child>
 
                         <child>
-                            <object class="GtkLabel">
+                            <object class="GtkStack" id="stack">
+                                <property name="hexpand">1</property>
                                 <property name="halign">center</property>
-                                <property name="valign">center</property>
-                                <property name="label" translatable="yes">Operating Mode</property>
-
-                                <layout>
-                                    <property name="column">0</property>
-                                    <property name="row">0</property>
-                                </layout>
+                                <property name="valign">start</property>
+                                <property name="hhomogeneous">0</property>
+                                <property name="vhomogeneous">0</property>
+                                <property name="transition_duration">250</property>
+                                <property name="transition_type">slide-left-right</property>
                             </object>
                         </child>
-
-                        <child>
-                            <object class="GtkComboBoxText" id="compressor_mode">
-                                <property name="halign">center</property>
-                                <items>
-                                    <item translatable="yes">Classic</item>
-                                    <item translatable="yes">Modern</item>
-                                </items>
-
-                                <layout>
-                                    <property name="column">0</property>
-                                    <property name="row">1</property>
-                                </layout>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                                <property name="label" translatable="yes">Sidechain Boost</property>
-
-                                <layout>
-                                    <property name="column">2</property>
-                                    <property name="row">0</property>
-                                </layout>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkComboBoxText" id="envelope_boost">
-                                <property name="halign">center</property>
-                                <items>
-                                    <item translatable="yes">None</item>
-                                    <item translatable="yes">Pink BT</item>
-                                    <item translatable="yes">Pink MT</item>
-                                    <item translatable="yes">Brown BT</item>
-                                    <item translatable="yes">Brown MT</item>
-                                </items>
-
-                                <layout>
-                                    <property name="column">2</property>
-                                    <property name="row">1</property>
-                                </layout>
-                            </object>
-                        </child>
-
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkStack" id="stack">
-                        <property name="hexpand">1</property>
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hhomogeneous">0</property>
-                        <property name="vhomogeneous">0</property>
-                        <property name="transition_duration">250</property>
-                        <property name="transition_type">slide-left-right</property>
-
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
                     </object>
                 </child>
 
                 <child>
                     <object class="GtkFrame">
-                        <property name="halign">end</property>
-                        <property name="valign">center</property>
+                        <property name="halign">center</property>
+                        <property name="valign">start</property>
 
                         <child>
                             <object class="GtkListBox" id="listbox">
-                                <property name="halign">end</property>
+                                <property name="halign">center</property>
                                 <property name="valign">center</property>
                                 <property name="selection-mode">single</property>
                                 <property name="show-separators">1</property>
@@ -318,12 +316,6 @@
                                 </style>
                             </object>
                         </child>
-
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                            <property name="row-span">2</property>
-                        </layout>
                     </object>
                 </child>
             </object>

--- a/data/ui/multiband_compressor_band.ui
+++ b/data/ui/multiband_compressor_band.ui
@@ -5,37 +5,8 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">18</property>
+        <property name="spacing">24</property>
         <property name="orientation">vertical</property>
-
-        <child>
-            <object class="GtkBox">
-                <property name="spacing">24</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-
-                <child>
-                    <object class="GtkToggleButton" id="bypass">
-                        <property name="halign">center</property>
-                        <property name="label" translatable="yes">Band Bypass</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkToggleButton" id="mute">
-                        <property name="halign">center</property>
-                        <property name="label" translatable="yes">Mute</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkToggleButton" id="solo">
-                        <property name="halign">center</property>
-                        <property name="label" translatable="yes">Solo</property>
-                    </object>
-                </child>
-            </object>
-        </child>
 
         <child>
             <object class="GtkGrid">
@@ -48,7 +19,7 @@
                     <object class="GtkLabel">
                         <property name="halign">center</property>
                         <property name="valign">center</property>
-                        <property name="label" translatable="yes">Start Frequency</property>
+                        <property name="label" translatable="yes">Band Start</property>
 
                         <layout>
                             <property name="column">0</property>
@@ -90,7 +61,7 @@
                     <object class="GtkLabel">
                         <property name="halign">center</property>
                         <property name="valign">center</property>
-                        <property name="label" translatable="yes">End Frequency</property>
+                        <property name="label" translatable="yes">Band End</property>
 
                         <layout>
                             <property name="column">1</property>
@@ -129,49 +100,26 @@
                 </child>
 
                 <child>
-                    <object class="GtkBox">
+                    <object class="GtkLabel">
                         <property name="halign">center</property>
                         <property name="valign">center</property>
-                        <property name="spacing">6</property>
+                        <property name="label" translatable="yes">Compression Mode</property>
 
                         <layout>
                             <property name="column">2</property>
                             <property name="row">0</property>
                         </layout>
-
-                        <child>
-                            <object class="GtkCheckButton" id="lowcut_filter">
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="label" translatable="yes">Low Cut Filter</property>
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                                <property name="hexpand">1</property>
-                            </object>
-                        </child>
                     </object>
                 </child>
 
                 <child>
-                    <object class="GtkSpinButton" id="lowcut_filter_frequency">
+                    <object class="GtkComboBoxText" id="compression_mode">
                         <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="digits">0</property>
-                        <property name="width-chars">10</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">10</property>
-                                <property name="upper">20000</property>
-                                <property name="value">10</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">10</property>
-                            </object>
-                        </property>
+                        <items>
+                            <item translatable="yes">Downward</item>
+                            <item translatable="yes">Upward</item>
+                            <item translatable="yes">Boosting</item>
+                        </items>
 
                         <layout>
                             <property name="column">2</property>
@@ -181,52 +129,36 @@
                 </child>
 
                 <child>
-                    <object class="GtkBox">
+                    <object class="GtkToggleButton" id="bypass">
                         <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="spacing">6</property>
+                        <property name="label" translatable="yes">Band Bypass</property>
 
                         <layout>
                             <property name="column">3</property>
-                            <property name="row">0</property>
+                            <property name="row">1</property>
                         </layout>
-
-                        <child>
-                            <object class="GtkCheckButton" id="highcut_filter">
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="label" translatable="yes">High Cut Filter</property>
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                                <property name="hexpand">1</property>
-                            </object>
-                        </child>
                     </object>
                 </child>
 
                 <child>
-                    <object class="GtkSpinButton" id="highcut_filter_frequency">
+                    <object class="GtkToggleButton" id="mute">
                         <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="digits">0</property>
-                        <property name="width-chars">10</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">10</property>
-                                <property name="upper">20000</property>
-                                <property name="value">20000</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">10</property>
-                            </object>
-                        </property>
+                        <property name="label" translatable="yes">Mute</property>
 
                         <layout>
-                            <property name="column">3</property>
+                            <property name="column">4</property>
+                            <property name="row">1</property>
+                        </layout>
+                    </object>
+                </child>
+
+                <child>
+                    <object class="GtkToggleButton" id="solo">
+                        <property name="halign">center</property>
+                        <property name="label" translatable="yes">Solo</property>
+
+                        <layout>
+                            <property name="column">5</property>
                             <property name="row">1</property>
                         </layout>
                     </object>
@@ -510,289 +442,428 @@
         </child>
 
         <child>
-            <object class="GtkGrid">
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">24</property>
+            <object class="GtkBox">
+                <property name="hexpand">1</property>
+                <property name="vexpand">0</property>
 
                 <child>
                     <object class="GtkLabel">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="label" translatable="yes">Compression Mode</property>
-
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
+                        <property name="halign">end</property>
+                        <property name="xalign">1</property>
+                        <property name="label" translatable="yes">Band Gain</property>
                     </object>
                 </child>
 
                 <child>
-                    <object class="GtkComboBoxText" id="compression_mode">
-                        <property name="halign">center</property>
-                        <items>
-                            <item translatable="yes">Downward</item>
-                            <item translatable="yes">Upward</item>
-                            <item translatable="yes">Boosting</item>
-                        </items>
+                    <object class="GtkLevelBar" id="band_level_bar">
+                        <property name="valign">center</property>
+                        <property name="hexpand">1</property>
+                        <property name="max-value">5</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
+                    </object>
+                </child>
 
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
+                <child>
+                    <object class="GtkLabel" id="band_level_label">
+                        <property name="halign">center</property>
+                        <property name="width-chars">4</property>
+                        <property name="label">0</property>
                     </object>
                 </child>
 
                 <child>
                     <object class="GtkLabel">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="label" translatable="yes">Sidechain Mode</property>
-
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkComboBoxText" id="sidechain_mode">
-                        <property name="halign">center</property>
-                        <items>
-                            <item translatable="yes">Peak</item>
-                            <item translatable="yes">RMS</item>
-                            <item translatable="yes">Low-Pass</item>
-                            <item translatable="yes">Uniform</item>
-                        </items>
-
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="label" translatable="yes">Sidechain Source</property>
-
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkComboBoxText" id="sidechain_source">
-                        <property name="halign">center</property>
-                        <items>
-                            <item translatable="yes">Middle</item>
-                            <item translatable="yes">Side</item>
-                            <item translatable="yes">Left</item>
-                            <item translatable="yes">Right</item>
-                        </items>
-
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
+                        <property name="halign">start</property>
+                        <property name="margin-start">2</property>
+                        <property name="label">db</property>
                     </object>
                 </child>
             </object>
         </child>
 
         <child>
-            <object class="GtkGrid">
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">24</property>
-
-                <child>
+            <object class="GtkExpander">
+                <child type="label">
                     <object class="GtkLabel">
                         <property name="halign">center</property>
                         <property name="valign">center</property>
-                        <property name="label" translatable="yes">SC PreAmp</property>
-
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
+                        <property name="label" translatable="yes">Band Sidechain Options</property>
                     </object>
                 </child>
 
                 <child>
-                    <object class="GtkSpinButton" id="sidechain_preamp">
-                        <property name="halign">center</property>
+                    <object class="GtkBox">
                         <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="upper">-120</property>
-                                <property name="upper">40</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel">
+                        <property name="spacing">24</property>
                         <property name="halign">center</property>
                         <property name="valign">center</property>
-                        <property name="label" translatable="yes">SC Reactivity</property>
+                        <property name="margin-top">6</property>
 
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
+                        <child>
+                            <object class="GtkGrid">
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">24</property>
 
-                <child>
-                    <object class="GtkSpinButton" id="sidechain_reactivity">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">2</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="upper">250</property>
-                                <property name="value">10</property>
-                                <property name="step-increment">0.01</property>
-                                <property name="page-increment">0.1</property>
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="label" translatable="yes">Mode</property>
+
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkComboBoxText" id="sidechain_mode">
+                                        <property name="halign">center</property>
+                                        <items>
+                                            <item translatable="yes">Peak</item>
+                                            <item translatable="yes">RMS</item>
+                                            <item translatable="yes">Low-Pass</item>
+                                            <item translatable="yes">Uniform</item>
+                                        </items>
+
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="label" translatable="yes">Source</property>
+
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkComboBoxText" id="sidechain_source">
+                                        <property name="halign">center</property>
+                                        <items>
+                                            <item translatable="yes">Middle</item>
+                                            <item translatable="yes">Side</item>
+                                            <item translatable="yes">Left</item>
+                                            <item translatable="yes">Right</item>
+                                        </items>
+
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="spacing">6</property>
+
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+
+                                        <child>
+                                            <object class="GtkCheckButton" id="lowcut_filter">
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="label" translatable="yes">Low-Cut Filter</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="hexpand">1</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkSpinButton" id="lowcut_filter_frequency">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="digits">0</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">10</property>
+                                                <property name="upper">20000</property>
+                                                <property name="value">10</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">10</property>
+                                            </object>
+                                        </property>
+
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="spacing">6</property>
+
+                                        <layout>
+                                            <property name="column">3</property>
+                                            <property name="row">0</property>
+                                        </layout>
+
+                                        <child>
+                                            <object class="GtkCheckButton" id="highcut_filter">
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="label" translatable="yes">High-Cut Filter</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="hexpand">1</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkSpinButton" id="highcut_filter_frequency">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="digits">0</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">10</property>
+                                                <property name="upper">20000</property>
+                                                <property name="value">20000</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">10</property>
+                                            </object>
+                                        </property>
+
+                                        <layout>
+                                            <property name="column">3</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
                             </object>
-                        </property>
+                        </child>
 
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                    </object>
-                </child>
+                        <child>
+                            <object class="GtkGrid">
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">24</property>
 
-                <child>
-                    <object class="GtkLabel">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="label" translatable="yes">SC LookAhead</property>
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="label" translatable="yes">SC PreAmp</property>
 
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
 
-                <child>
-                    <object class="GtkSpinButton" id="sidechain_lookahead">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">2</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="upper">20</property>
-                                <property name="step-increment">0.01</property>
-                                <property name="page-increment">0.1</property>
+                                <child>
+                                    <object class="GtkSpinButton" id="sidechain_preamp">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="upper">-120</property>
+                                                <property name="upper">40</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="label" translatable="yes">SC Reactivity</property>
+
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkSpinButton" id="sidechain_reactivity">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">2</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="upper">250</property>
+                                                <property name="value">10</property>
+                                                <property name="step-increment">0.01</property>
+                                                <property name="page-increment">0.1</property>
+                                            </object>
+                                        </property>
+
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="label" translatable="yes">SC LookAhead</property>
+
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkSpinButton" id="sidechain_lookahead">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">2</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="upper">20</property>
+                                                <property name="step-increment">0.01</property>
+                                                <property name="page-increment">0.1</property>
+                                            </object>
+                                        </property>
+
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="label" translatable="yes">Boost Amount</property>
+
+                                        <layout>
+                                            <property name="column">3</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkSpinButton" id="boost_amount">
+                                    <property name="halign">center</property>
+                                    <property name="orientation">vertical</property>
+                                    <property name="width-chars">10</property>
+                                    <property name="digits">0</property>
+                                    <property name="update-policy">if-valid</property>
+                                    <property name="adjustment">
+                                        <object class="GtkAdjustment">
+                                            <property name="lower">0</property>
+                                            <property name="upper">72</property>
+                                            <property name="value">6</property>
+                                            <property name="step-increment">1</property>
+                                            <property name="page-increment">10</property>
+                                        </object>
+                                    </property>
+                                    <layout>
+                                        <property name="column">3</property>
+                                        <property name="row">1</property>
+                                    </layout>
+                                </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="label" translatable="yes">Boost Threshold</property>
+
+                                        <layout>
+                                            <property name="column">4</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkSpinButton" id="boost_threshold">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">0</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-120</property>
+                                                <property name="upper">-60</property>
+                                                <property name="value">-72</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">10</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">4</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
                             </object>
-                        </property>
-
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="label" translatable="yes">Boost Amount</property>
-
-                        <layout>
-                            <property name="column">3</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkSpinButton" id="boost_amount">
-                    <property name="halign">center</property>
-                    <property name="orientation">vertical</property>
-                    <property name="width-chars">10</property>
-                    <property name="digits">0</property>
-                    <property name="update-policy">if-valid</property>
-                    <property name="adjustment">
-                        <object class="GtkAdjustment">
-                            <property name="lower">0</property>
-                            <property name="upper">72</property>
-                            <property name="value">6</property>
-                            <property name="step-increment">1</property>
-                            <property name="page-increment">10</property>
-                        </object>
-                    </property>
-                    <layout>
-                        <property name="column">3</property>
-                        <property name="row">1</property>
-                    </layout>
-                </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="label" translatable="yes">Boost Threshold</property>
-
-                        <layout>
-                            <property name="column">4</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkSpinButton" id="boost_threshold">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">0</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-120</property>
-                                <property name="upper">-60</property>
-                                <property name="value">-72</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">10</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">4</property>
-                            <property name="row">1</property>
-                        </layout>
+                        </child>
                     </object>
                 </child>
             </object>
+
         </child>
     </object>
 </interface>

--- a/src/multiband_compressor_ui.cpp
+++ b/src/multiband_compressor_ui.cpp
@@ -226,9 +226,18 @@ MultibandCompressorUi::MultibandCompressorUi(BaseObjectType* cobject,
   listbox->select_row(*listbox->get_row_at_index(0));
 
   listbox->signal_selected_rows_changed().connect([=, this]() {
-    int row = listbox->get_selected_row()->get_index();
+    // some core dumps happened here
+    // checking pointer and int row integrity might fix them
 
-    stack->set_visible_child("band" + std::to_string(row));
+    auto* selected_row = listbox->get_selected_row();
+
+    if (selected_row != nullptr) {
+      int row = selected_row->get_index();
+
+      if (row > -1) {
+        stack->set_visible_child("band" + std::to_string(row));
+      }
+    }
   });
 
   // gsettings bindings


### PR DESCRIPTION
> Solid work. I am still quite busy but after a quick look I have only 2 concerns
> 
>     1. The plugin interface height seems too big. I know that there is a scroll there but we still have to find a place for each band signal meters. Maybe we will still need to use a tab for each band somewhere like in the single band compressor. As I have a big monitor at my desktop I could just maximize the window. But I am concerned about users on laptop screens.

I added an expander. It seems better than the stackpage because when you change band, you still see the main compress options. With stackswitcher, if you switch to sidechain options and change band, then return to the original band, you can't see the compressor options.
 
>     2. Sometimes there is a segmentation fault. Looking at `gdb` output the cause is the line with `int row = listbox->get_selected_row()->get_index();`. I am not sure I will have time today to understand why.

Maybe the signal is emitted when the listbox return a null pointer. I made a safer function for row switching. 

Please test on your system.

Tomorrow I'll try to link the presets and test with audio reproduction. There's still to link the band gain and "band end freq" in the UI.