### PR TITLE
LSP MBC presets completed

### DIFF
--- a/data/schemas/com.github.wwmm.easyeffects.multibandcompressor.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.multibandcompressor.gschema.xml
@@ -30,11 +30,11 @@
     </enum>
     <schema id="com.github.wwmm.easyeffects.multibandcompressor">
         <key name="input-gain" type="d">
-            <range min="-40.0" max="20.0" />
+            <range min="-36.1" max="36.1" />
             <default>0.0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-40.0" max="20.0" />
+            <range min="-36.1" max="36.1" />
             <default>0.0</default>
         </key>
 

--- a/data/ui/multiband_compressor_band.ui
+++ b/data/ui/multiband_compressor_band.ui
@@ -305,7 +305,7 @@
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
                                         <property name="lower">-120</property>
-                                        <property name="lower">-36</property>
+                                        <property name="upper">-36</property>
                                         <property name="value">-120</property>
                                         <property name="step-increment">0.01</property>
                                         <property name="page-increment">0.1</property>
@@ -702,7 +702,7 @@
                                         <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
-                                                <property name="upper">-120</property>
+                                                <property name="lower">-120</property>
                                                 <property name="upper">40</property>
                                                 <property name="step-increment">0.1</property>
                                                 <property name="page-increment">1</property>

--- a/include/multiband_compressor_preset.hpp
+++ b/include/multiband_compressor_preset.hpp
@@ -27,6 +27,8 @@ class MultibandCompressorPreset : public PluginPresetBase {
   MultibandCompressorPreset();
 
  private:
+  static constexpr uint n_bands = 8;
+
   void save(nlohmann::json& json, const std::string& section, const Glib::RefPtr<Gio::Settings>& settings) override;
 
   void load(const nlohmann::json& json,

--- a/src/multiband_compressor.cpp
+++ b/src/multiband_compressor.cpp
@@ -45,57 +45,57 @@ MultibandCompressor::MultibandCompressor(const std::string& tag,
   lv2_wrapper->bind_key_enum(settings, "envelope-boost", "envb");
 
   for (uint n = 0; n < n_bands; n++) {
-    if (n > 0) {
-      lv2_wrapper->bind_key_bool(settings, "enable-band" + std::to_string(n), "cbe_" + std::to_string(n));
+    auto nstr = std::to_string(n);
 
-      lv2_wrapper->bind_key_double(settings, "split-frequency" + std::to_string(n), "sf_" + std::to_string(n));
+    if (n > 0) {
+      lv2_wrapper->bind_key_bool(settings, "enable-band" + nstr, "cbe_" + nstr);
+
+      lv2_wrapper->bind_key_double(settings, "split-frequency" + nstr, "sf_" + nstr);
     }
 
-    lv2_wrapper->bind_key_enum(settings, "sidechain-source" + std::to_string(n), "scs_" + std::to_string(n));
+    lv2_wrapper->bind_key_enum(settings, "sidechain-source" + nstr, "scs_" + nstr);
 
-    lv2_wrapper->bind_key_enum(settings, "sidechain-mode" + std::to_string(n), "scm_" + std::to_string(n));
+    lv2_wrapper->bind_key_enum(settings, "sidechain-mode" + nstr, "scm_" + nstr);
 
-    lv2_wrapper->bind_key_double(settings, "sidechain-lookahead" + std::to_string(n), "sla_" + std::to_string(n));
+    lv2_wrapper->bind_key_double(settings, "sidechain-lookahead" + nstr, "sla_" + nstr);
 
-    lv2_wrapper->bind_key_double(settings, "sidechain-reactivity" + std::to_string(n), "scr_" + std::to_string(n));
+    lv2_wrapper->bind_key_double(settings, "sidechain-reactivity" + nstr, "scr_" + nstr);
 
-    lv2_wrapper->bind_key_double_db(settings, "sidechain-preamp" + std::to_string(n), "scp_" + std::to_string(n));
+    lv2_wrapper->bind_key_double_db(settings, "sidechain-preamp" + nstr, "scp_" + nstr);
 
-    lv2_wrapper->bind_key_bool(settings, "sidechain-custom-lowcut-filter" + std::to_string(n),
-                               "sclc_" + std::to_string(n));
+    lv2_wrapper->bind_key_bool(settings, "sidechain-custom-lowcut-filter" + nstr, "sclc_" + nstr);
 
-    lv2_wrapper->bind_key_bool(settings, "sidechain-custom-highcut-filter" + std::to_string(n),
-                               "schc_" + std::to_string(n));
+    lv2_wrapper->bind_key_bool(settings, "sidechain-custom-highcut-filter" + nstr, "schc_" + nstr);
 
-    lv2_wrapper->bind_key_double(settings, "sidechain-lowcut-frequency" + std::to_string(n),
-                                 "sclf_" + std::to_string(n));
+    lv2_wrapper->bind_key_double(settings, "sidechain-lowcut-frequency" + nstr, "sclf_" + nstr);
 
-    lv2_wrapper->bind_key_double(settings, "sidechain-highcut-frequency" + std::to_string(n),
-                                 "schf_" + std::to_string(n));
+    lv2_wrapper->bind_key_double(settings, "sidechain-highcut-frequency" + nstr, "schf_" + nstr);
 
-    lv2_wrapper->bind_key_enum(settings, "compression-mode" + std::to_string(n), "cm_" + std::to_string(n));
+    lv2_wrapper->bind_key_enum(settings, "compression-mode" + nstr, "cm_" + nstr);
 
-    lv2_wrapper->bind_key_bool(settings, "solo" + std::to_string(n), "bs_" + std::to_string(n));
+    lv2_wrapper->bind_key_bool(settings, "compressor-enable" + nstr, "ce_" + nstr);
 
-    lv2_wrapper->bind_key_bool(settings, "mute" + std::to_string(n), "bm_" + std::to_string(n));
+    lv2_wrapper->bind_key_bool(settings, "solo" + nstr, "bs_" + nstr);
 
-    lv2_wrapper->bind_key_double_db(settings, "attack-threshold" + std::to_string(n), "al_" + std::to_string(n));
+    lv2_wrapper->bind_key_bool(settings, "mute" + nstr, "bm_" + nstr);
 
-    lv2_wrapper->bind_key_double(settings, "attack-time" + std::to_string(n), "at_" + std::to_string(n));
+    lv2_wrapper->bind_key_double_db(settings, "attack-threshold" + nstr, "al_" + nstr);
 
-    lv2_wrapper->bind_key_double_db(settings, "release-threshold" + std::to_string(n), "rrl_" + std::to_string(n));
+    lv2_wrapper->bind_key_double(settings, "attack-time" + nstr, "at_" + nstr);
 
-    lv2_wrapper->bind_key_double(settings, "release-time" + std::to_string(n), "rt_" + std::to_string(n));
+    lv2_wrapper->bind_key_double_db(settings, "release-threshold" + nstr, "rrl_" + nstr);
 
-    lv2_wrapper->bind_key_double(settings, "ratio" + std::to_string(n), "cr_" + std::to_string(n));
+    lv2_wrapper->bind_key_double(settings, "release-time" + nstr, "rt_" + nstr);
 
-    lv2_wrapper->bind_key_double_db(settings, "knee" + std::to_string(n), "kn_" + std::to_string(n));
+    lv2_wrapper->bind_key_double(settings, "ratio" + nstr, "cr_" + nstr);
 
-    lv2_wrapper->bind_key_double_db(settings, "boost-threshold" + std::to_string(n), "bth_" + std::to_string(n));
+    lv2_wrapper->bind_key_double_db(settings, "knee" + nstr, "kn_" + nstr);
 
-    lv2_wrapper->bind_key_double_db(settings, "boost-amount" + std::to_string(n), "bsa_" + std::to_string(n));
+    lv2_wrapper->bind_key_double_db(settings, "boost-threshold" + nstr, "bth_" + nstr);
 
-    lv2_wrapper->bind_key_double_db(settings, "makeup" + std::to_string(n), "mk_" + std::to_string(n));
+    lv2_wrapper->bind_key_double_db(settings, "boost-amount" + nstr, "bsa_" + nstr);
+
+    lv2_wrapper->bind_key_double_db(settings, "makeup" + nstr, "mk_" + nstr);
   }
 
   initialize_listener();
@@ -180,23 +180,25 @@ void MultibandCompressor::process(std::span<float>& left_in,
     notification_dt += sample_duration;
 
     if (notification_dt >= notification_time_window) {
-      std::array<double, n_bands> frequency_range_array{};
+      std::array<double, n_bands> frequency_range_end_array{};
       std::array<double, n_bands> envelope_array{};
       std::array<double, n_bands> curve_array{};
       std::array<double, n_bands> reduction_array{};
 
       for (uint n = 0; n < n_bands; n++) {
-        frequency_range_array.at(n) = lv2_wrapper->get_control_port_value("fre_" + std::to_string(n));
+        auto nstr = std::to_string(n);
 
-        envelope_array.at(n) = lv2_wrapper->get_control_port_value("elm_" + std::to_string(n));
+        frequency_range_end_array.at(n) = lv2_wrapper->get_control_port_value("fre_" + nstr);
 
-        curve_array.at(n) = lv2_wrapper->get_control_port_value("clm_" + std::to_string(n));
+        envelope_array.at(n) = lv2_wrapper->get_control_port_value("elm_" + nstr);
 
-        reduction_array.at(n) = lv2_wrapper->get_control_port_value("rlm_" + std::to_string(n));
+        curve_array.at(n) = lv2_wrapper->get_control_port_value("clm_" + nstr);
+
+        reduction_array.at(n) = lv2_wrapper->get_control_port_value("rlm_" + nstr);
       }
 
       Glib::signal_idle().connect_once([=, this] {
-        frequency_range.emit(frequency_range_array);
+        frequency_range.emit(frequency_range_end_array);
 
         envelope.emit(envelope_array);
 

--- a/src/multiband_compressor_preset.cpp
+++ b/src/multiband_compressor_preset.cpp
@@ -30,192 +30,178 @@ MultibandCompressorPreset::MultibandCompressorPreset() {
 void MultibandCompressorPreset::save(nlohmann::json& json,
                                      const std::string& section,
                                      const Glib::RefPtr<Gio::Settings>& settings) {
-  // json[section]["multiband_compressor"]["input-gain"] = settings->get_double("input-gain");
+  json[section]["multiband_compressor"]["input-gain"] = settings->get_double("input-gain");
 
-  // json[section]["multiband_compressor"]["output-gain"] = settings->get_double("output-gain");
+  json[section]["multiband_compressor"]["output-gain"] = settings->get_double("output-gain");
 
-  // json[section]["multiband_compressor"]["freq0"] = settings->get_double("freq0");
+  json[section]["multiband_compressor"]["compressor-mode"] = settings->get_string("compressor-mode").c_str();
 
-  // json[section]["multiband_compressor"]["freq1"] = settings->get_double("freq1");
+  json[section]["multiband_compressor"]["envelope-boost"] = settings->get_string("envelope-boost").c_str();
 
-  // json[section]["multiband_compressor"]["freq2"] = settings->get_double("freq2");
+  for (uint n = 0; n < n_bands; n++) {
+    auto nstr = std::to_string(n);
 
-  // json[section]["multiband_compressor"]["mode"] = settings->get_string("mode").c_str();
+    if (n > 0) {
+      json[section]["multiband_compressor"]["band" + nstr]["enable-band"] = settings->get_boolean("enable-band" + nstr);
 
-  // // sub band
+      json[section]["multiband_compressor"]["band" + nstr]["split-frequency"] =
+          settings->get_double("split-frequency" + nstr);
+    }
 
-  // json[section]["multiband_compressor"]["subband"]["threshold"] = settings->get_double("threshold0");
+    json[section]["multiband_compressor"]["band" + nstr]["compressor-enable"] =
+        settings->get_boolean("compressor-enable" + nstr);
 
-  // json[section]["multiband_compressor"]["subband"]["ratio"] = settings->get_double("ratio0");
+    json[section]["multiband_compressor"]["band" + nstr]["solo"] =
+        settings->get_boolean("solo" + nstr);
 
-  // json[section]["multiband_compressor"]["subband"]["attack"] = settings->get_double("attack0");
+    json[section]["multiband_compressor"]["band" + nstr]["mute"] =
+        settings->get_boolean("mute" + nstr);
 
-  // json[section]["multiband_compressor"]["subband"]["release"] = settings->get_double("release0");
+    json[section]["multiband_compressor"]["band" + nstr]["attack-threshold"] =
+        settings->get_double("attack-threshold" + nstr);
 
-  // json[section]["multiband_compressor"]["subband"]["makeup"] = settings->get_double("makeup0");
+    json[section]["multiband_compressor"]["band" + nstr]["attack-time"] =
+        settings->get_double("attack-time" + nstr);
 
-  // json[section]["multiband_compressor"]["subband"]["knee"] = settings->get_double("knee0");
+    json[section]["multiband_compressor"]["band" + nstr]["release-threshold"] =
+        settings->get_double("release-threshold" + nstr);
 
-  // json[section]["multiband_compressor"]["subband"]["detection"] = settings->get_string("detection0").c_str();
+    json[section]["multiband_compressor"]["band" + nstr]["release-time"] =
+        settings->get_double("release-time" + nstr);
 
-  // json[section]["multiband_compressor"]["subband"]["bypass"] = settings->get_boolean("bypass0");
+    json[section]["multiband_compressor"]["band" + nstr]["ratio"] =
+        settings->get_double("ratio" + nstr);
 
-  // json[section]["multiband_compressor"]["subband"]["solo"] = settings->get_boolean("solo0");
+    json[section]["multiband_compressor"]["band" + nstr]["knee"] =
+        settings->get_double("knee" + nstr);
 
-  // // low band
+    json[section]["multiband_compressor"]["band" + nstr]["makeup"] =
+        settings->get_double("makeup" + nstr);
 
-  // json[section]["multiband_compressor"]["lowband"]["threshold"] = settings->get_double("threshold1");
+    json[section]["multiband_compressor"]["band" + nstr]["compression-mode"] =
+        settings->get_string("compression-mode" + nstr).c_str();
 
-  // json[section]["multiband_compressor"]["lowband"]["ratio"] = settings->get_double("ratio1");
+    json[section]["multiband_compressor"]["band" + nstr]["sidechain-mode"] =
+        settings->get_string("sidechain-mode" + nstr).c_str();
 
-  // json[section]["multiband_compressor"]["lowband"]["attack"] = settings->get_double("attack1");
+    json[section]["multiband_compressor"]["band" + nstr]["sidechain-source"] =
+        settings->get_string("sidechain-source" + nstr).c_str();
 
-  // json[section]["multiband_compressor"]["lowband"]["release"] = settings->get_double("release1");
+    json[section]["multiband_compressor"]["band" + nstr]["sidechain-lookahead"] =
+        settings->get_double("sidechain-lookahead" + nstr);
 
-  // json[section]["multiband_compressor"]["lowband"]["makeup"] = settings->get_double("makeup1");
+    json[section]["multiband_compressor"]["band" + nstr]["sidechain-reactivity"] =
+        settings->get_double("sidechain-reactivity" + nstr);
 
-  // json[section]["multiband_compressor"]["lowband"]["knee"] = settings->get_double("knee1");
+    json[section]["multiband_compressor"]["band" + nstr]["sidechain-preamp"] =
+        settings->get_double("sidechain-preamp" + nstr);
 
-  // json[section]["multiband_compressor"]["lowband"]["detection"] = settings->get_string("detection1").c_str();
+    json[section]["multiband_compressor"]["band" + nstr]["sidechain-custom-lowcut-filter"] =
+        settings->get_boolean("sidechain-custom-lowcut-filter" + nstr);
 
-  // json[section]["multiband_compressor"]["lowband"]["bypass"] = settings->get_boolean("bypass1");
+    json[section]["multiband_compressor"]["band" + nstr]["sidechain-custom-highcut-filter"] =
+        settings->get_boolean("sidechain-custom-highcut-filter" + nstr);
 
-  // json[section]["multiband_compressor"]["lowband"]["solo"] = settings->get_boolean("solo1");
+    json[section]["multiband_compressor"]["band" + nstr]["sidechain-lowcut-frequency"] =
+        settings->get_double("sidechain-lowcut-frequency" + nstr);
 
-  // // mid band
+    json[section]["multiband_compressor"]["band" + nstr]["sidechain-highcut-frequency"] =
+        settings->get_double("sidechain-highcut-frequency" + nstr);
 
-  // json[section]["multiband_compressor"]["midband"]["threshold"] = settings->get_double("threshold2");
+    json[section]["multiband_compressor"]["band" + nstr]["boost-threshold"] =
+        settings->get_double("boost-threshold" + nstr);
 
-  // json[section]["multiband_compressor"]["midband"]["ratio"] = settings->get_double("ratio2");
-
-  // json[section]["multiband_compressor"]["midband"]["attack"] = settings->get_double("attack2");
-
-  // json[section]["multiband_compressor"]["midband"]["release"] = settings->get_double("release2");
-
-  // json[section]["multiband_compressor"]["midband"]["makeup"] = settings->get_double("makeup2");
-
-  // json[section]["multiband_compressor"]["midband"]["knee"] = settings->get_double("knee2");
-
-  // json[section]["multiband_compressor"]["midband"]["detection"] = settings->get_string("detection2").c_str();
-
-  // json[section]["multiband_compressor"]["midband"]["bypass"] = settings->get_boolean("bypass2");
-
-  // json[section]["multiband_compressor"]["midband"]["solo"] = settings->get_boolean("solo2");
-
-  // // high band
-
-  // json[section]["multiband_compressor"]["highband"]["threshold"] = settings->get_double("threshold3");
-
-  // json[section]["multiband_compressor"]["highband"]["ratio"] = settings->get_double("ratio3");
-
-  // json[section]["multiband_compressor"]["highband"]["attack"] = settings->get_double("attack3");
-
-  // json[section]["multiband_compressor"]["highband"]["release"] = settings->get_double("release3");
-
-  // json[section]["multiband_compressor"]["highband"]["makeup"] = settings->get_double("makeup3");
-
-  // json[section]["multiband_compressor"]["highband"]["knee"] = settings->get_double("knee3");
-
-  // json[section]["multiband_compressor"]["highband"]["detection"] = settings->get_string("detection3").c_str();
-
-  // json[section]["multiband_compressor"]["highband"]["bypass"] = settings->get_boolean("bypass3");
-
-  // json[section]["multiband_compressor"]["highband"]["solo"] = settings->get_boolean("solo3");
+    json[section]["multiband_compressor"]["band" + nstr]["boost-amount"] =
+        settings->get_double("boost-amount" + nstr);
+  }
 }
 
 void MultibandCompressorPreset::load(const nlohmann::json& json,
                                      const std::string& section,
                                      const Glib::RefPtr<Gio::Settings>& settings) {
-  // update_key<double>(json.at(section).at("multiband_compressor"), settings, "input-gain", "input-gain");
+  update_key<double>(json.at(section).at("multiband_compressor"), settings, "input-gain", "input-gain");
 
-  // update_key<double>(json.at(section).at("multiband_compressor"), settings, "output-gain", "output-gain");
+  update_key<double>(json.at(section).at("multiband_compressor"), settings, "output-gain", "output-gain");
 
-  // update_key<double>(json.at(section).at("multiband_compressor"), settings, "freq0", "freq0");
+  update_string_key(json.at(section).at("multiband_compressor"), settings, "compressor-mode", "compressor-mode");
 
-  // update_key<double>(json.at(section).at("multiband_compressor"), settings, "freq1", "freq1");
+  update_string_key(json.at(section).at("multiband_compressor"), settings, "envelope-boost", "envelope-boost");
 
-  // update_key<double>(json.at(section).at("multiband_compressor"), settings, "freq2", "freq2");
+  for (uint n = 0; n < n_bands; n++) {
+    auto nstr = std::to_string(n);
 
-  // update_string_key(json.at(section).at("multiband_compressor"), settings, "mode", "mode");
+    if (n > 0) {
+      update_key<bool>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+          "enable-band" + nstr, "enable-band");
 
-  // // sub band
+      update_key<double>(json.at(section).at("multiband_compressor"), settings,
+          "split-frequency" + nstr, "split-frequency");
+    }
 
-  // update_key<double>(json.at(section).at("multiband_compressor").at("subband"), settings, "threshold0", "threshold");
+    update_key<bool>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+        "compressor-enable" + nstr, "compressor-enable");
 
-  // update_key<double>(json.at(section).at("multiband_compressor").at("subband"), settings, "ratio0", "ratio");
+    update_key<bool>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+        "solo" + nstr, "solo");
 
-  // update_key<double>(json.at(section).at("multiband_compressor").at("subband"), settings, "attack0", "attack");
+    update_key<bool>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+        "mute" + nstr, "mute");
 
-  // update_key<double>(json.at(section).at("multiband_compressor").at("subband"), settings, "release0", "release");
+    update_key<double>(json.at(section).at("multiband_compressor"), settings,
+        "attack-threshold" + nstr, "attack-threshold");
 
-  // update_key<double>(json.at(section).at("multiband_compressor").at("subband"), settings, "makeup0", "makeup");
+    update_key<double>(json.at(section).at("multiband_compressor"), settings,
+        "attack-time" + nstr, "attack-time");
 
-  // update_key<double>(json.at(section).at("multiband_compressor").at("subband"), settings, "knee0", "knee");
+    update_key<double>(json.at(section).at("multiband_compressor"), settings,
+        "release-threshold" + nstr, "release-threshold");
 
-  // update_string_key(json.at(section).at("multiband_compressor").at("subband"), settings, "detection0", "detection");
+    update_key<double>(json.at(section).at("multiband_compressor"), settings,
+        "release-time" + nstr, "release-time");
 
-  // update_key<bool>(json.at(section).at("multiband_compressor").at("subband"), settings, "bypass0", "bypass");
+    update_key<double>(json.at(section).at("multiband_compressor"), settings,
+        "ratio" + nstr, "ratio");
 
-  // update_key<bool>(json.at(section).at("multiband_compressor").at("subband"), settings, "solo0", "solo");
+    update_key<double>(json.at(section).at("multiband_compressor"), settings,
+        "knee" + nstr, "knee");
 
-  // // low band
+    update_key<double>(json.at(section).at("multiband_compressor"), settings,
+        "makeup" + nstr, "makeup");
 
-  // update_key<double>(json.at(section).at("multiband_compressor").at("lowband"), settings, "threshold1", "threshold");
+    update_string_key(json.at(section).at("multiband_compressor"), settings,
+        "compression-mode", "compression-mode");
 
-  // update_key<double>(json.at(section).at("multiband_compressor").at("lowband"), settings, "ratio1", "ratio");
+    update_string_key(json.at(section).at("multiband_compressor"), settings,
+        "sidechain-mode", "sidechain-mode");
 
-  // update_key<double>(json.at(section).at("multiband_compressor").at("lowband"), settings, "attack1", "attack");
+    update_string_key(json.at(section).at("multiband_compressor"), settings,
+        "sidechain-source", "sidechain-source");
 
-  // update_key<double>(json.at(section).at("multiband_compressor").at("lowband"), settings, "release1", "release");
+    update_key<double>(json.at(section).at("multiband_compressor"), settings,
+        "sidechain-lookahead" + nstr, "sidechain-lookahead");
 
-  // update_key<double>(json.at(section).at("multiband_compressor").at("lowband"), settings, "makeup1", "makeup");
+    update_key<double>(json.at(section).at("multiband_compressor"), settings,
+        "sidechain-reactivity" + nstr, "sidechain-reactivity");
 
-  // update_key<double>(json.at(section).at("multiband_compressor").at("lowband"), settings, "knee1", "knee");
+    update_key<double>(json.at(section).at("multiband_compressor"), settings,
+        "sidechain-preamp" + nstr, "sidechain-preamp");
 
-  // update_string_key(json.at(section).at("multiband_compressor").at("lowband"), settings, "detection1", "detection");
+    update_key<bool>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+        "sidechain-custom-lowcut-filter" + nstr, "sidechain-custom-lowcut-filter");
 
-  // update_key<bool>(json.at(section).at("multiband_compressor").at("lowband"), settings, "bypass1", "bypass");
+    update_key<bool>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+        "sidechain-custom-highcut-filter" + nstr, "sidechain-custom-highcut-filter");
 
-  // update_key<bool>(json.at(section).at("multiband_compressor").at("lowband"), settings, "solo1", "solo");
+    update_key<double>(json.at(section).at("multiband_compressor"), settings,
+        "sidechain-lowcut-frequency" + nstr, "sidechain-lowcut-frequency");
 
-  // // mid band
+    update_key<double>(json.at(section).at("multiband_compressor"), settings,
+        "sidechain-highcut-frequency" + nstr, "sidechain-highcut-frequency");
 
-  // update_key<double>(json.at(section).at("multiband_compressor").at("midband"), settings, "threshold2", "threshold");
+    update_key<double>(json.at(section).at("multiband_compressor"), settings,
+        "boost-threshold" + nstr, "boost-threshold");
 
-  // update_key<double>(json.at(section).at("multiband_compressor").at("midband"), settings, "ratio2", "ratio");
-
-  // update_key<double>(json.at(section).at("multiband_compressor").at("midband"), settings, "attack2", "attack");
-
-  // update_key<double>(json.at(section).at("multiband_compressor").at("midband"), settings, "release2", "release");
-
-  // update_key<double>(json.at(section).at("multiband_compressor").at("midband"), settings, "makeup2", "makeup");
-
-  // update_key<double>(json.at(section).at("multiband_compressor").at("midband"), settings, "knee2", "knee");
-
-  // update_string_key(json.at(section).at("multiband_compressor").at("midband"), settings, "detection2", "detection");
-
-  // update_key<bool>(json.at(section).at("multiband_compressor").at("midband"), settings, "bypass2", "bypass");
-
-  // update_key<bool>(json.at(section).at("multiband_compressor").at("midband"), settings, "solo2", "solo");
-
-  // // high band
-
-  // update_key<double>(json.at(section).at("multiband_compressor").at("highband"), settings, "threshold3",
-  // "threshold");
-
-  // update_key<double>(json.at(section).at("multiband_compressor").at("highband"), settings, "ratio3", "ratio");
-
-  // update_key<double>(json.at(section).at("multiband_compressor").at("highband"), settings, "attack3", "attack");
-
-  // update_key<double>(json.at(section).at("multiband_compressor").at("highband"), settings, "release3", "release");
-
-  // update_key<double>(json.at(section).at("multiband_compressor").at("highband"), settings, "makeup3", "makeup");
-
-  // update_key<double>(json.at(section).at("multiband_compressor").at("highband"), settings, "knee3", "knee");
-
-  // update_string_key(json.at(section).at("multiband_compressor").at("highband"), settings, "detection3", "detection");
-
-  // update_key<bool>(json.at(section).at("multiband_compressor").at("highband"), settings, "bypass3", "bypass");
-
-  // update_key<bool>(json.at(section).at("multiband_compressor").at("highband"), settings, "solo3", "solo");
+    update_key<double>(json.at(section).at("multiband_compressor"), settings,
+        "boost-amount" + nstr, "boost-amount");
+  }
 }

--- a/src/multiband_compressor_ui.cpp
+++ b/src/multiband_compressor_ui.cpp
@@ -453,93 +453,63 @@ void MultibandCompressorUi::reset() {
 
   settings->reset("output-gain");
 
-  // settings->reset("freq0");
+  settings->reset("compressor-mode");
 
-  // settings->reset("freq1");
+  settings->reset("envelope-boost");
 
-  // settings->reset("freq2");
+  for (uint n = 0; n < n_bands; n++) {
+    auto nstr = std::to_string(n);
 
-  // settings->reset("mode");
+    if (n > 0) {
+      settings->reset("enable-band" + nstr);
 
-  // // sub band
+      settings->reset("split-frequency" + nstr);
+    }
 
-  // settings->reset("threshold0");
+    settings->reset("compressor-enable" + nstr);
 
-  // settings->reset("ratio0");
+    settings->reset("solo" + nstr);
 
-  // settings->reset("attack0");
+    settings->reset("mute" + nstr);
 
-  // settings->reset("release0");
+    settings->reset("attack-threshold" + nstr);
 
-  // settings->reset("makeup0");
+    settings->reset("attack-time" + nstr);
 
-  // settings->reset("knee0");
+    settings->reset("release-threshold" + nstr);
 
-  // settings->reset("detection0");
+    settings->reset("release-time" + nstr);
 
-  // settings->reset("bypass0");
+    settings->reset("ratio" + nstr);
 
-  // settings->reset("solo0");
+    settings->reset("knee" + nstr);
 
-  // // low band
+    settings->reset("makeup" + nstr);
 
-  // settings->reset("threshold1");
+    settings->reset("compression-mode" + nstr);
 
-  // settings->reset("ratio1");
+    settings->reset("sidechain-mode" + nstr);
 
-  // settings->reset("attack1");
+    settings->reset("sidechain-source" + nstr);
 
-  // settings->reset("release1");
+    settings->reset("sidechain-lookahead" + nstr);
 
-  // settings->reset("makeup1");
+    settings->reset("sidechain-reactivity" + nstr);
 
-  // settings->reset("knee1");
+    settings->reset("sidechain-preamp" + nstr);
 
-  // settings->reset("detection1");
+    settings->reset("sidechain-custom-lowcut-filter" + nstr);
 
-  // settings->reset("bypass1");
+    settings->reset("sidechain-custom-highcut-filter" + nstr);
 
-  // settings->reset("solo1");
+    settings->reset("sidechain-lowcut-frequency" + nstr);
 
-  // // mid band
+    settings->reset("sidechain-highcut-frequency" + nstr);
 
-  // settings->reset("threshold2");
+    settings->reset("boost-threshold" + nstr);
 
-  // settings->reset("ratio2");
-
-  // settings->reset("attack2");
-
-  // settings->reset("release2");
-
-  // settings->reset("makeup2");
-
-  // settings->reset("knee2");
-
-  // settings->reset("detection2");
-
-  // settings->reset("bypass2");
-
-  // settings->reset("solo2");
-
-  // // high band
-
-  // settings->reset("threshold3");
-
-  // settings->reset("ratio3");
-
-  // settings->reset("attack3");
-
-  // settings->reset("release3");
-
-  // settings->reset("makeup3");
-
-  // settings->reset("knee3");
-
-  // settings->reset("detection3");
-
-  // settings->reset("bypass3");
-
-  // settings->reset("solo3");
+    settings->reset("boost-amount" + nstr);
+  }
 }
 
 void MultibandCompressorUi::on_new_output0(double value) {


### PR DESCRIPTION
Linked all the presets.

I have issues on loading, wrote about it in #1031

The plugin works. It only remains to link frequency_end and reduction plugin ports to their labels inside the UI. I think "reduction" is the gain. "Curve level" is the band level instead? There's also "envelope meter" which I don't have any clue what it is, maybe the band sidechain level? I don't even know if is useful to show it the UI.

Can you suggest me how to link these ports to show them in the UI?

About the tests, nothing wrong except that I keep getting a critical log line during the application shutdown

```
(easyeffects:6103): easyeffects-DEBUG: 11:37:45.364: application_ui: destroyed

(easyeffects:6103): GLib-GIO-CRITICAL **: 11:37:45.389: g_application_release: assertion 'application->priv->use_count > 0' failed
(easyeffects:6103): easyeffects-DEBUG: 11:37:45.390: application:  destroyed
(easyeffects:6103): easyeffects-DEBUG: 11:37:45.390: presets_manager: destroyed
(easyeffects:6103): easyeffects-DEBUG: 11:37:45.391: sie: destroyed
(easyeffects:6103): easyeffects-DEBUG: 11:37:45.391: effects_base: destroyed

```

 
  