### PR TITLE
Compressor UI fixed

### DIFF
--- a/data/ui/compressor.ui
+++ b/data/ui/compressor.ui
@@ -37,7 +37,7 @@
                         <property name="title" translatable="yes">Compressor</property>
                         <property name="child">
                             <object class="GtkBox">
-                                <property name="spacing">12</property>
+                                <property name="spacing">24</property>
                                 <property name="orientation">vertical</property>
                                 <child>
                                     <object class="GtkGrid">
@@ -406,12 +406,6 @@
                                 <property name="halign">center</property>
                                 <property name="spacing">24</property>
                                 <property name="orientation">vertical</property>
-                                <child>
-                                    <object class="GtkToggleButton" id="listen">
-                                        <property name="halign">center</property>
-                                        <property name="label" translatable="yes">Listen</property>
-                                    </object>
-                                </child>
 
                                 <child>
                                     <object class="GtkBox">
@@ -422,7 +416,7 @@
                                             <object class="GtkGrid">
                                                 <property name="valign">center</property>
                                                 <property name="row-spacing">6</property>
-                                                <property name="column-spacing">6</property>
+                                                <property name="column-spacing">18</property>
                                                 <property name="column-homogeneous">1</property>
                                                 <child>
                                                     <object class="GtkLabel">
@@ -450,11 +444,22 @@
                                                 </child>
 
                                                 <child>
+                                                    <object class="GtkToggleButton" id="listen">
+                                                        <property name="halign">center</property>
+                                                        <property name="label" translatable="yes">Listen</property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+
+                                                <child>
                                                     <object class="GtkLabel">
                                                         <property name="valign">end</property>
                                                         <property name="label" translatable="yes">Source</property>
                                                         <layout>
-                                                            <property name="column">1</property>
+                                                            <property name="column">2</property>
                                                             <property name="row">0</property>
                                                         </layout>
                                                     </object>
@@ -468,7 +473,7 @@
                                                             <item translatable="yes">Right</item>
                                                         </items>
                                                         <layout>
-                                                            <property name="column">1</property>
+                                                            <property name="column">2</property>
                                                             <property name="row">1</property>
                                                         </layout>
                                                     </object>
@@ -792,6 +797,8 @@
                 <property name="hexpand">1</property>
                 <property name="vexpand">0</property>
                 <property name="homogeneous">1</property>
+                <property name="margin-top">4</property>
+                <property name="margin-bottom">4</property>
 
                 <child>
                     <object class="GtkBox">
@@ -802,14 +809,14 @@
                             <object class="GtkLabel" id="gain_title">
                                 <property name="halign">end</property>
                                 <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Band Gain</property>
+                                <property name="label" translatable="yes">Gain</property>
                             </object>
                         </child>
 
                         <child>
                             <object class="GtkLabel" id="gain_label">
                                 <property name="halign">center</property>
-                                <property name="width-chars">5</property>
+                                <property name="width-chars">6</property>
                                 <property name="label">0</property>
                             </object>
                         </child>
@@ -817,7 +824,6 @@
                         <child>
                             <object class="GtkLabel">
                                 <property name="halign">start</property>
-                                <property name="margin-start">2</property>
                                 <property name="label">db</property>
                             </object>
                         </child>
@@ -840,7 +846,7 @@
                         <child>
                             <object class="GtkLabel" id="envelope_label">
                                 <property name="halign">center</property>
-                                <property name="width-chars">5</property>
+                                <property name="width-chars">6</property>
                                 <property name="label">0</property>
                             </object>
                         </child>
@@ -848,7 +854,6 @@
                         <child>
                             <object class="GtkLabel">
                                 <property name="halign">start</property>
-                                <property name="margin-start">2</property>
                                 <property name="label">db</property>
                             </object>
                         </child>
@@ -871,7 +876,7 @@
                         <child>
                             <object class="GtkLabel" id="sidechain_label">
                                 <property name="halign">center</property>
-                                <property name="width-chars">5</property>
+                                <property name="width-chars">6</property>
                                 <property name="label">0</property>
                             </object>
                         </child>
@@ -879,7 +884,6 @@
                         <child>
                             <object class="GtkLabel">
                                 <property name="halign">start</property>
-                                <property name="margin-start">2</property>
                                 <property name="label">db</property>
                             </object>
                         </child>
@@ -902,7 +906,7 @@
                         <child>
                             <object class="GtkLabel" id="curve_label">
                                 <property name="halign">center</property>
-                                <property name="width-chars">5</property>
+                                <property name="width-chars">6</property>
                                 <property name="label">0</property>
                             </object>
                         </child>
@@ -910,7 +914,6 @@
                         <child>
                             <object class="GtkLabel">
                                 <property name="halign">start</property>
-                                <property name="margin-start">2</property>
                                 <property name="label">db</property>
                             </object>
                         </child>

--- a/data/ui/compressor.ui
+++ b/data/ui/compressor.ui
@@ -791,6 +791,138 @@
             <object class="GtkBox">
                 <property name="hexpand">1</property>
                 <property name="vexpand">0</property>
+                <property name="homogeneous">1</property>
+
+                <child>
+                    <object class="GtkBox">
+                        <property name="halign">center</property>
+                        <property name="valign">center</property>
+
+                        <child>
+                            <object class="GtkLabel" id="gain_title">
+                                <property name="halign">end</property>
+                                <property name="xalign">1</property>
+                                <property name="label" translatable="yes">Band Gain</property>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkLabel" id="gain_label">
+                                <property name="halign">center</property>
+                                <property name="width-chars">5</property>
+                                <property name="label">0</property>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkLabel">
+                                <property name="halign">start</property>
+                                <property name="margin-start">2</property>
+                                <property name="label">db</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+
+                <child>
+                    <object class="GtkBox">
+                        <property name="halign">center</property>
+                        <property name="valign">center</property>
+
+                        <child>
+                            <object class="GtkLabel" id="envelope_title">
+                                <property name="halign">end</property>
+                                <property name="xalign">1</property>
+                                <property name="label" translatable="yes">Envelope</property>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkLabel" id="envelope_label">
+                                <property name="halign">center</property>
+                                <property name="width-chars">5</property>
+                                <property name="label">0</property>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkLabel">
+                                <property name="halign">start</property>
+                                <property name="margin-start">2</property>
+                                <property name="label">db</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+
+                <child>
+                    <object class="GtkBox">
+                        <property name="halign">center</property>
+                        <property name="valign">center</property>
+
+                        <child>
+                            <object class="GtkLabel" id="sidechain_title">
+                                <property name="halign">end</property>
+                                <property name="xalign">1</property>
+                                <property name="label" translatable="yes">Sidechain</property>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkLabel" id="sidechain_label">
+                                <property name="halign">center</property>
+                                <property name="width-chars">5</property>
+                                <property name="label">0</property>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkLabel">
+                                <property name="halign">start</property>
+                                <property name="margin-start">2</property>
+                                <property name="label">db</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+
+                <child>
+                    <object class="GtkBox">
+                        <property name="halign">center</property>
+                        <property name="valign">center</property>
+
+                        <child>
+                            <object class="GtkLabel" id="curve_title">
+                                <property name="halign">end</property>
+                                <property name="xalign">1</property>
+                                <property name="label" translatable="yes">Curve</property>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkLabel" id="curve_label">
+                                <property name="halign">center</property>
+                                <property name="width-chars">5</property>
+                                <property name="label">0</property>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkLabel">
+                                <property name="halign">start</property>
+                                <property name="margin-start">2</property>
+                                <property name="label">db</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+            </object>
+        </child>
+
+        <child>
+            <object class="GtkBox">
+                <property name="hexpand">1</property>
+                <property name="vexpand">0</property>
                 <property name="spacing">6</property>
                 <child>
                     <object class="GtkLabel" id="input_level_title">
@@ -947,98 +1079,6 @@
             <object class="GtkBox">
                 <property name="hexpand">1</property>
                 <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="curve_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Curve</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="curve">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="curve_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">4</property>
-                        <property name="label">0</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="sidechain_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Sidechain</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="sidechain">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="sidechain_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">4</property>
-                        <property name="label">0</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="reduction_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Reduction</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="reduction">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="min-value">0</property>
-                        <property name="max-value">251</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="reduction_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">4</property>
-                        <property name="label">0</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
                 <property name="layout-manager">
                     <object class="GtkBinLayout"></object>
                 </property>
@@ -1086,7 +1126,8 @@
             <widget name="output_level_title" />
             <widget name="curve_title" />
             <widget name="sidechain_title" />
-            <widget name="reduction_title" />
+            <widget name="gain_title" />
+            <widget name="envelope_title" />
         </widgets>
     </object>
 

--- a/data/ui/multiband_compressor_band.ui
+++ b/data/ui/multiband_compressor_band.ui
@@ -846,7 +846,7 @@
                         <child>
                             <object class="GtkLabel" id="band_gain_label">
                                 <property name="halign">center</property>
-                                <property name="width-chars">5</property>
+                                <property name="width-chars">6</property>
                                 <property name="label">0</property>
                             </object>
                         </child>
@@ -854,7 +854,6 @@
                         <child>
                             <object class="GtkLabel">
                                 <property name="halign">start</property>
-                                <property name="margin-start">2</property>
                                 <property name="label">db</property>
                             </object>
                         </child>
@@ -877,7 +876,7 @@
                         <child>
                             <object class="GtkLabel" id="band_envelope_label">
                                 <property name="halign">center</property>
-                                <property name="width-chars">5</property>
+                                <property name="width-chars">6</property>
                                 <property name="label">0</property>
                             </object>
                         </child>
@@ -885,7 +884,6 @@
                         <child>
                             <object class="GtkLabel">
                                 <property name="halign">start</property>
-                                <property name="margin-start">2</property>
                                 <property name="label">db</property>
                             </object>
                         </child>
@@ -908,7 +906,7 @@
                         <child>
                             <object class="GtkLabel" id="band_curve_label">
                                 <property name="halign">center</property>
-                                <property name="width-chars">5</property>
+                                <property name="width-chars">6</property>
                                 <property name="label">0</property>
                             </object>
                         </child>
@@ -916,7 +914,6 @@
                         <child>
                             <object class="GtkLabel">
                                 <property name="halign">start</property>
-                                <property name="margin-start">2</property>
                                 <property name="label">db</property>
                             </object>
                         </child>

--- a/include/compressor.hpp
+++ b/include/compressor.hpp
@@ -44,7 +44,7 @@ class Compressor : public PluginBase {
                std::span<float>& probe_left,
                std::span<float>& probe_right) override;
 
-  sigc::signal<void(double)> reduction, sidechain, curve, latency;
+  sigc::signal<void(double)> reduction, sidechain, curve, envelope, latency;
 
  private:
   uint latency_n_frames = 0U;

--- a/include/compressor_ui.hpp
+++ b/include/compressor_ui.hpp
@@ -40,6 +40,8 @@ class CompressorUi : public Gtk::Box, public PluginUiBase {
 
   void on_new_reduction(double value);
 
+  void on_new_envelope(double value);
+
   void on_new_sidechain(double value);
 
   void on_new_curve(double value);
@@ -56,9 +58,7 @@ class CompressorUi : public Gtk::Box, public PluginUiBase {
 
   Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
 
-  Gtk::LevelBar *reduction = nullptr, *sidechain = nullptr, *curve = nullptr;
-
-  Gtk::Label *reduction_label = nullptr, *sidechain_label = nullptr, *curve_label = nullptr;
+  Gtk::Label *reduction_label = nullptr, *sidechain_label = nullptr, *curve_label = nullptr, *envelope_label = nullptr;
 
   Gtk::ComboBoxText *compression_mode = nullptr, *sidechain_type = nullptr, *sidechain_mode = nullptr,
                     *sidechain_source = nullptr, *lpf_mode = nullptr, *hpf_mode = nullptr;

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -221,11 +221,13 @@ void Compressor::process(std::span<float>& left_in,
       float reduction_value = lv2_wrapper->get_control_port_value("rlm");
       float sidechain_value = lv2_wrapper->get_control_port_value("slm");
       float curve_value = lv2_wrapper->get_control_port_value("clm");
+      float envelope_value = lv2_wrapper->get_control_port_value("elm");
 
       Glib::signal_idle().connect_once([=, this] {
         reduction.emit(reduction_value);
         sidechain.emit(sidechain_value);
         curve.emit(curve_value);
+        envelope.emit(envelope_value);
       });
 
       notify();

--- a/src/compressor_ui.cpp
+++ b/src/compressor_ui.cpp
@@ -237,15 +237,12 @@ CompressorUi::CompressorUi(BaseObjectType* cobject,
   hpf_mode = builder->get_widget<Gtk::ComboBoxText>("hpf_mode");
   lpf_mode = builder->get_widget<Gtk::ComboBoxText>("lpf_mode");
 
-  reduction = builder->get_widget<Gtk::LevelBar>("reduction");
-  sidechain = builder->get_widget<Gtk::LevelBar>("sidechain");
-  curve = builder->get_widget<Gtk::LevelBar>("curve");
-
   listen = builder->get_widget<Gtk::ToggleButton>("listen");
 
-  reduction_label = builder->get_widget<Gtk::Label>("reduction_label");
+  reduction_label = builder->get_widget<Gtk::Label>("gain_label");
   sidechain_label = builder->get_widget<Gtk::Label>("sidechain_label");
   curve_label = builder->get_widget<Gtk::Label>("curve_label");
+  envelope_label = builder->get_widget<Gtk::Label>("envelope_label");
 
   dropdown_input_devices = builder->get_widget<Gtk::DropDown>("dropdown_input_devices");
 
@@ -404,20 +401,18 @@ void CompressorUi::reset() {
 }
 
 void CompressorUi::on_new_reduction(double value) {
-  reduction->set_value(value);
-
   reduction_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
-void CompressorUi::on_new_sidechain(double value) {
-  sidechain->set_value(value);
+void CompressorUi::on_new_envelope(double value) {
+  envelope_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));
+}
 
+void CompressorUi::on_new_sidechain(double value) {
   sidechain_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
 void CompressorUi::on_new_curve(double value) {
-  curve->set_value(value);
-
   curve_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -359,6 +359,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
       effects_base->compressor->input_level.connect(sigc::mem_fun(*compressor_ui, &CompressorUi::on_new_input_level));
       effects_base->compressor->output_level.connect(sigc::mem_fun(*compressor_ui, &CompressorUi::on_new_output_level));
       effects_base->compressor->reduction.connect(sigc::mem_fun(*compressor_ui, &CompressorUi::on_new_reduction));
+      effects_base->compressor->envelope.connect(sigc::mem_fun(*compressor_ui, &CompressorUi::on_new_envelope));
       effects_base->compressor->sidechain.connect(sigc::mem_fun(*compressor_ui, &CompressorUi::on_new_sidechain));
       effects_base->compressor->curve.connect(sigc::mem_fun(*compressor_ui, &CompressorUi::on_new_curve));
 


### PR DESCRIPTION
Since sidechain compressor level meters have the same issue of mbc level bars, simplify it's layout copying mbc labels.

Besides compressor and sidechain stackpages now have same height. 