### PR TITLE
Optimized node linking

### DIFF
--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -1389,12 +1389,7 @@ auto PipeManager::link_nodes(const uint& output_node_id,
       if (ports_match) {
         pw_properties* props = pw_properties_new(nullptr, nullptr);
 
-        if (link_passive) {
-          pw_properties_set(props, PW_KEY_LINK_PASSIVE, "true");
-        } else {
-          pw_properties_set(props, PW_KEY_LINK_PASSIVE, "false");
-        }
-
+        pw_properties_set(props, PW_KEY_LINK_PASSIVE, (link_passive) ? "true" : "false");
         pw_properties_set(props, PW_KEY_OBJECT_LINGER, "false");
         pw_properties_set(props, PW_KEY_LINK_OUTPUT_NODE, std::to_string(output_node_id).c_str());
         pw_properties_set(props, PW_KEY_LINK_OUTPUT_PORT, std::to_string(outp.id).c_str());

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -156,46 +156,27 @@ void StreamOutputEffects::on_link_changed(const LinkInfo& link_info) {
 void StreamOutputEffects::connect_filters() {
   auto list = settings->get_string_array("plugins");
 
-  if (list.empty()) {
-    auto links = pm->link_nodes(pm->pe_sink_node.id, spectrum->get_node_id());
+  uint prev_node_id = pm->pe_sink_node.id, next_node_id = 0U;
 
-    for (const auto& link : links) {
-      list_proxies.emplace_back(link);
-    }
-  } else {
-    bool plugin_connected = false;
-    uint prev = 0U;
+  // link plugins
 
-    plugin_connected = (!plugins[list[prev]]->connected_to_pw) ? plugins[list[prev]]->connect_to_pw() : true;
-
-    if (plugin_connected) {
-      auto links = pm->link_nodes(pm->pe_sink_node.id, plugins[list[prev]]->get_node_id());
-
-      prev++;
-
-      for (const auto& link : links) {
-        list_proxies.emplace_back(link);
-      }
-    }
-
-    for (size_t n = 1, list_size = list.size(); n < list_size; n++) {
-      plugin_connected = (!plugins[list[prev]]->connected_to_pw) ? plugins[list[prev]]->connect_to_pw() : true;
+  if (!list.empty()) {
+    for (size_t n = 0, list_size = list.size(); n < list_size; n++) {
+      bool plugin_connected = (!plugins[list[n]]->connected_to_pw) ? plugins[list[n]]->connect_to_pw() : true;
 
       if (plugin_connected) {
-        auto links = pm->link_nodes(plugins[list[prev - 1]]->get_node_id(), plugins[list[prev]]->get_node_id());
+        next_node_id = plugins[list[n]]->get_node_id();
 
-        prev++;
+        auto links = pm->link_nodes(prev_node_id, next_node_id);
 
-        for (const auto& link : links) {
-          list_proxies.emplace_back(link);
+        auto link_size = links.size();
+
+        for (size_t n = 0; n < link_size; n++) {
+          list_proxies.emplace_back(links[n]);
         }
+
+        prev_node_id = (link_size < 2) ? prev_node_id : next_node_id;
       }
-    }
-
-    auto links = pm->link_nodes(plugins[list[prev - 1]]->get_node_id(), spectrum->get_node_id());
-
-    for (const auto& link : links) {
-      list_proxies.emplace_back(link);
     }
 
     // checking if we have to link the echo_canceller probe to the output device
@@ -215,16 +196,22 @@ void StreamOutputEffects::connect_filters() {
     }
   }
 
-  auto links = pm->link_nodes(spectrum->get_node_id(), output_level->get_node_id());
+  // link spectrum, output level meter and output device
 
-  for (const auto& link : links) {
-    list_proxies.emplace_back(link);
-  }
+  auto node_id_list = {spectrum->get_node_id(), output_level->get_node_id(), pm->output_device.id};
 
-  links = pm->link_nodes(output_level->get_node_id(), pm->output_device.id);
+  for (auto& node_id : node_id_list) {
+    next_node_id = node_id;
 
-  for (const auto& link : links) {
-    list_proxies.emplace_back(link);
+    auto links = pm->link_nodes(prev_node_id, next_node_id);
+
+    auto link_size = links.size();
+
+    for (size_t n = 0; n < link_size; n++) {
+      list_proxies.emplace_back(links[n]);
+    }
+
+    prev_node_id = (link_size < 2) ? prev_node_id : next_node_id;
   }
 }
 


### PR DESCRIPTION
This should be slightly better. Not only it skips the unconnected filter, but also the node with less than two channels linked.

Then saving and using the prev/next node id is better and more intuitive.

It's working on my side, please test on yours.