### PR TITLE
New default values for split frequencies in LSP MBC

### DIFF
--- a/data/schemas/com.github.wwmm.easyeffects.multibandcompressor.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.multibandcompressor.gschema.xml
@@ -69,31 +69,31 @@
 
         <key name="split-frequency1" type="d">
             <range min="10.0" max="20000.0" />
-            <default>40.0</default>
+            <default>500.0</default>
         </key>
         <key name="split-frequency2" type="d">
             <range min="10.0" max="20000.0" />
-            <default>100.0</default>
+            <default>1000.0</default>
         </key>
         <key name="split-frequency3" type="d">
             <range min="10.0" max="20000.0" />
-            <default>252.0</default>
+            <default>2000.0</default>
         </key>
         <key name="split-frequency4" type="d">
             <range min="10.0" max="20000.0" />
-            <default>632.0</default>
+            <default>4000.0</default>
         </key>
         <key name="split-frequency5" type="d">
             <range min="10.0" max="20000.0" />
-            <default>1587.0</default>
+            <default>8000.0</default>
         </key>
         <key name="split-frequency6" type="d">
             <range min="10.0" max="20000.0" />
-            <default>3984.0</default>
+            <default>12000.0</default>
         </key>
         <key name="split-frequency7" type="d">
             <range min="10.0" max="20000.0" />
-            <default>10000.0</default>
+            <default>16000.0</default>
         </key>
 
         <key name="sidechain-mode0" enum="com.github.wwmm.easyeffects.multibandcompressor.sidechainmode.enum">

--- a/src/multiband_compressor_ui.cpp
+++ b/src/multiband_compressor_ui.cpp
@@ -232,7 +232,7 @@ MultibandCompressorUi::MultibandCompressorUi(BaseObjectType* cobject,
     auto* selected_row = listbox->get_selected_row();
 
     if (selected_row != nullptr) {
-      int row = selected_row->get_index();
+      const auto row = selected_row->get_index();
 
       if (row > -1) {
         stack->set_visible_child("band" + std::to_string(row));


### PR DESCRIPTION
I noticed that band frequency end in mbc ui is not always updating on split frequency changes. This is because the emit method of frequency_range signal is inside process fuction, so it's working only when an audio stream is playing.

I would be better to make it work always, not only during playback, since it could be confusing to the user seeing a wrong frequency on frequency split update.

Unfortunately I'm not so good with signals, so I wasn't able to make it update always. Maybe I'm missing something and you @wwmm can suggest me how to do it correctly.

Anyway, if it can't be done with signals, another solution could be calculating manually the frequencies on split changes. I made some tests and it should be done on settings changes because on spinbuttons changes the signal is not emitted when the value changes through preset application.

It's also quite tricky to to it this way since the bands can also be non-contiguous, so for every enabled band we have to scan all other enabled bands to pick the minimum split frequency major than the current split frequency.

It's not impossible, but if it could be done listening always to plugin ports changes it would be better and easier.

Meanwhile I changed default values for bands since the plugin has 0, 2, 4 and 6 enabled by default while we have the first four. To me seems better to have the first four with other values.