### PR TITLE
Track pw proxies on global bypass

### DIFF
--- a/include/stream_input_effects.hpp
+++ b/include/stream_input_effects.hpp
@@ -38,7 +38,7 @@ class StreamInputEffects : public EffectsBase {
  private:
   bool bypass = false;
 
-  void connect_filters();
+  void connect_filters(const bool& bypass = false);
 
   void disconnect_filters();
 

--- a/include/stream_output_effects.hpp
+++ b/include/stream_output_effects.hpp
@@ -38,7 +38,7 @@ class StreamOutputEffects : public EffectsBase {
  private:
   bool bypass = false;
 
-  void connect_filters();
+  void connect_filters(const bool& bypass = false);
 
   void disconnect_filters();
 

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -385,17 +385,10 @@ void Application::create_actions() {
 }
 
 void Application::update_bypass_state(const std::string& key) {
-  auto state = settings->get_boolean(key);
+  const auto& state = settings->get_boolean(key);
 
-  if (state) {
-    util::info(log_tag + "enabling global bypass");
+  soe->set_bypass(state);
+  sie->set_bypass(state);
 
-    soe->set_bypass(true);
-    sie->set_bypass(true);
-  } else {
-    util::info(log_tag + "disabling global bypass");
-
-    soe->set_bypass(false);
-    sie->set_bypass(false);
-  }
+  util::info(log_tag + ((state) ? "enabling" : "disabling") + " global bypass");
 }

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -127,7 +127,7 @@ void StreamInputEffects::on_link_changed(const LinkInfo& link_info) {
   }
 
   /*
-    If bypass is enable to do touch the plugin pipeline
+    If bypass is enabled do not touch the plugin pipeline
   */
 
   if (bypass) {
@@ -157,14 +157,14 @@ void StreamInputEffects::on_link_changed(const LinkInfo& link_info) {
   }
 }
 
-void StreamInputEffects::connect_filters() {
+void StreamInputEffects::connect_filters(const bool& bypass) {
   if (pm->input_device.id == SPA_ID_INVALID) {
     util::debug(log_tag + "Input device id is invalid. Aborting the link between filters in the microphone pipeline");
 
     return;
   }
 
-  auto list = settings->get_string_array("plugins");
+  const auto& list = (bypass) ? std::vector<Glib::ustring>() : settings->get_string_array("plugins");
 
   bool mic_linked = false;
 
@@ -274,17 +274,9 @@ void StreamInputEffects::disconnect_filters() {
 void StreamInputEffects::set_bypass(const bool& state) {
   bypass = state;
 
-  if (state) {
-    disconnect_filters();
+  disconnect_filters();
 
-    pm->link_nodes(pm->input_device.id, spectrum->get_node_id());
-    pm->link_nodes(spectrum->get_node_id(), output_level->get_node_id());
-    pm->link_nodes(output_level->get_node_id(), pm->pe_source_node.id);
-  } else {
-    disconnect_filters();
-
-    connect_filters();
-  }
+  connect_filters(state);
 }
 
 void StreamInputEffects::set_listen_to_mic(const bool& state) {

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -123,7 +123,7 @@ void StreamOutputEffects::on_app_added(const NodeInfo& node_info) {
 
 void StreamOutputEffects::on_link_changed(const LinkInfo& link_info) {
   /*
-    If bypass is enable to do touch the plugin pipeline
+    If bypass is enabled do not touch the plugin pipeline
   */
 
   if (bypass) {
@@ -153,8 +153,8 @@ void StreamOutputEffects::on_link_changed(const LinkInfo& link_info) {
   }
 }
 
-void StreamOutputEffects::connect_filters() {
-  auto list = settings->get_string_array("plugins");
+void StreamOutputEffects::connect_filters(const bool& bypass) {
+  const auto& list = (bypass) ? std::vector<Glib::ustring>() : settings->get_string_array("plugins");
 
   uint prev_node_id = pm->pe_sink_node.id;
   uint next_node_id = 0U;
@@ -273,15 +273,7 @@ void StreamOutputEffects::disconnect_filters() {
 void StreamOutputEffects::set_bypass(const bool& state) {
   bypass = state;
 
-  if (state) {
-    disconnect_filters();
+  disconnect_filters();
 
-    pm->link_nodes(pm->pe_sink_node.id, spectrum->get_node_id());
-    pm->link_nodes(spectrum->get_node_id(), output_level->get_node_id());
-    pm->link_nodes(output_level->get_node_id(), pm->output_device.id);
-  } else {
-    disconnect_filters();
-
-    connect_filters();
-  }
+  connect_filters(state);
 }


### PR DESCRIPTION
I noticed that pw proxies returned by link_nodes() are saved and then destroyed in disconnect_filters(). This is happening when bypass is disabled, but when it is enabled the proxies are not tracked into the vector, so they are not destroyed when disconnect_filters() is called another time on bypass disabling.

Don't know if this is an intended behaviour, but I thought it's better to track them and destroy them afterwards, like it's usually made.