### PR TITLE
Fix 6.1.0 release date in metainfo

### DIFF
--- a/data/com.github.wwmm.easyeffects.metainfo.xml.in
+++ b/data/com.github.wwmm.easyeffects.metainfo.xml.in
@@ -30,7 +30,7 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="6.1.0" date="2021-08-10"/>
+    <release version="6.1.0" date="2021-08-17"/>
     <release version="6.0.3" date="2021-07-16"/>
     <release version="6.0.2" date="2021-07-11"/>
     <release version="6.0.1" date="2021-07-09"/>


### PR DESCRIPTION
According to https://github.com/wwmm/easyeffects/releases/tag/v6.1.0
6.1.0 was released on 2021-08-17