### PR TITLE
Code optimizations and fixes

### DIFF
--- a/data/ui/app_info.ui
+++ b/data/ui/app_info.ui
@@ -25,6 +25,7 @@
 
                 <child>
                     <object class="GtkImage" id="app_icon">
+                        <property name="visible">False</property>
                         <property name="halign">start</property>
                         <property name="valign">center</property>
                         <property name="icon_size">large</property>
@@ -222,6 +223,7 @@
 
                 <child>
                     <object class="GtkScale" id="scale_volume">
+                        <property name="visible">False</property>
                         <property name="hexpand">1</property>
                         <property name="valign">center</property>
                         <property name="adjustment">volume</property>

--- a/data/ui/crossfeed.ui
+++ b/data/ui/crossfeed.ui
@@ -36,7 +36,6 @@
                 <child>
                     <object class="GtkButton" id="preset_jmeier">
                         <property name="label" translatable="yes">Jmeier</property>
-                        <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
                     </object>

--- a/data/ui/effects_base.ui
+++ b/data/ui/effects_base.ui
@@ -250,7 +250,7 @@
 
                 <child type="end">
                     <object class="GtkToggleButton" id="toggle_listen_mic">
-                        <property name="visible">0</property>
+                        <property name="visible">False</property>
                         <child>
                             <object class="GtkBox">
                                 <property name="halign">center</property>

--- a/data/ui/limiter.ui
+++ b/data/ui/limiter.ui
@@ -459,7 +459,7 @@
 
                 <child>
                     <object class="GtkBox">
-                        <property name="visible">0</property>
+                        <property name="visible">False</property>
                         <property name="halign">center</property>
                         <property name="valign">center</property>
                         <property name="spacing">6</property>
@@ -483,7 +483,6 @@
 
                 <child>
                     <object class="GtkBox">
-                        <property name="visible">1</property>
                         <property name="halign">center</property>
                         <property name="valign">center</property>
                         <property name="spacing">24</property>

--- a/data/ui/multiband_compressor_band.ui
+++ b/data/ui/multiband_compressor_band.ui
@@ -207,7 +207,7 @@
 
                         <child>
                             <object class="GtkLabel">
-                                <property name="visible">0</property>
+                                <property name="visible">False</property>
                                 <property name="halign">end</property>
                                 <property name="valign">center</property>
                                 <property name="label" translatable="yes">Device</property>
@@ -334,7 +334,7 @@
 
                         <child>
                             <object class="GtkDropDown" id="dropdown_input_devices">
-                                <property name="visible">0</property>
+                                <property name="visible">False</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
 

--- a/include/application.hpp
+++ b/include/application.hpp
@@ -58,12 +58,12 @@ class Application : public Gtk::Application {
   void on_activate() override;
 
  private:
-  std::string log_tag = "application: ";
+  const std::string log_tag = "application: ";
 
   bool running_as_service = false;
 
   void create_actions();
-  void update_bypass_state(const std::string& key);
+  void update_bypass_state(const Glib::ustring& key);
 };
 
 #endif

--- a/include/application_ui.hpp
+++ b/include/application_ui.hpp
@@ -43,7 +43,7 @@ class ApplicationUi : public Gtk::ApplicationWindow {
   static auto create(Application* app) -> ApplicationUi*;
 
  private:
-  std::string log_tag = "application_ui: ";
+  const std::string log_tag = "application_ui: ";
 
   Application* app;
 

--- a/include/autogain.hpp
+++ b/include/autogain.hpp
@@ -42,9 +42,13 @@ class AutoGain : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  // loudness, gain, momentary, shortterm, integrated, relative, range;
-
-  sigc::signal<void(double, double, double, double, double, double, double)> results;
+  sigc::signal<void(const double&,              // loudness
+                    const double&,              // gain
+                    const double&,              // momentary
+                    const double&,              // shortterm
+                    const double&,              // integrated
+                    const double&,              // relative
+                    const double&)> results;    // range
 
  private:
   bool ebur128_ready = false;

--- a/include/bass_enhancer.hpp
+++ b/include/bass_enhancer.hpp
@@ -42,7 +42,7 @@ class BassEnhancer : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(double)> harmonics;
+  sigc::signal<void(const double&)> harmonics;
 
  private:
   std::unique_ptr<lv2::Lv2Wrapper> lv2_wrapper;

--- a/include/bass_enhancer_ui.hpp
+++ b/include/bass_enhancer_ui.hpp
@@ -36,7 +36,7 @@ class BassEnhancerUi : public Gtk::Box, public PluginUiBase {
 
   static auto add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> BassEnhancerUi*;
 
-  void on_new_harmonics_level(double value);
+  void on_new_harmonics_level(const double& value);
 
   void reset() override;
 

--- a/include/calibration_mic.hpp
+++ b/include/calibration_mic.hpp
@@ -22,7 +22,6 @@
 
 #include <gst/gst.h>
 #include <sigc++/sigc++.h>
-#include <iostream>
 #include <vector>
 
 class CalibrationMic {
@@ -33,8 +32,6 @@ class CalibrationMic {
   CalibrationMic(const CalibrationMic&&) = delete;
   auto operator=(const CalibrationMic&&) -> CalibrationMic& = delete;
   ~CalibrationMic();
-
-  std::string log_tag = "calibration_mic: ";
 
   GstElement *pipeline = nullptr, *source = nullptr, *sink = nullptr, *spectrum = nullptr;
 
@@ -57,6 +54,8 @@ class CalibrationMic {
   void set_input_node_id(const uint& id) const;
 
  private:
+  const std::string log_tag = "calibration_mic: ";
+
   GstBus* bus = nullptr;
 };
 

--- a/include/calibration_mic_ui.hpp
+++ b/include/calibration_mic_ui.hpp
@@ -40,7 +40,7 @@ class CalibrationMicUi : public Gtk::Box {
   std::unique_ptr<CalibrationMic> cm;
 
  private:
-  std::string log_tag = "calibration_mic_ui: ";
+  const std::string log_tag = "calibration_mic_ui: ";
 
   const double default_time_window = 2.0;  // seconds
 

--- a/include/calibration_signals.hpp
+++ b/include/calibration_signals.hpp
@@ -22,7 +22,6 @@
 
 #include <gst/gst.h>
 #include <sigc++/sigc++.h>
-#include <iostream>
 #include <vector>
 
 class CalibrationSignals {
@@ -33,8 +32,6 @@ class CalibrationSignals {
   CalibrationSignals(const CalibrationSignals&&) = delete;
   auto operator=(const CalibrationSignals&&) -> CalibrationSignals& = delete;
   ~CalibrationSignals();
-
-  std::string log_tag = "calibration_signals: ";
 
   GstElement *pipeline = nullptr, *source = nullptr, *sink = nullptr, *spectrum = nullptr;
 
@@ -55,6 +52,8 @@ class CalibrationSignals {
   void set_volume(const double& value) const;
 
  private:
+  const std::string log_tag = "calibration_signals: ";
+
   GstBus* bus = nullptr;
 };
 

--- a/include/calibration_signals_ui.hpp
+++ b/include/calibration_signals_ui.hpp
@@ -40,7 +40,7 @@ class CalibrationSignalsUi : public Gtk::Box {
   std::unique_ptr<CalibrationSignals> cs;
 
  private:
-  std::string log_tag = "calibration_signals_ui: ";
+  const std::string log_tag = "calibration_signals_ui: ";
 
   Gtk::Switch* enable = nullptr;
   Gtk::Scale* volume = nullptr;

--- a/include/calibration_ui.hpp
+++ b/include/calibration_ui.hpp
@@ -44,7 +44,7 @@ class CalibrationUi : public Gtk::Window {
   void set_input_node_id(const uint& id);
 
  private:
-  std::string log_tag = "calibration_ui: ";
+  const std::string log_tag = "calibration_ui: ";
 
   Gtk::Stack* stack = nullptr;
   Gtk::DrawingArea* spectrum = nullptr;
@@ -59,7 +59,7 @@ class CalibrationUi : public Gtk::Window {
   CalibrationSignalsUi* calibration_signals_ui = nullptr;
   CalibrationMicUi* calibration_mic_ui = nullptr;
 
-  void on_new_spectrum(const std::vector<float>& magnitudes);
+  void on_new_spectrum(std::vector<float> magnitudes);
 
   auto on_spectrum_draw(const Cairo::RefPtr<Cairo::Context>& ctx) -> bool;
 

--- a/include/compressor.hpp
+++ b/include/compressor.hpp
@@ -44,7 +44,7 @@ class Compressor : public PluginBase {
                std::span<float>& probe_left,
                std::span<float>& probe_right) override;
 
-  sigc::signal<void(double)> reduction, sidechain, curve, envelope, latency;
+  sigc::signal<void(const float&)> reduction, sidechain, curve, envelope, latency;
 
  private:
   uint latency_n_frames = 0U;

--- a/include/compressor_ui.hpp
+++ b/include/compressor_ui.hpp
@@ -20,7 +20,6 @@
 #ifndef COMPRESSOR_UI_HPP
 #define COMPRESSOR_UI_HPP
 
-#include <cstring>
 #include "info_holders.hpp"
 #include "plugin_ui_base.hpp"
 
@@ -38,13 +37,13 @@ class CompressorUi : public Gtk::Box, public PluginUiBase {
 
   static auto add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> CompressorUi*;
 
-  void on_new_reduction(double value);
+  void on_new_reduction(const float& value);
 
-  void on_new_envelope(double value);
+  void on_new_envelope(const float& value);
 
-  void on_new_sidechain(double value);
+  void on_new_sidechain(const float& value);
 
-  void on_new_curve(double value);
+  void on_new_curve(const float& value);
 
   void set_pipe_manager_ptr(PipeManager* pipe_manager);
 

--- a/include/convolver.hpp
+++ b/include/convolver.hpp
@@ -47,7 +47,7 @@ class Convolver : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(double)> latency;
+  sigc::signal<void(const float&)> latency;
 
  private:
   bool kernel_is_initialized = false;
@@ -90,7 +90,7 @@ class Convolver : public PluginBase {
     std::copy(data_right.begin(), data_right.end(), conv_right_in.begin());
 
     if (zita_ready) {
-      int ret = conv->process(true);  // thread sync mode set to true
+      const int& ret = conv->process(true);  // thread sync mode set to true
 
       if (ret != 0) {
         util::debug(log_tag + "IR: process failed: " + std::to_string(ret));

--- a/include/convolver_ui.hpp
+++ b/include/convolver_ui.hpp
@@ -49,7 +49,9 @@ class ConvolverUi : public Gtk::Box, public PluginUiBase {
   void reset() override;
 
  private:
-  std::string log_tag = "convolver_ui: ";
+  const std::string log_tag = "convolver_ui: ";
+
+  const std::string irs_ext = ".irs";
 
   Gtk::SpinButton* ir_width = nullptr;
 
@@ -93,7 +95,7 @@ class ConvolverUi : public Gtk::Box, public PluginUiBase {
 
   void setup_listview();
 
-  auto get_irs_names() -> std::vector<std::string>;
+  auto get_irs_names() -> std::vector<Glib::ustring>;
 
   void import_irs_file(const std::string& file_path);
 

--- a/include/crystalizer.hpp
+++ b/include/crystalizer.hpp
@@ -47,7 +47,7 @@ class Crystalizer : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(double)> latency;
+  sigc::signal<void(const float&)> latency;
 
  private:
   bool n_samples_is_power_of_2 = true;
@@ -128,8 +128,8 @@ class Crystalizer : public PluginBase {
           the next round.
         */
 
-        float L = band_data_L.at(n)[0];
-        float R = band_data_R.at(n)[0];
+        const float& L = band_data_L.at(n)[0];
+        const float& R = band_data_R.at(n)[0];
 
         band_data_L.at(n)[0] = band_next_L.at(n);
         band_data_R.at(n)[0] = band_next_R.at(n);
@@ -144,30 +144,30 @@ class Crystalizer : public PluginBase {
 
       if (!band_bypass.at(n)) {
         for (uint m = 0U; m < blocksize; m++) {
-          float L = band_data_L.at(n)[m];
-          float R = band_data_R.at(n)[m];
+          const float& L = band_data_L.at(n)[m];
+          const float& R = band_data_R.at(n)[m];
 
           if (m > 0 && m < blocksize - 1) {
-            float L_lower = band_data_L.at(n)[m - 1U];
-            float R_lower = band_data_R.at(n)[m - 1U];
-            float L_upper = band_data_L.at(n)[m + 1U];
-            float R_upper = band_data_R.at(n)[m + 1U];
+            const float& L_lower = band_data_L.at(n)[m - 1U];
+            const float& R_lower = band_data_R.at(n)[m - 1U];
+            const float& L_upper = band_data_L.at(n)[m + 1U];
+            const float& R_upper = band_data_R.at(n)[m + 1U];
 
             band_second_derivative_L.at(n)[m] = L_upper - 2.0F * L + L_lower;
             band_second_derivative_R.at(n)[m] = R_upper - 2.0F * R + R_lower;
           } else if (m == 0U) {
-            float L_lower = band_last_L.at(n);
-            float R_lower = band_last_R.at(n);
-            float L_upper = band_data_L.at(n)[m + 1];
-            float R_upper = band_data_R.at(n)[m + 1];
+            const float& L_lower = band_last_L.at(n);
+            const float& R_lower = band_last_R.at(n);
+            const float& L_upper = band_data_L.at(n)[m + 1];
+            const float& R_upper = band_data_R.at(n)[m + 1];
 
             band_second_derivative_L.at(n)[m] = L_upper - 2.0F * L + L_lower;
             band_second_derivative_R.at(n)[m] = R_upper - 2.0F * R + R_lower;
           } else if (m == blocksize - 1) {
-            float L_upper = band_next_L.at(n);
-            float R_upper = band_next_R.at(n);
-            float L_lower = band_data_L.at(n)[m - 1U];
-            float R_lower = band_data_R.at(n)[m - 1U];
+            const float& L_upper = band_next_L.at(n);
+            const float& R_upper = band_next_R.at(n);
+            const float& L_lower = band_data_L.at(n)[m - 1U];
+            const float& R_lower = band_data_R.at(n)[m - 1U];
 
             band_second_derivative_L.at(n)[m] = L_upper - 2.0F * L + L_lower;
             band_second_derivative_R.at(n)[m] = R_upper - 2.0F * R + R_lower;
@@ -177,10 +177,10 @@ class Crystalizer : public PluginBase {
         // peak enhancing using second derivative
 
         for (uint m = 0U; m < blocksize; m++) {
-          float L = band_data_L.at(n)[m];
-          float R = band_data_R.at(n)[m];
-          float d2L = band_second_derivative_L.at(n)[m];
-          float d2R = band_second_derivative_R.at(n)[m];
+          const float& L = band_data_L.at(n)[m];
+          const float& R = band_data_R.at(n)[m];
+          const float& d2L = band_second_derivative_L.at(n)[m];
+          const float& d2R = band_second_derivative_R.at(n)[m];
 
           band_data_L.at(n)[m] = L - band_intensity.at(n) * d2L;
           band_data_R.at(n)[m] = R - band_intensity.at(n) * d2R;

--- a/include/deesser.hpp
+++ b/include/deesser.hpp
@@ -39,7 +39,7 @@ class Deesser : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(double)> compression, detected;
+  sigc::signal<void(const double&)> compression, detected;
 
  private:
   std::unique_ptr<lv2::Lv2Wrapper> lv2_wrapper;

--- a/include/deesser_ui.hpp
+++ b/include/deesser_ui.hpp
@@ -20,7 +20,6 @@
 #ifndef DEESSER_UI_HPP
 #define DEESSER_UI_HPP
 
-#include <cstring>
 #include "plugin_ui_base.hpp"
 
 class DeesserUi : public Gtk::Box, public PluginUiBase {
@@ -37,8 +36,8 @@ class DeesserUi : public Gtk::Box, public PluginUiBase {
 
   static auto add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> DeesserUi*;
 
-  void on_new_compression(double value);
-  void on_new_detected(double value);
+  void on_new_compression(const double& value);
+  void on_new_detected(const double& value);
 
   void reset() override;
 

--- a/include/delay.hpp
+++ b/include/delay.hpp
@@ -39,7 +39,7 @@ class Delay : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(double)> latency;
+  sigc::signal<void(const float&)> latency;
 
  private:
   uint latency_n_frames = 0U;

--- a/include/echo_canceller.hpp
+++ b/include/echo_canceller.hpp
@@ -45,7 +45,7 @@ class EchoCanceller : public PluginBase {
                std::span<float>& probe_left,
                std::span<float>& probe_right) override;
 
-  sigc::signal<void(double)> latency;
+  sigc::signal<void(const float&)> latency;
 
  private:
   bool notify_latency = false;

--- a/include/effects_base.hpp
+++ b/include/effects_base.hpp
@@ -57,7 +57,7 @@ class EffectsBase {
   auto operator=(const EffectsBase&&) -> EffectsBase& = delete;
   virtual ~EffectsBase();
 
-  std::string log_tag;
+  const std::string log_tag;
 
   PipeManager* pm = nullptr;
 
@@ -90,7 +90,7 @@ class EffectsBase {
 
   auto get_pipeline_latency() -> float;
 
-  sigc::signal<void(float)> pipeline_latency;
+  sigc::signal<void(const float&)> pipeline_latency;
 
  protected:
   Glib::RefPtr<Gio::Settings> settings, global_settings;

--- a/include/effects_base_ui.hpp
+++ b/include/effects_base_ui.hpp
@@ -24,7 +24,6 @@
 #include <glibmm.h>
 #include <glibmm/i18n.h>
 #include <gtkmm.h>
-#include <algorithm>
 #include <memory>
 #include <vector>
 #include "autogain_ui.hpp"
@@ -95,7 +94,7 @@ class EffectsBaseUi {
   std::vector<sigc::connection> connections;
 
   /*
-    Do not pass node_info by reference. Sometimes it dies before we use it and a segmentation fault happens
+    Do not pass node_info by reference. Sometimes it dies before we use it and a segmentation fault happens.
   */
 
   void on_app_added(NodeInfo node_info);
@@ -104,7 +103,7 @@ class EffectsBaseUi {
 
   void on_new_output_level_db(const float& left, const float& right);
 
-  static auto node_state_to_string(const pw_node_state& state) -> std::string;
+  static auto node_state_to_ustring(const pw_node_state& state) -> Glib::ustring;
 
  private:
   Gtk::ListView *listview_players = nullptr, *listview_blocklist = nullptr, *listview_plugins = nullptr,
@@ -154,16 +153,10 @@ class EffectsBaseUi {
                                                    {plugin_name::rnnoise, _("Noise Reduction")},
                                                    {plugin_name::stereo_tools, _("Stereo Tools")}};
 
-  template <typename T>
-  auto level_to_localized_string_showpos(const T& value, const int& places) -> std::string {
-    std::ostringstream msg;
+  /* enabled_app_list saves the "enabled state" of processed apps regardless of their presence in the blocklist,
+     useful to restore the enabled state when the app is removed from the blocklist */
 
-    msg.precision(places);
-
-    msg << ((value > 0.0) ? "+" : "") << std::fixed << value;
-
-    return msg.str();
-  }
+  std::map<uint, bool> enabled_app_list;
 
   void add_plugins_to_stack_plugins();
 
@@ -175,17 +168,17 @@ class EffectsBaseUi {
 
   void setup_listview_selected_plugins();
 
+  auto app_is_enabled(const NodeInfo& node_info) -> bool;
+
   auto app_is_blocklisted(const Glib::ustring& name) -> bool;
 
   auto add_new_blocklist_entry(const Glib::ustring& name) -> bool;
 
   void remove_blocklist_entry(const Glib::ustring& name);
 
-  void connect_stream(const std::shared_ptr<NodeInfoHolder>& holder);
+  void connect_stream(const NodeInfo& node_info);
 
-  void disconnect_stream(const std::shared_ptr<NodeInfoHolder>& holder);
-
-  static auto float_to_localized_string(const float& value, const int& places) -> std::string;
+  void disconnect_stream(const NodeInfo& node_info);
 };
 
 #endif

--- a/include/equalizer.hpp
+++ b/include/equalizer.hpp
@@ -45,7 +45,7 @@ class Equalizer : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(double)> latency;
+  sigc::signal<void(const float&)> latency;
 
  private:
   Glib::RefPtr<Gio::Settings> settings_left, settings_right;

--- a/include/equalizer_preset.hpp
+++ b/include/equalizer_preset.hpp
@@ -27,7 +27,7 @@ class EqualizerPreset : public PluginPresetBase {
   EqualizerPreset();
 
  private:
-  std::string log_tag = "equalizer_preset: ";
+  const std::string log_tag = "equalizer_preset: ";
 
   Glib::RefPtr<Gio::Settings> input_settings_left, input_settings_right, output_settings_left, output_settings_right;
 

--- a/include/exciter.hpp
+++ b/include/exciter.hpp
@@ -39,7 +39,7 @@ class Exciter : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(double)> harmonics;
+  sigc::signal<void(const double&)> harmonics;
 
  private:
   std::unique_ptr<lv2::Lv2Wrapper> lv2_wrapper;

--- a/include/exciter_ui.hpp
+++ b/include/exciter_ui.hpp
@@ -36,7 +36,7 @@ class ExciterUi : public Gtk::Box, public PluginUiBase {
 
   static auto add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> ExciterUi*;
 
-  void on_new_harmonics_level(double value);
+  void on_new_harmonics_level(const double& value);
 
   void reset() override;
 

--- a/include/filter_ui.hpp
+++ b/include/filter_ui.hpp
@@ -20,7 +20,6 @@
 #ifndef FILTER_UI_HPP
 #define FILTER_UI_HPP
 
-#include <cstring>
 #include "plugin_ui_base.hpp"
 
 class FilterUi : public Gtk::Box, public PluginUiBase {

--- a/include/fir_filter_base.hpp
+++ b/include/fir_filter_base.hpp
@@ -62,7 +62,7 @@ class FirFilterBase {
     std::copy(data_right.begin(), data_right.end(), conv_right_in.begin());
 
     if (zita_ready) {
-      int ret = conv->process(true);  // thread sync mode set to true
+      const int& ret = conv->process(true);  // thread sync mode set to true
 
       if (ret != 0) {
         util::debug(log_tag + "IR: process failed: " + std::to_string(ret));
@@ -76,7 +76,7 @@ class FirFilterBase {
   }
 
  protected:
-  std::string log_tag;
+  const std::string log_tag;
 
   bool zita_ready = false;
 

--- a/include/gate.hpp
+++ b/include/gate.hpp
@@ -39,7 +39,7 @@ class Gate : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(double)> gating;
+  sigc::signal<void(const double&)> gating;
 
  private:
   std::unique_ptr<lv2::Lv2Wrapper> lv2_wrapper;

--- a/include/gate_ui.hpp
+++ b/include/gate_ui.hpp
@@ -36,7 +36,7 @@ class GateUi : public Gtk::Box, public PluginUiBase {
 
   static auto add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> GateUi*;
 
-  void on_new_gating(double value);
+  void on_new_gating(const double& value);
 
   void reset() override;
 

--- a/include/general_settings_ui.hpp
+++ b/include/general_settings_ui.hpp
@@ -40,7 +40,7 @@ class GeneralSettingsUi : public Gtk::Box {
   static void add_to_stack(Gtk::Stack* stack, Application* app);
 
  private:
-  std::string log_tag = "general_settings_ui: ";
+  const std::string log_tag = "general_settings_ui: ";
 
   Glib::RefPtr<Gio::Settings> settings;
 

--- a/include/info_holders.hpp
+++ b/include/info_holders.hpp
@@ -31,12 +31,6 @@ class NodeInfoHolder : public Glib::Object {
 
   sigc::signal<void(NodeInfo)> info_updated;
 
-  bool enabled = false;
-
-  bool app_blocklisted = false;
-
-  bool pre_blocklisted_state = false;
-
  protected:
   NodeInfoHolder(NodeInfo info);
 };

--- a/include/limiter.hpp
+++ b/include/limiter.hpp
@@ -39,9 +39,9 @@ class Limiter : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(double)> latency;
+  sigc::signal<void(const float&)> latency;
 
-  sigc::signal<void(double)> gain_left, gain_right, sidechain_left, sidechain_right;
+  sigc::signal<void(const float&)> gain_left, gain_right, sidechain_left, sidechain_right;
 
  private:
   uint latency_n_frames = 0U;

--- a/include/limiter_ui.hpp
+++ b/include/limiter_ui.hpp
@@ -20,7 +20,6 @@
 #ifndef LIMITER_UI_HPP
 #define LIMITER_UI_HPP
 
-#include <cstring>
 #include "plugin_ui_base.hpp"
 
 class LimiterUi : public Gtk::Box, public PluginUiBase {
@@ -37,10 +36,10 @@ class LimiterUi : public Gtk::Box, public PluginUiBase {
 
   static auto add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> LimiterUi*;
 
-  void on_new_left_gain(double value);
-  void on_new_right_gain(double value);
-  void on_new_left_sidechain(double value);
-  void on_new_right_sidechain(double value);
+  void on_new_left_gain(const float& value);
+  void on_new_right_gain(const float& value);
+  void on_new_left_sidechain(const float& value);
+  void on_new_right_sidechain(const float& value);
 
   void reset() override;
 

--- a/include/loudness.hpp
+++ b/include/loudness.hpp
@@ -42,7 +42,7 @@ class Loudness : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(double)> latency;
+  sigc::signal<void(const float&)> latency;
 
  private:
   uint latency_n_frames = 0U;

--- a/include/loudness_ui.hpp
+++ b/include/loudness_ui.hpp
@@ -20,7 +20,6 @@
 #ifndef LOUDNESS_UI_HPP
 #define LOUDNESS_UI_HPP
 
-#include <cstring>
 #include "plugin_ui_base.hpp"
 
 class LoudnessUi : public Gtk::Box, public PluginUiBase {

--- a/include/lv2_wrapper.hpp
+++ b/include/lv2_wrapper.hpp
@@ -96,27 +96,27 @@ class Lv2Wrapper {
   auto has_instance() -> bool;
 
   void bind_key_double(const Glib::RefPtr<Gio::Settings>& settings,
-                       const std::string& gsettings_key,
+                       const Glib::ustring& gsettings_key,
                        const std::string& lv2_symbol);
 
   void bind_key_double_db(const Glib::RefPtr<Gio::Settings>& settings,
-                          const std::string& gsettings_key,
+                          const Glib::ustring& gsettings_key,
                           const std::string& lv2_symbol);
 
   void bind_key_bool(const Glib::RefPtr<Gio::Settings>& settings,
-                     const std::string& gsettings_key,
+                     const Glib::ustring& gsettings_key,
                      const std::string& lv2_symbol);
 
   void bind_key_enum(const Glib::RefPtr<Gio::Settings>& settings,
-                     const std::string& gsettings_key,
+                     const Glib::ustring& gsettings_key,
                      const std::string& lv2_symbol);
 
   void bind_key_int(const Glib::RefPtr<Gio::Settings>& settings,
-                    const std::string& gsettings_key,
+                    const Glib::ustring& gsettings_key,
                     const std::string& lv2_symbol);
 
  private:
-  std::string log_tag = "lv2_wrapper: ";
+  const std::string log_tag = "lv2_wrapper: ";
 
   std::string plugin_uri;
 

--- a/include/maximizer.hpp
+++ b/include/maximizer.hpp
@@ -42,7 +42,9 @@ class Maximizer : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(double)> reduction, latency;
+  sigc::signal<void(const double&)> reduction;
+
+  sigc::signal<void(const float&)> latency;
 
  private:
   uint latency_n_frames = 0U;

--- a/include/maximizer_ui.hpp
+++ b/include/maximizer_ui.hpp
@@ -36,7 +36,7 @@ class MaximizerUi : public Gtk::Box, public PluginUiBase {
 
   static auto add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> MaximizerUi*;
 
-  void on_new_reduction(double value);
+  void on_new_reduction(const double& value);
 
   void reset() override;
 

--- a/include/multiband_compressor.hpp
+++ b/include/multiband_compressor.hpp
@@ -44,9 +44,9 @@ class MultibandCompressor : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(double)> latency;
+  sigc::signal<void(const float&)> latency;
 
-  sigc::signal<void(std::array<double, n_bands>)> reduction, envelope, curve, frequency_range;
+  sigc::signal<void(const std::array<float, n_bands>&)> reduction, envelope, curve, frequency_range;
 
  private:
   uint latency_n_frames = 0U;

--- a/include/multiband_compressor_ui.hpp
+++ b/include/multiband_compressor_ui.hpp
@@ -20,7 +20,6 @@
 #ifndef MULTIBAND_COMPRESSOR_UI_HPP
 #define MULTIBAND_COMPRESSOR_UI_HPP
 
-#include <cstring>
 #include "plugin_ui_base.hpp"
 
 class MultibandCompressorUi : public Gtk::Box, public PluginUiBase {
@@ -39,13 +38,13 @@ class MultibandCompressorUi : public Gtk::Box, public PluginUiBase {
 
   static auto add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> MultibandCompressorUi*;
 
-  void on_new_frequency_range(std::array<double, n_bands>);
+  void on_new_frequency_range(const std::array<float, n_bands>& values);
 
-  void on_new_envelope(std::array<double, n_bands>);
+  void on_new_envelope(const std::array<float, n_bands>& values);
 
-  void on_new_curve(std::array<double, n_bands>);
+  void on_new_curve(const std::array<float, n_bands>& values);
 
-  void on_new_reduction(std::array<double, n_bands>);
+  void on_new_reduction(const std::array<float, n_bands>& values);
 
   void reset() override;
 

--- a/include/multiband_gate.hpp
+++ b/include/multiband_gate.hpp
@@ -42,7 +42,7 @@ class MultibandGate : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(double)> output0, output1, output2, output3, gating0, gating1, gating2, gating3;
+  sigc::signal<void(const double&)> output0, output1, output2, output3, gating0, gating1, gating2, gating3;
 
  private:
   std::unique_ptr<lv2::Lv2Wrapper> lv2_wrapper;

--- a/include/multiband_gate_ui.hpp
+++ b/include/multiband_gate_ui.hpp
@@ -20,7 +20,6 @@
 #ifndef MULTIBAND_GATE_UI_HPP
 #define MULTIBAND_GATE_UI_HPP
 
-#include <cstring>
 #include "plugin_ui_base.hpp"
 
 class MultibandGateUi : public Gtk::Box, public PluginUiBase {
@@ -37,15 +36,15 @@ class MultibandGateUi : public Gtk::Box, public PluginUiBase {
 
   static auto add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> MultibandGateUi*;
 
-  void on_new_output0(double value);
-  void on_new_output1(double value);
-  void on_new_output2(double value);
-  void on_new_output3(double value);
+  void on_new_output0(const double& value);
+  void on_new_output1(const double& value);
+  void on_new_output2(const double& value);
+  void on_new_output3(const double& value);
 
-  void on_new_gating0(double value);
-  void on_new_gating1(double value);
-  void on_new_gating2(double value);
-  void on_new_gating3(double value);
+  void on_new_gating0(const double& value);
+  void on_new_gating1(const double& value);
+  void on_new_gating2(const double& value);
+  void on_new_gating3(const double& value);
 
   void reset() override;
 

--- a/include/pipe_info_ui.hpp
+++ b/include/pipe_info_ui.hpp
@@ -22,8 +22,6 @@
 
 #include <giomm.h>
 #include <gtkmm.h>
-#include <filesystem>
-#include <fstream>
 #include <memory>
 #include "info_holders.hpp"
 #include "pipe_manager.hpp"
@@ -46,7 +44,7 @@ class PipeInfoUi : public Gtk::Box {
   static auto add_to_stack(Gtk::Stack* stack, PipeManager* pm, PresetsManager* presets_manager) -> PipeInfoUi*;
 
  private:
-  std::string log_tag = "pipe_info: ";
+  const std::string log_tag = "pipe_info: ";
 
   PipeManager* pm = nullptr;
 

--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -30,10 +30,8 @@
 #include <spa/utils/result.h>
 #include <algorithm>
 #include <array>
-#include <cstring>
 #include <memory>
 #include <string>
-#include <vector>
 #include "util.hpp"
 
 struct NodeInfo {
@@ -165,7 +163,7 @@ class PipeManager {
   auto operator=(const PipeManager&&) -> PipeManager& = delete;
   ~PipeManager();
 
-  std::string log_tag = "pipe_manager: ";
+  const std::string log_tag = "pipe_manager: ";
 
   pw_thread_loop* thread_loop = nullptr;
   pw_core* core = nullptr;
@@ -191,9 +189,6 @@ class PipeManager {
   NodeInfo default_output_device, default_input_device;
 
   NodeInfo output_device, input_device;
-
-  std::vector<Glib::ustring> blocklist_in;   // for input effects
-  std::vector<Glib::ustring> blocklist_out;  // for output effects
 
   std::array<std::string, 14> blocklist_node_name = {"EasyEffects",
                                                      "easyeffects",
@@ -248,7 +243,11 @@ class PipeManager {
 
   void unlock() const;
 
-  static auto json_object_find(const char* obj, const char* key, char* value, size_t len) -> int;
+  static auto json_object_find(const char* obj, const char* key, char* value, const size_t& len) -> int;
+
+  /*
+    Do not pass NodeInfo by reference. Sometimes it dies before we use it and a segmentation fault happens.
+  */
 
   sigc::signal<void(NodeInfo)> source_added;
   sigc::signal<void(NodeInfo)> source_changed;

--- a/include/pitch.hpp
+++ b/include/pitch.hpp
@@ -39,7 +39,7 @@ class Pitch : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(double)> latency;
+  sigc::signal<void(const float&)> latency;
 
  private:
   bool rubberband_ready = false;

--- a/include/plot.hpp
+++ b/include/plot.hpp
@@ -21,6 +21,7 @@
 #define PLOT_UI_HPP
 
 #include <gtkmm.h>
+#include <iomanip>
 #include <ranges>
 #include "util.hpp"
 
@@ -61,12 +62,12 @@ class Plot {
 
   void set_n_y_decimals(const int& v);
 
-  void set_x_unit(const std::string& value);
+  void set_x_unit(const Glib::ustring& value);
 
-  void set_y_unit(const std::string& value);
+  void set_y_unit(const Glib::ustring& value);
 
  private:
-  std::string log_tag = "plot: ";
+  const std::string log_tag = "plot: ";
 
   Gtk::DrawingArea* da = nullptr;
 
@@ -93,7 +94,7 @@ class Plot {
 
   PlotScale plot_scale = PlotScale::logarithmic;
 
-  std::string x_unit, y_unit;
+  Glib::ustring x_unit, y_unit;
 
   std::vector<float> original_x, original_y;
   std::vector<float> y_axis, x_axis;
@@ -103,17 +104,6 @@ class Plot {
   void on_draw(const Cairo::RefPtr<Cairo::Context>& ctx, const int& width, const int& height);
 
   auto draw_x_labels(const Cairo::RefPtr<Cairo::Context>& ctx, const int& width, const int& height) -> int;
-
-  template <typename T>
-  auto value_to_localized_string(const T& value, const int& places) -> std::string {
-    std::ostringstream msg;
-
-    msg.precision(places);
-
-    msg << std::fixed << value;
-
-    return msg.str();
-  }
 };
 
 #endif

--- a/include/plugin_base.hpp
+++ b/include/plugin_base.hpp
@@ -62,7 +62,9 @@ class PluginBase {
     PluginBase* pb = nullptr;
   };
 
-  std::string log_tag, name;
+  const std::string log_tag;
+
+  std::string name;
 
   pw_filter* filter = nullptr;
 
@@ -102,8 +104,8 @@ class PluginBase {
                        std::span<float>& probe_left,
                        std::span<float>& probe_right);
 
-  sigc::signal<void(float, float)> input_level;
-  sigc::signal<void(float, float)> output_level;
+  sigc::signal<void(const float&, const float&)> input_level;
+  sigc::signal<void(const float&, const float&)> output_level;
 
  protected:
   std::mutex data_mutex;

--- a/include/plugin_preset_base.hpp
+++ b/include/plugin_preset_base.hpp
@@ -21,7 +21,6 @@
 #define PLUGIN_PRESET_BASE_HPP
 
 #include <giomm.h>
-#include <iostream>
 #include <nlohmann/json.hpp>
 #include "preset_type.hpp"
 #include "util.hpp"
@@ -75,7 +74,7 @@ class PluginPresetBase {
                     const Glib::RefPtr<Gio::Settings>& settings) = 0;
 
   template <typename T>
-  auto get_default(const Glib::RefPtr<Gio::Settings>& settings, const std::string& key) -> T {
+  auto get_default(const Glib::RefPtr<Gio::Settings>& settings, const Glib::ustring& key) -> T {
     Glib::Variant<T> value;
 
     settings->get_default_value(key, value);
@@ -86,30 +85,28 @@ class PluginPresetBase {
   template <typename T>
   void update_key(const nlohmann::json& json,
                   const Glib::RefPtr<Gio::Settings>& settings,
-                  const std::string& key,
+                  const Glib::ustring& key,
                   const std::string& json_key) {
     Glib::Variant<T> aux;
 
     settings->get_value(key, aux);
 
-    T current_value = aux.get();
+    const T& current_value = aux.get();
 
-    T new_value = json.value(json_key, get_default<T>(settings, key));
+    const T& new_value = json.value(json_key, get_default<T>(settings, key));
 
     if (is_different(current_value, new_value)) {
-      auto v = Glib::Variant<T>::create(new_value);
-
-      settings->set_value(key, v);
+      settings->set_value(key, Glib::Variant<T>::create(new_value));
     }
   }
 
   void update_string_key(const nlohmann::json& json,
                          const Glib::RefPtr<Gio::Settings>& settings,
-                         const std::string& key,
+                         const Glib::ustring& key,
                          const std::string& json_key) {
-    std::string current_value = settings->get_string(key);
+    const auto& current_value = settings->get_string(key);
 
-    std::string new_value = json.value(json_key, get_default<std::string>(settings, key));
+    const Glib::ustring& new_value = json.value(json_key, get_default<std::string>(settings, key));
 
     if (current_value != new_value) {
       settings->set_string(key, new_value);

--- a/include/plugin_ui_base.hpp
+++ b/include/plugin_ui_base.hpp
@@ -22,6 +22,7 @@
 
 #include <giomm.h>
 #include <gtkmm.h>
+#include <iomanip>
 #include "plugin_name.hpp"
 #include "scale_helper.hpp"
 #include "spinbutton_helper.hpp"
@@ -63,17 +64,11 @@ class PluginUiBase {
   virtual void reset() = 0;
 
   template <typename T>
-  auto level_to_localized_string(const T& value, const int& places) -> std::string {
-    std::ostringstream msg;
-
-    msg.precision(places);
-
-    msg << std::fixed << value;
-
-    return msg.str();
+  auto level_to_localized_string(const T& value, const int& places) -> Glib::ustring {
+    return Glib::ustring::format(std::setprecision(places), std::fixed, value);
   }
 
-  static void prepare_spinbutton(Gtk::SpinButton* button, const std::string& unit);
+  static void prepare_spinbutton(Gtk::SpinButton* button, const Glib::ustring& unit);
 
   static auto string_to_float(const std::string& value) -> float;
 
@@ -85,8 +80,7 @@ class PluginUiBase {
                     const T4& w_right_label,
                     const float& left,
                     const float& right) {
-    if (left >= -99.0) {
-      auto db_value = util::db_to_linear(left);
+    if (auto db_value = util::db_to_linear(left); left >= -99.0) {
 
       if (db_value < 0.0) {
         db_value = 0.0;
@@ -101,8 +95,7 @@ class PluginUiBase {
       w_left_label->set_text("-99");
     }
 
-    if (right >= -99.0) {
-      auto db_value = util::db_to_linear(right);
+    if (auto db_value = util::db_to_linear(right); right >= -99.0) {
 
       if (db_value < 0.0) {
         db_value = 0.0;

--- a/include/presets_manager.hpp
+++ b/include/presets_manager.hpp
@@ -69,18 +69,18 @@ class PresetsManager {
 
   auto get_names(const PresetType& preset_type) -> std::vector<Glib::ustring>;
 
-  static auto search_names(std::filesystem::directory_iterator& it) -> std::vector<std::string>;
+  static auto search_names(std::filesystem::directory_iterator& it) -> std::vector<Glib::ustring>;
 
   void add(const PresetType& preset_type, const Glib::ustring& name);
 
-  void save_preset_file(const PresetType& preset_type, const std::string& name);
+  void save_preset_file(const PresetType& preset_type, const Glib::ustring& name);
 
   void write_plugins_preset(const PresetType& preset_type, const std::vector<Glib::ustring>& plugins,
                             nlohmann::json& json);
 
-  void remove(const PresetType& preset_type, const std::string& name);
+  void remove(const PresetType& preset_type, const Glib::ustring& name);
 
-  void load_preset_file(const PresetType& preset_type, const std::string& name);
+  void load_preset_file(const PresetType& preset_type, const Glib::ustring& name);
 
   void read_plugins_preset(const PresetType& preset_type, const std::vector<Glib::ustring>& plugins,
                            const nlohmann::json& json);
@@ -98,13 +98,13 @@ class PresetsManager {
                        const std::string& device_profile);
 
   auto find_autoload(const PresetType& preset_type, const std::string& device_name, const std::string& device_profile)
-      -> std::string;
+      -> Glib::ustring;
 
   void autoload(const PresetType& preset_type, const std::string& device_name, const std::string& device_profile);
 
   auto get_autoload_profiles(const PresetType& preset_type) -> std::vector<nlohmann::json>;
 
-  auto preset_file_exists(const PresetType& preset_type, const std::string& name) -> bool;
+  auto preset_file_exists(const PresetType& preset_type, const Glib::ustring& name) -> bool;
 
   sigc::signal<void(const Glib::RefPtr<Gio::File>& file)> user_output_preset_created;
   sigc::signal<void(const Glib::RefPtr<Gio::File>& file)> user_output_preset_removed;
@@ -115,7 +115,9 @@ class PresetsManager {
   sigc::signal<void(const std::vector<nlohmann::json>& profiles)> autoload_output_profiles_changed;
 
  private:
-  std::string log_tag = "presets_manager: ";
+  const std::string log_tag = "presets_manager: ";
+
+  const std::string json_ext = ".json";
 
   std::filesystem::path user_presets_dir, user_input_dir, user_output_dir, autoload_input_dir, autoload_output_dir;
 

--- a/include/presets_menu_ui.hpp
+++ b/include/presets_menu_ui.hpp
@@ -41,7 +41,7 @@ class PresetsMenuUi : public Gtk::Popover {
   static auto create(Application* app) -> PresetsMenuUi*;
 
  private:
-  std::string log_tag = "presets_menu_ui: ";
+  const std::string log_tag = "presets_menu_ui: ";
 
   Glib::RefPtr<Gio::Settings> settings;
 

--- a/include/rnnoise.hpp
+++ b/include/rnnoise.hpp
@@ -41,7 +41,7 @@ class RNNoise : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(double)> latency;
+  sigc::signal<void(const float&)> latency;
 
  private:
   bool resample = false;
@@ -78,7 +78,7 @@ class RNNoise : public PluginBase {
 
       if (data_L.size() == blocksize) {
         if (state_left != nullptr) {
-          std::ranges::for_each(data_L, [](auto& v) { v *= (SHRT_MAX + 1); });
+          std::ranges::for_each(data_L, [](auto& v) { v *= static_cast<float>(SHRT_MAX + 1); });
 
           rnnoise_process_frame(state_left, data_L.data(), data_L.data());
 
@@ -98,7 +98,7 @@ class RNNoise : public PluginBase {
 
       if (data_R.size() == blocksize) {
         if (state_right != nullptr) {
-          std::ranges::for_each(data_R, [](auto& v) { v *= (SHRT_MAX + 1); });
+          std::ranges::for_each(data_R, [](auto& v) { v *= static_cast<float>(SHRT_MAX + 1); });
 
           rnnoise_process_frame(state_right, data_R.data(), data_R.data());
 

--- a/include/rnnoise_ui.hpp
+++ b/include/rnnoise_ui.hpp
@@ -41,7 +41,9 @@ class RNNoiseUi : public Gtk::Box, public PluginUiBase {
   void reset() override;
 
  private:
-  std::string log_tag = "rnnoise_ui: ";
+  const std::string log_tag = "rnnoise_ui: ";
+
+  const std::string rnnn_ext = ".rnnn";
 
   Glib::ustring default_model_name;
 
@@ -69,9 +71,9 @@ class RNNoiseUi : public Gtk::Box, public PluginUiBase {
 
   void import_model_file(const std::string& file_path);
 
-  auto get_model_names() -> std::vector<std::string>;
+  auto get_model_names() -> std::vector<Glib::ustring>;
 
-  void remove_model_file(const std::string& name);
+  void remove_model_file(const Glib::ustring& name);
 
   void set_active_model_label();
 };

--- a/include/scale_helper.hpp
+++ b/include/scale_helper.hpp
@@ -21,17 +21,13 @@
 #define SCALE_HELPER_HPP
 
 #include <gtkmm.h>
-#include <sstream>
 
 inline auto prepare_scale(Gtk::Scale* scale, const std::string& unit) {
-  scale->set_format_value_func([=](double value) {
-    std::ostringstream str;
+  scale->set_format_value_func([=](const auto& value) {
+    const auto& v_str = Glib::ustring::format(std::setprecision(scale->get_digits()), std::fixed,
+                                              scale->get_adjustment()->get_value());
 
-    str.precision(scale->get_digits());
-
-    str << std::fixed << scale->get_adjustment()->get_value() << " " << unit;
-
-    return str.str();
+    return v_str + ((unit.empty()) ? "" : (" " + unit));
   });
 }
 

--- a/include/spectrum_settings_ui.hpp
+++ b/include/spectrum_settings_ui.hpp
@@ -23,7 +23,6 @@
 #include <giomm.h>
 #include <glibmm/i18n.h>
 #include <gtkmm.h>
-#include <cstring>
 #include "application.hpp"
 #include "spinbutton_helper.hpp"
 #include "util.hpp"
@@ -40,7 +39,7 @@ class SpectrumSettingsUi : public Gtk::Box {
   static void add_to_stack(Gtk::Stack* stack, Application* app);
 
  private:
-  std::string log_tag = "spectrum_settings_ui: ";
+  const std::string log_tag = "spectrum_settings_ui: ";
 
   Glib::RefPtr<Gio::Settings> settings;
 

--- a/include/spectrum_ui.hpp
+++ b/include/spectrum_ui.hpp
@@ -37,10 +37,10 @@ class SpectrumUi : public Gtk::DrawingArea {
 
   static auto add_to_box(Gtk::Box* box) -> SpectrumUi*;
 
-  void on_new_spectrum(const uint& rate, const uint& n_bands, const std::vector<float>& magnitudes);
+  void on_new_spectrum(uint rate, uint n_bands, std::vector<float> magnitudes);
 
  private:
-  std::string log_tag = "spectrum_ui: ";
+  const std::string log_tag = "spectrum_ui: ";
 
   Glib::RefPtr<Gio::Settings> settings;
 

--- a/include/spinbutton_helper.hpp
+++ b/include/spinbutton_helper.hpp
@@ -23,26 +23,19 @@
 #include <gtkmm.h>
 #include <sstream>
 
-inline auto parse_spinbutton_output(Gtk::SpinButton* button, const std::string& unit) -> bool {
-  std::ostringstream str;
+inline auto parse_spinbutton_output(Gtk::SpinButton* button, const Glib::ustring& unit) -> bool {
+  const auto& value = Glib::ustring::format(std::setprecision(button->get_digits()), std::fixed,
+                                            button->get_adjustment()->get_value());
 
-  str.precision(button->get_digits());
-
-  str << std::fixed << button->get_adjustment()->get_value() << " " << unit;
-
-  button->set_text(str.str());
+  button->set_text(value + ((unit.empty()) ? "" : (" " + unit)));
 
   return true;
 }
 
 inline auto parse_spinbutton_input(Gtk::SpinButton* button, double& new_value) {
-  std::istringstream str(button->get_text());
+  std::istringstream str(button->get_text().c_str());
 
-  if (str >> new_value) {
-    return 1;
-  }
-
-  return GTK_INPUT_ERROR;
+  return (str >> new_value) ? 1 : GTK_INPUT_ERROR;
 }
 
 #endif

--- a/include/stereo_tools.hpp
+++ b/include/stereo_tools.hpp
@@ -42,7 +42,7 @@ class StereoTools : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(double)> new_correlation;
+  sigc::signal<void(const double&)> new_correlation;
 
  private:
   std::unique_ptr<lv2::Lv2Wrapper> lv2_wrapper;

--- a/include/stereo_tools_ui.hpp
+++ b/include/stereo_tools_ui.hpp
@@ -36,7 +36,7 @@ class StereoToolsUi : public Gtk::Box, public PluginUiBase {
 
   static auto add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> StereoToolsUi*;
 
-  void on_new_phase_correlation(double value);
+  void on_new_phase_correlation(const double& value);
 
   void reset() override;
 

--- a/include/stream_input_effects.hpp
+++ b/include/stream_input_effects.hpp
@@ -43,12 +43,12 @@ class StreamInputEffects : public EffectsBase {
   void disconnect_filters();
 
   /*
-    Do not pass nd_info by reference. Sometimes it dies before we use it and a segmentation fault happens
+    Do not pass node_info by reference. Sometimes it dies before we use it and a segmentation fault happens.
   */
 
-  void on_app_added(const NodeInfo& node_info);
+  void on_app_added(NodeInfo node_info);
 
-  void on_link_changed(const LinkInfo& link_info);
+  void on_link_changed(LinkInfo link_info);
 };
 
 #endif

--- a/include/stream_input_effects_ui.hpp
+++ b/include/stream_input_effects_ui.hpp
@@ -38,7 +38,7 @@ class StreamInputEffectsUi : public Gtk::Box, public EffectsBaseUi {
   static auto add_to_stack(Gtk::Stack* stack, StreamInputEffects* sie_ptr) -> StreamInputEffectsUi*;
 
  protected:
-  std::string log_tag = "sie_ui: ";
+  const std::string log_tag = "sie_ui: ";
 
  private:
   StreamInputEffects* sie = nullptr;

--- a/include/stream_output_effects.hpp
+++ b/include/stream_output_effects.hpp
@@ -20,8 +20,6 @@
 #ifndef STREAM_OUTPUT_EFFECTS_HPP
 #define STREAM_OUTPUT_EFFECTS_HPP
 
-#include <algorithm>
-#include <ranges>
 #include "effects_base.hpp"
 
 class StreamOutputEffects : public EffectsBase {
@@ -43,12 +41,12 @@ class StreamOutputEffects : public EffectsBase {
   void disconnect_filters();
 
   /*
-    Do not pass nd_info by reference. Sometimes it dies before we use it and a segmentation fault happens
+    Do not pass node_info by reference. Sometimes it dies before we use it and a segmentation fault happens.
   */
 
-  void on_app_added(const NodeInfo& node_info);
+  void on_app_added(NodeInfo node_info);
 
-  void on_link_changed(const LinkInfo& link_info);
+  void on_link_changed(LinkInfo link_info);
 };
 
 #endif

--- a/include/stream_output_effects_ui.hpp
+++ b/include/stream_output_effects_ui.hpp
@@ -38,7 +38,7 @@ class StreamOutputEffectsUi : public Gtk::Box, public EffectsBaseUi {
   static auto add_to_stack(Gtk::Stack* stack, StreamOutputEffects* soe_ptr) -> StreamOutputEffectsUi*;
 
  protected:
-  std::string log_tag = "soe_ui: ";
+  const std::string log_tag = "soe_ui: ";
 
  private:
   StreamOutputEffects* soe = nullptr;

--- a/include/test_signals.hpp
+++ b/include/test_signals.hpp
@@ -50,8 +50,6 @@ class TestSignals {
     TestSignals* ts = nullptr;
   };
 
-  std::string log_tag = "test signals: ";
-
   pw_filter* filter = nullptr;
 
   uint n_samples = 0U;
@@ -81,6 +79,8 @@ class TestSignals {
   auto white_noise() -> float;
 
  private:
+  const std::string log_tag = "test signals: ";
+
   PipeManager* pm = nullptr;
 
   spa_hook listener{};

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -22,9 +22,9 @@
 
 #include <glib-object.h>
 #include <glib.h>
+#include <glibmm/ustring.h>
 #include <cmath>
 #include <iostream>
-#include <sstream>
 #include <thread>
 #include <vector>
 
@@ -67,7 +67,7 @@ auto double_x10_to_int(GValue* value, GVariant* variant, gpointer user_data) -> 
 
 auto ms_to_ns(GValue* value, GVariant* variant, gpointer user_data) -> gboolean;
 
-auto remove_filename_extension(const std::string& basename) -> std::string;
+auto remove_filename_extension(const Glib::ustring& basename) -> Glib::ustring;
 
 void print_thread_id();
 

--- a/src/autogain.cpp
+++ b/src/autogain.cpp
@@ -103,7 +103,7 @@ void AutoGain::process(std::span<float>& left_in,
 
   ebur128_add_frames_float(ebur_state, data.data(), n_samples);
 
-  bool failed = false;
+  auto failed = false;
   double momentary = 0.0;
   double shortterm = 0.0;
   double global = 0.0;
@@ -146,17 +146,17 @@ void AutoGain::process(std::span<float>& left_in,
     if (!failed) {
       loudness = std::cbrt(momentary * shortterm * global);
 
-      double diff = target - loudness;
+      const double diff = target - loudness;
 
       // 10^(diff/20). The way below should be faster than using pow
-      double gain = exp((diff / 20.0) * log(10.0));
+      const double gain = std::exp((diff / 20.0) * std::log(10.0));
 
-      double peak = (peak_L > peak_R) ? peak_L : peak_R;
+      const double peak = (peak_L > peak_R) ? peak_L : peak_R;
 
-      double db_peak = util::linear_to_db(peak);
+      const auto& db_peak = util::linear_to_db(peak);
 
       if (db_peak > util::minimum_db_level) {
-        if (gain * peak < 1.0F) {
+        if (gain * peak < 1.0) {
           output_gain = gain;
         }
       }

--- a/src/autogain_ui.cpp
+++ b/src/autogain_ui.cpp
@@ -67,7 +67,7 @@ AutoGainUi::~AutoGainUi() {
 auto AutoGainUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> AutoGainUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/autogain.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<AutoGainUi>(builder, "top_box", "com.github.wwmm.easyeffects.autogain",
+  auto* const ui = Gtk::Builder::get_widget_derived<AutoGainUi>(builder, "top_box", "com.github.wwmm.easyeffects.autogain",
                                                           schema_path + "autogain/");
 
   stack->add(*ui, plugin_name::autogain);

--- a/src/bass_enhancer.cpp
+++ b/src/bass_enhancer.cpp
@@ -96,7 +96,9 @@ void BassEnhancer::process(std::span<float>& left_in,
     notification_dt += sample_duration;
 
     if (notification_dt >= notification_time_window) {
-      float harmonics_value = lv2_wrapper->get_control_port_value("meter_drive");
+      // harmonics needed as double for levelbar widget ui, so we convert it here 
+
+      const double& harmonics_value = static_cast<double>(lv2_wrapper->get_control_port_value("meter_drive"));
 
       Glib::signal_idle().connect_once([=, this] { harmonics.emit(harmonics_value); });
 

--- a/src/bass_enhancer_ui.cpp
+++ b/src/bass_enhancer_ui.cpp
@@ -72,7 +72,7 @@ BassEnhancerUi::~BassEnhancerUi() {
 auto BassEnhancerUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> BassEnhancerUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/bass_enhancer.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<BassEnhancerUi>(
+  auto* const ui = Gtk::Builder::get_widget_derived<BassEnhancerUi>(
       builder, "top_box", "com.github.wwmm.easyeffects.bassenhancer", schema_path + "bassenhancer/");
 
   stack->add(*ui, plugin_name::bass_enhancer);
@@ -102,7 +102,7 @@ void BassEnhancerUi::reset() {
   settings->reset("listen");
 }
 
-void BassEnhancerUi::on_new_harmonics_level(double value) {
+void BassEnhancerUi::on_new_harmonics_level(const double& value) {
   harmonics_levelbar->set_value(value);
 
   harmonics_levelbar_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));

--- a/src/bass_loudness_ui.cpp
+++ b/src/bass_loudness_ui.cpp
@@ -54,7 +54,7 @@ BassLoudnessUi::~BassLoudnessUi() {
 auto BassLoudnessUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> BassLoudnessUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/bass_loudness.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<BassLoudnessUi>(
+  auto* const ui = Gtk::Builder::get_widget_derived<BassLoudnessUi>(
       builder, "top_box", "com.github.wwmm.easyeffects.bassloudness", schema_path + "bassloudness/");
 
   stack->add(*ui, plugin_name::bass_loudness);

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -42,7 +42,7 @@ Compressor::Compressor(const std::string& tag,
 
   settings->signal_changed("sidechain-type").connect([=, this](const auto& key) {
     if (settings->get_string(key) == "External") {
-      const auto& device_name = std::string(settings->get_string("sidechain-input-device"));
+      const auto* device_name = settings->get_string("sidechain-input-device").c_str();
 
       NodeInfo input_device = pm->pe_source_node;
 
@@ -66,7 +66,7 @@ Compressor::Compressor(const std::string& tag,
 
   settings->signal_changed("sidechain-input-device").connect([=, this](const auto& key) {
     if (settings->get_string("sidechain-type") == "External") {
-      const auto& device_name = std::string(settings->get_string(key));
+      const auto* device_name = settings->get_string(key).c_str();
 
       NodeInfo input_device = pm->pe_source_node;
 
@@ -172,12 +172,12 @@ void Compressor::process(std::span<float>& left_in,
    This plugin gives the latency in number of samples
  */
 
-  uint lv = static_cast<uint>(lv2_wrapper->get_control_port_value("out_latency"));
+  const auto& lv = static_cast<uint>(lv2_wrapper->get_control_port_value("out_latency"));
 
   if (latency_n_frames != lv) {
     latency_n_frames = lv;
 
-    float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
     util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
 
@@ -204,10 +204,10 @@ void Compressor::process(std::span<float>& left_in,
     notification_dt += sample_duration;
 
     if (notification_dt >= notification_time_window) {
-      float reduction_value = lv2_wrapper->get_control_port_value("rlm");
-      float sidechain_value = lv2_wrapper->get_control_port_value("slm");
-      float curve_value = lv2_wrapper->get_control_port_value("clm");
-      float envelope_value = lv2_wrapper->get_control_port_value("elm");
+      const float& reduction_value = lv2_wrapper->get_control_port_value("rlm");
+      const float& sidechain_value = lv2_wrapper->get_control_port_value("slm");
+      const float& curve_value = lv2_wrapper->get_control_port_value("clm");
+      const float& envelope_value = lv2_wrapper->get_control_port_value("elm");
 
       Glib::signal_idle().connect_once([=, this] {
         reduction.emit(reduction_value);

--- a/src/compressor_ui.cpp
+++ b/src/compressor_ui.cpp
@@ -486,10 +486,8 @@ void CompressorUi::set_pipe_manager_ptr(PipeManager* pipe_manager) {
   }
 
   connections.emplace_back(pm->source_added.connect([=, this](const NodeInfo& info) {
-    for (guint n = 0U; n < input_devices_model->get_n_items(); n++) {
-      const auto& item = input_devices_model->get_item(n);
-
-      if (item->info.id == info.id) {
+    for (guint n = 0U, list_size = input_devices_model->get_n_items(); n < list_size; n++) {
+      if (input_devices_model->get_item(n)->info.id == info.id) {
         return;
       }
     }
@@ -498,10 +496,8 @@ void CompressorUi::set_pipe_manager_ptr(PipeManager* pipe_manager) {
   }));
 
   connections.emplace_back(pm->source_removed.connect([=, this](const NodeInfo& info) {
-    for (guint n = 0U; n < input_devices_model->get_n_items(); n++) {
-      auto item = input_devices_model->get_item(n);
-
-      if (item->info.id == info.id) {
+    for (guint n = 0U, list_size = input_devices_model->get_n_items(); n < list_size; n++) {
+      if (input_devices_model->get_item(n)->info.id == info.id) {
         input_devices_model->remove(n);
 
         return;

--- a/src/compressor_ui.cpp
+++ b/src/compressor_ui.cpp
@@ -24,11 +24,11 @@ namespace {
 auto mode_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "Downward") == 0) {
+  if (g_strcmp0(v, "Downward") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Upward") == 0) {
+  } else if (g_strcmp0(v, "Upward") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "Boosting") == 0) {
+  } else if (g_strcmp0(v, "Boosting") == 0) {
     g_value_set_int(value, 2);
   }
 
@@ -54,11 +54,11 @@ auto int_to_mode_enum(const GValue* value, const GVariantType* expected_type, gp
 auto sidechain_type_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "Feed-forward") == 0) {
+  if (g_strcmp0(v, "Feed-forward") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Feed-back") == 0) {
+  } else if (g_strcmp0(v, "Feed-back") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "External") == 0) {
+  } else if (g_strcmp0(v, "External") == 0) {
     g_value_set_int(value, 2);
   }
 
@@ -85,13 +85,13 @@ auto int_to_sidechain_type_enum(const GValue* value, const GVariantType* expecte
 auto sidechain_mode_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "Peak") == 0) {
+  if (g_strcmp0(v, "Peak") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "RMS") == 0) {
+  } else if (g_strcmp0(v, "RMS") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "Low-Pass") == 0) {
+  } else if (g_strcmp0(v, "Low-Pass") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "Uniform") == 0) {
+  } else if (g_strcmp0(v, "Uniform") == 0) {
     g_value_set_int(value, 3);
   }
 
@@ -121,13 +121,13 @@ auto int_to_sidechain_mode_enum(const GValue* value, const GVariantType* expecte
 auto sidechain_source_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "Middle") == 0) {
+  if (g_strcmp0(v, "Middle") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Side") == 0) {
+  } else if (g_strcmp0(v, "Side") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "Left") == 0) {
+  } else if (g_strcmp0(v, "Left") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "Right") == 0) {
+  } else if (g_strcmp0(v, "Right") == 0) {
     g_value_set_int(value, 3);
   }
 
@@ -157,13 +157,13 @@ auto int_to_sidechain_source_enum(const GValue* value, const GVariantType* expec
 auto filter_mode_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "off") == 0) {
+  if (g_strcmp0(v, "off") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "12 dB/oct") == 0) {
+  } else if (g_strcmp0(v, "12 dB/oct") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "24 dB/oct") == 0) {
+  } else if (g_strcmp0(v, "24 dB/oct") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "36 dB/oct") == 0) {
+  } else if (g_strcmp0(v, "36 dB/oct") == 0) {
     g_value_set_int(value, 3);
   }
 
@@ -358,7 +358,7 @@ CompressorUi::~CompressorUi() {
 auto CompressorUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> CompressorUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/compressor.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<CompressorUi>(
+  auto* const ui = Gtk::Builder::get_widget_derived<CompressorUi>(
       builder, "top_box", "com.github.wwmm.easyeffects.compressor", schema_path + "compressor/");
 
   stack->add(*ui, plugin_name::compressor);
@@ -414,19 +414,19 @@ void CompressorUi::reset() {
   settings->reset("lpf-frequency");
 }
 
-void CompressorUi::on_new_reduction(double value) {
+void CompressorUi::on_new_reduction(const float& value) {
   reduction_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
-void CompressorUi::on_new_envelope(double value) {
+void CompressorUi::on_new_envelope(const float& value) {
   envelope_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
-void CompressorUi::on_new_sidechain(double value) {
+void CompressorUi::on_new_sidechain(const float& value) {
   sidechain_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
-void CompressorUi::on_new_curve(double value) {
+void CompressorUi::on_new_curve(const float& value) {
   curve_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
@@ -444,9 +444,9 @@ void CompressorUi::setup_dropdown_input_devices() {
   // setting the factory callbacks
 
   factory->signal_setup().connect([=](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* box = Gtk::make_managed<Gtk::Box>();
-    auto* label = Gtk::make_managed<Gtk::Label>();
-    auto* icon = Gtk::make_managed<Gtk::Image>();
+    auto* const box = Gtk::make_managed<Gtk::Box>();
+    auto* const label = Gtk::make_managed<Gtk::Label>();
+    auto* const icon = Gtk::make_managed<Gtk::Image>();
 
     label->set_hexpand(true);
     label->set_halign(Gtk::Align::START);
@@ -465,7 +465,7 @@ void CompressorUi::setup_dropdown_input_devices() {
   });
 
   factory->signal_bind().connect([=](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* label = static_cast<Gtk::Label*>(list_item->get_data("name"));
+    auto* const label = static_cast<Gtk::Label*>(list_item->get_data("name"));
 
     auto holder = std::dynamic_pointer_cast<NodeInfoHolder>(list_item->get_item());
 
@@ -485,7 +485,7 @@ void CompressorUi::set_pipe_manager_ptr(PipeManager* pipe_manager) {
     }
   }
 
-  connections.emplace_back(pm->source_added.connect([=, this](const NodeInfo& info) {
+  connections.emplace_back(pm->source_added.connect([=, this](NodeInfo info) {
     for (guint n = 0U, list_size = input_devices_model->get_n_items(); n < list_size; n++) {
       if (input_devices_model->get_item(n)->info.id == info.id) {
         return;
@@ -495,7 +495,7 @@ void CompressorUi::set_pipe_manager_ptr(PipeManager* pipe_manager) {
     input_devices_model->append(NodeInfoHolder::create(info));
   }));
 
-  connections.emplace_back(pm->source_removed.connect([=, this](const NodeInfo& info) {
+  connections.emplace_back(pm->source_removed.connect([=, this](NodeInfo info) {
     for (guint n = 0U, list_size = input_devices_model->get_n_items(); n < list_size; n++) {
       if (input_devices_model->get_item(n)->info.id == info.id) {
         input_devices_model->remove(n);

--- a/src/convolver.cpp
+++ b/src/convolver.cpp
@@ -212,7 +212,7 @@ void Convolver::process(std::span<float>& left_in,
         deque_out_R.pop_front();
       }
     } else {
-      uint offset = 2 * (left_out.size() - deque_out_L.size());
+      uint offset = 2U * (left_out.size() - deque_out_L.size());
 
       if (offset != latency_n_frames) {
         latency_n_frames = offset;

--- a/src/convolver.cpp
+++ b/src/convolver.cpp
@@ -212,7 +212,7 @@ void Convolver::process(std::span<float>& left_in,
         deque_out_R.pop_front();
       }
     } else {
-      uint offset = 2U * (left_out.size() - deque_out_L.size());
+      const uint offset = 2U * (left_out.size() - deque_out_L.size());
 
       if (offset != latency_n_frames) {
         latency_n_frames = offset;
@@ -238,7 +238,7 @@ void Convolver::process(std::span<float>& left_in,
   apply_gain(left_out, right_out, output_gain);
 
   if (notify_latency) {
-    float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
     util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
 
@@ -279,13 +279,15 @@ void Convolver::read_kernel_file() {
 
   const auto& path = settings->get_string("kernel-path");
 
-  if (path.c_str() == nullptr) {
+  if (path.empty()) {
     util::warning(log_tag + name + ": irs file path is null. Entering passthrough mode...");
 
     return;
   }
 
-  SndfileHandle file = SndfileHandle(path);
+  // SndfileHandle might have issues with std::string, so we provide cstring
+
+  SndfileHandle file = SndfileHandle(path.c_str());
 
   if (file.channels() == 0 || file.frames() == 0) {
     util::warning(log_tag + name + ": irs file does not exists or it is empty: " + path);
@@ -344,10 +346,12 @@ void Convolver::apply_kernel_autogain() {
     return;
   }
 
-  float abs_peak_L = std::ranges::max(kernel_L, [](const auto& a, const auto& b) { return (std::fabs(a) < std::fabs(b)); });
-  float abs_peak_R = std::ranges::max(kernel_R, [](const auto& a, const auto& b) { return (std::fabs(a) < std::fabs(b)); });
+  const float abs_peak_L =
+      std::ranges::max(kernel_L, [](const auto& a, const auto& b) { return (std::fabs(a) < std::fabs(b)); });
+  const float abs_peak_R =
+      std::ranges::max(kernel_R, [](const auto& a, const auto& b) { return (std::fabs(a) < std::fabs(b)); });
 
-  float peak = (abs_peak_L > abs_peak_R) ? abs_peak_L : abs_peak_R;
+  const float peak = (abs_peak_L > abs_peak_R) ? abs_peak_L : abs_peak_R;
 
   // normalize
 
@@ -363,7 +367,7 @@ void Convolver::apply_kernel_autogain() {
 
   power *= 0.5F;
 
-  float autogain = std::min(1.0F, 1.0F / sqrtf(power));
+  const float autogain = std::min(1.0F, 1.0F / std::sqrt(power));
 
   util::debug(log_tag + "autogain factor: " + std::to_string(autogain));
 
@@ -376,12 +380,12 @@ void Convolver::apply_kernel_autogain() {
    taken from https://github.com/tomszilagyi/ir.lv2/blob/automatable/ir.cc
 */
 void Convolver::set_kernel_stereo_width() {
-  float w = static_cast<float>(ir_width) * 0.01F;
-  float x = (1.0F - w) / (1.0F + w);  // M-S coeff.; L_out = L + x*R; R_out = R + x*L
+  const float w = static_cast<float>(ir_width) * 0.01F;
+  const float x = (1.0F - w) / (1.0F + w);  // M-S coeff.; L_out = L + x*R; R_out = R + x*L
 
   for (uint i = 0U, okl_size = original_kernel_L.size(); i < okl_size; i++) {
-    float L = original_kernel_L[i];
-    float R = original_kernel_R[i];
+    const auto& L = original_kernel_L[i];
+    const auto& R = original_kernel_R[i];
 
     kernel_L[i] = L + x * R;
     kernel_R[i] = R + x * L;
@@ -396,9 +400,9 @@ void Convolver::setup_zita() {
   }
 
   int ret = 0;
-  uint max_convolution_size = kernel_L.size();
-  uint buffer_size = get_zita_buffer_size();
-  float density = 0.0F;
+  const uint max_convolution_size = kernel_L.size();
+  const uint buffer_size = get_zita_buffer_size();
+  const float density = 0.0F;
 
   if (conv == nullptr) {
     conv = new Convproc();

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -147,23 +147,27 @@ ConvolverUi::ConvolverUi(BaseObjectType* cobject,
     [=, this](const Glib::RefPtr<Gio::File>& file, const auto& other_f, const auto& event) {
       switch (event) {
         case Gio::FileMonitor::Event::CREATED: {
-          string_list->append(util::remove_filename_extension(file->get_basename()));
+          const auto& new_name = Glib::ustring(util::remove_filename_extension(file->get_basename()));
+
+          for (guint n = 0, list_size = string_list->get_n_items(); n < list_size; n++) {
+            if (string_list->get_string(n) == new_name) {
+              return;
+            }
+          }
+
+          string_list->append(new_name);
 
           break;
         }
         case Gio::FileMonitor::Event::DELETED: {
-          const Glib::ustring& name_removed = util::remove_filename_extension(file->get_basename());
+          const auto& name_to_remove = Glib::ustring(util::remove_filename_extension(file->get_basename()));
 
-          int count = 0;
-
-          for (auto name = string_list->get_string(count); name.c_str() != nullptr;) {
-            if (name_removed == name) {
-              string_list->remove(count);
+          for (guint n = 0, list_size = string_list->get_n_items(); n < list_size; n++) {
+            if (string_list->get_string(n) == name_to_remove) {
+              string_list->remove(n);
 
               break;
             }
-
-            name = string_list->get_string(++count);
           }
 
           break;

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -89,30 +89,18 @@ ConvolverUi::ConvolverUi(BaseObjectType* cobject,
 
   check_left->signal_toggled().connect([&, this]() {
     if (check_left->get_active()) {
-      if (show_fft->get_active()) {
-        plot_fft();
-      } else {
-        plot_waveform();
-      }
+      (show_fft->get_active()) ? plot_fft() : plot_waveform();
     }
   });
 
   check_right->signal_toggled().connect([&, this]() {
     if (check_right->get_active()) {
-      if (show_fft->get_active()) {
-        plot_fft();
-      } else {
-        plot_waveform();
-      }
+      (show_fft->get_active()) ? plot_fft() : plot_waveform();
     }
   });
 
   show_fft->signal_toggled().connect([=, this]() {
-    if (show_fft->get_active()) {
-      plot_fft();
-    } else {
-      plot_waveform();
-    }
+    (show_fft->get_active()) ? plot_fft() : plot_waveform();
   });
 
   // gsettings bindings
@@ -145,25 +133,29 @@ ConvolverUi::ConvolverUi(BaseObjectType* cobject,
 
   folder_monitor->signal_changed().connect(
     [=, this](const Glib::RefPtr<Gio::File>& file, const auto& other_f, const auto& event) {
+      const auto& irs_filename = util::remove_filename_extension(file->get_basename());
+
+      if (irs_filename.empty()) {
+        util::warning("Can't retrieve information about irs file");
+
+        return;
+      }
+
       switch (event) {
         case Gio::FileMonitor::Event::CREATED: {
-          const auto& new_name = Glib::ustring(util::remove_filename_extension(file->get_basename()));
-
           for (guint n = 0, list_size = string_list->get_n_items(); n < list_size; n++) {
-            if (string_list->get_string(n) == new_name) {
+            if (string_list->get_string(n) == irs_filename) {
               return;
             }
           }
 
-          string_list->append(new_name);
+          string_list->append(irs_filename);
 
           break;
         }
         case Gio::FileMonitor::Event::DELETED: {
-          const auto& name_to_remove = Glib::ustring(util::remove_filename_extension(file->get_basename()));
-
           for (guint n = 0, list_size = string_list->get_n_items(); n < list_size; n++) {
-            if (string_list->get_string(n) == name_to_remove) {
+            if (string_list->get_string(n) == irs_filename) {
               string_list->remove(n);
 
               break;
@@ -189,7 +181,7 @@ ConvolverUi::~ConvolverUi() {
 auto ConvolverUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> ConvolverUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/convolver.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<ConvolverUi>(builder, "top_box", "com.github.wwmm.easyeffects.convolver",
+  auto* const ui = Gtk::Builder::get_widget_derived<ConvolverUi>(builder, "top_box", "com.github.wwmm.easyeffects.convolver",
                                                            schema_path + "convolver/");
 
   stack->add(*ui, plugin_name::convolver);
@@ -217,10 +209,10 @@ void ConvolverUi::setup_listview() {
 
   // sorter
 
-  auto sorter =
+  const auto& sorter =
       Gtk::StringSorter::create(Gtk::PropertyExpression<Glib::ustring>::create(GTK_TYPE_STRING_OBJECT, "string"));
 
-  auto sort_list_model = Gtk::SortListModel::create(filter_model, sorter);
+  const auto& sort_list_model = Gtk::SortListModel::create(filter_model, sorter);
 
   // setting the listview model and factory
 
@@ -233,10 +225,10 @@ void ConvolverUi::setup_listview() {
   // setting the factory callbacks
 
   factory->signal_setup().connect([=](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* box = Gtk::make_managed<Gtk::Box>();
-    auto* label = Gtk::make_managed<Gtk::Label>();
-    auto* load = Gtk::make_managed<Gtk::Button>();
-    auto* remove = Gtk::make_managed<Gtk::Button>();
+    auto* const box = Gtk::make_managed<Gtk::Box>();
+    auto* const label = Gtk::make_managed<Gtk::Label>();
+    auto* const load = Gtk::make_managed<Gtk::Button>();
+    auto* const remove = Gtk::make_managed<Gtk::Button>();
 
     label->set_hexpand(true);
     label->set_halign(Gtk::Align::START);
@@ -258,21 +250,21 @@ void ConvolverUi::setup_listview() {
   });
 
   factory->signal_bind().connect([=, this](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* label = static_cast<Gtk::Label*>(list_item->get_data("name"));
-    auto* load = static_cast<Gtk::Button*>(list_item->get_data("load"));
-    auto* remove = static_cast<Gtk::Button*>(list_item->get_data("remove"));
+    auto* const label = static_cast<Gtk::Label*>(list_item->get_data("name"));
+    auto* const load = static_cast<Gtk::Button*>(list_item->get_data("load"));
+    auto* const remove = static_cast<Gtk::Button*>(list_item->get_data("remove"));
 
     const auto& name = list_item->get_item()->get_property<Glib::ustring>("string");
 
     label->set_text(name);
 
     auto connection_load = load->signal_clicked().connect([=, this]() {
-      const auto& irs_file = irs_dir / std::filesystem::path{name + ".irs"};
+      const auto& irs_file = irs_dir / std::filesystem::path{name.c_str() + irs_ext};
 
-      settings->set_string("kernel-path", irs_file.string());
+      settings->set_string("kernel-path", irs_file.c_str());
     });
 
-    auto connection_remove = remove->signal_clicked().connect([=, this]() { remove_irs_file(name); });
+    auto connection_remove = remove->signal_clicked().connect([=, this]() { remove_irs_file(name.raw()); });
 
     list_item->set_data("connection_load", new sigc::connection(connection_load),
                         Glib::destroy_notify_delete<sigc::connection>);
@@ -308,13 +300,13 @@ void ConvolverUi::reset() {
   settings->reset("ir-width");
 }
 
-auto ConvolverUi::get_irs_names() -> std::vector<std::string> {
-  std::vector<std::string> names;
+auto ConvolverUi::get_irs_names() -> std::vector<Glib::ustring> {
+  std::vector<Glib::ustring> names;
 
   for (std::filesystem::directory_iterator it{irs_dir}; it != std::filesystem::directory_iterator{}; ++it) {
     if (std::filesystem::is_regular_file(it->status())) {
-      if (it->path().extension().string() == ".irs") {
-        names.emplace_back(it->path().stem().string());
+      if (it->path().extension().c_str() == irs_ext) {
+        names.emplace_back(it->path().stem().c_str());
       }
     }
   }
@@ -326,7 +318,7 @@ void ConvolverUi::import_irs_file(const std::string& file_path) {
   std::filesystem::path p{file_path};
 
   if (std::filesystem::is_regular_file(p)) {
-    if (SndfileHandle file = SndfileHandle(file_path); file.channels() != 2 || file.frames() == 0) {
+    if (SndfileHandle file = SndfileHandle(file_path.c_str()); file.channels() != 2 || file.frames() == 0) {
       util::warning(log_tag + " Only stereo impulse files are supported!");
       util::warning(log_tag + file_path + " loading failed");
 
@@ -335,7 +327,7 @@ void ConvolverUi::import_irs_file(const std::string& file_path) {
 
     auto out_path = irs_dir / p.filename();
 
-    out_path.replace_extension(".irs");
+    out_path.replace_extension(irs_ext);
 
     std::filesystem::copy_file(p, out_path, std::filesystem::copy_options::overwrite_existing);
 
@@ -346,7 +338,7 @@ void ConvolverUi::import_irs_file(const std::string& file_path) {
 }
 
 void ConvolverUi::remove_irs_file(const std::string& name) {
-  auto irs_file = irs_dir / std::filesystem::path{name + ".irs"};
+  const auto& irs_file = irs_dir / std::filesystem::path{name + irs_ext};
 
   if (std::filesystem::exists(irs_file)) {
     std::filesystem::remove(irs_file);
@@ -395,7 +387,7 @@ void ConvolverUi::on_import_irs_clicked() {
 void ConvolverUi::get_irs_info() {
   const auto& path = settings->get_string("kernel-path");
 
-  if (path.c_str() == nullptr) {
+  if (path.empty()) {
     util::warning(log_tag + name + ": irs file path is null.");
 
     return;
@@ -403,7 +395,7 @@ void ConvolverUi::get_irs_info() {
 
   util::debug(log_tag + "reading the impulse file: " + path);
 
-  SndfileHandle file = SndfileHandle(path);
+  SndfileHandle file = SndfileHandle(path.c_str());
 
   if (file.channels() != 2 || file.frames() == 0) {
     // warning user that there is a problem
@@ -426,20 +418,20 @@ void ConvolverUi::get_irs_info() {
 
   file.readf(kernel.data(), file.frames());
 
-  float dt = 1.0F / static_cast<float>(file.samplerate());
+  const float dt = 1.0F / static_cast<float>(file.samplerate());
 
-  float duration = (static_cast<float>(file.frames()) - 1.0F) * dt;
+  const float duration = (static_cast<float>(file.frames()) - 1.0F) * dt;
 
   time_axis.resize(file.frames());
   left_mag.resize(file.frames());
   right_mag.resize(file.frames());
 
-  for (uint n = 0U; n < file.frames(); n++) {
+  for (int n = 0; n < file.frames(); n++) {
     time_axis[n] = n * dt;
 
-    left_mag[n] = kernel[2U * n];
+    left_mag[n] = kernel[2 * n];
 
-    right_mag[n] = kernel[2U * n + 1U];
+    right_mag[n] = kernel[2 * n + 1];
   }
 
   get_irs_spectrum(file.samplerate());
@@ -489,15 +481,15 @@ void ConvolverUi::get_irs_info() {
 
   // ensure that the fft can be computed
 
-  if (time_axis.size() % 2 != 0) {
-    time_axis.emplace_back(static_cast<float>(time_axis.size() - 1) * dt);
+  if (time_axis.size() % 2U != 0U) {
+    time_axis.emplace_back(static_cast<float>(time_axis.size() - 1U) * dt);
   }
 
-  if (left_mag.size() % 2 != 0) {
+  if (left_mag.size() % 2U != 0U) {
     left_mag.emplace_back(0.0F);
   }
 
-  if (right_mag.size() % 2 != 0) {
+  if (right_mag.size() % 2U != 0U) {
     right_mag.emplace_back(0.0F);
   }
 
@@ -523,14 +515,14 @@ void ConvolverUi::get_irs_info() {
   // updating interface with ir file info
 
   connections.emplace_back(Glib::signal_idle().connect([=, this]() {
-    label_sampling_rate->set_text(std::to_string(file.samplerate()) + " Hz");
-    label_samples->set_text(std::to_string(file.frames()));
+    label_sampling_rate->set_text(Glib::ustring::format(file.samplerate()) + " Hz");
+    label_samples->set_text(Glib::ustring::format(file.frames()));
 
     label_duration->set_text(level_to_localized_string(duration, 3) + " s");
 
-    const auto& fpath = std::filesystem::path{path};
+    const auto& fpath = std::filesystem::path{path.raw()};
 
-    label_file_name->set_text(fpath.stem().string());
+    label_file_name->set_text(fpath.stem().c_str());
 
     plot_waveform();
 
@@ -545,15 +537,17 @@ void ConvolverUi::get_irs_spectrum(const int& rate) {
 
   util::debug(log_tag + "calculating the impulse fft...");
 
-  left_spectrum.resize(left_mag.size() / 2 + 1);
-  right_spectrum.resize(right_mag.size() / 2 + 1);
+  left_spectrum.resize(left_mag.size() / 2U + 1U);
+  right_spectrum.resize(right_mag.size() / 2U + 1U);
 
   auto real_input = left_mag;
 
   for (uint n = 0U, ri_size = real_input.size(); n < ri_size; n++) {
     // https://en.wikipedia.org/wiki/Hann_function
 
-    auto w = 0.5F * (1.0F - cosf(2.0F * std::numbers::pi_v<float> * n / static_cast<float>(real_input.size() - 1)));
+    const float w =
+        0.5F * (1.0F - std::cos(2.0F * std::numbers::pi_v<float> * static_cast<float>(n) /
+        static_cast<float>(real_input.size() - 1U)));
 
     real_input[n] *= w;
   }
@@ -580,7 +574,9 @@ void ConvolverUi::get_irs_spectrum(const int& rate) {
   for (uint n = 0U, ri_size = real_input.size(); n < ri_size; n++) {
     // https://en.wikipedia.org/wiki/Hann_function
 
-    auto w = 0.5F * (1.0F - cosf(2.0F * std::numbers::pi_v<float> * n / static_cast<float>(real_input.size() - 1)));
+    const float w =
+        0.5F * (1.0F - std::cos(2.0F * std::numbers::pi_v<float> * static_cast<float>(n) /
+        static_cast<float>(real_input.size() - 1U)));
 
     real_input[n] *= w;
   }
@@ -613,13 +609,12 @@ void ConvolverUi::get_irs_spectrum(const int& rate) {
 
   // initializing the logarithmic frequency axis
 
-  const auto& log_axis = util::logspace(log10f(20.0F), log10f(22000.0F), spectrum_settings->get_int("n-points"));
+  const auto& log_axis = util::logspace(std::log10(20.0F), std::log10(22000.0F), spectrum_settings->get_int("n-points"));
   // auto log_axis = util::linspace(20.0F, 22000.0F, spectrum_settings->get_int("n-points"));
-
-  std::vector<uint> bin_count(log_axis.size());
 
   std::vector<float> l(log_axis.size());
   std::vector<float> r(log_axis.size());
+  std::vector<uint> bin_count(log_axis.size());
 
   std::ranges::fill(l, 0.0F);
   std::ranges::fill(r, 0.0F);

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -311,7 +311,7 @@ void ConvolverUi::reset() {
 auto ConvolverUi::get_irs_names() -> std::vector<std::string> {
   std::vector<std::string> names;
 
-  for (std::filesystem::directory_iterator it{irs_dir}; it != std::filesystem::directory_iterator{}; it++) {
+  for (std::filesystem::directory_iterator it{irs_dir}; it != std::filesystem::directory_iterator{}; ++it) {
     if (std::filesystem::is_regular_file(it->status())) {
       if (it->path().extension().string() == ".irs") {
         names.emplace_back(it->path().stem().string());

--- a/src/crossfeed_ui.cpp
+++ b/src/crossfeed_ui.cpp
@@ -61,7 +61,7 @@ CrossfeedUi::~CrossfeedUi() {
 auto CrossfeedUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> CrossfeedUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/crossfeed.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<CrossfeedUi>(builder, "top_box", "com.github.wwmm.easyeffects.crossfeed",
+  auto* const ui = Gtk::Builder::get_widget_derived<CrossfeedUi>(builder, "top_box", "com.github.wwmm.easyeffects.crossfeed",
                                                            schema_path + "crossfeed/");
 
   stack->add(*ui, plugin_name::crossfeed);

--- a/src/crystalizer.cpp
+++ b/src/crystalizer.cpp
@@ -192,7 +192,7 @@ void Crystalizer::process(std::span<float>& left_in,
         deque_out_R.pop_front();
       }
     } else {
-      uint offset = 2 * (left_out.size() - deque_out_L.size());
+      uint offset = 2U * (left_out.size() - deque_out_L.size());
 
       if (offset != latency_n_frames) {
         latency_n_frames = offset + 1U;  // the second derivative forces us to delay at least one sample

--- a/src/crystalizer.cpp
+++ b/src/crystalizer.cpp
@@ -218,7 +218,7 @@ void Crystalizer::process(std::span<float>& left_in,
   apply_gain(left_out, right_out, output_gain);
 
   if (notify_latency) {
-    float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
     util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
 
@@ -255,21 +255,21 @@ void Crystalizer::process(std::span<float>& left_in,
 }
 
 void Crystalizer::bind_band(const int& n) {
-  const auto& nstr = std::to_string(n);
+  const auto& bandn = "band" + std::to_string(n);
 
-  band_intensity.at(n) = static_cast<float>(util::db_to_linear(settings->get_double("intensity-band" + nstr)));
-  band_mute.at(n) = settings->get_boolean("mute-band" + nstr);
-  band_bypass.at(n) = settings->get_boolean("bypass-band" + nstr);
+  band_intensity.at(n) = static_cast<float>(util::db_to_linear(settings->get_double("intensity-" + bandn)));
+  band_mute.at(n) = settings->get_boolean("mute-" + bandn);
+  band_bypass.at(n) = settings->get_boolean("bypass-" + bandn);
 
-  settings->signal_changed("intensity-band" + nstr).connect([=, this](const auto& key) {
+  settings->signal_changed("intensity-" + bandn).connect([=, this](const auto& key) {
     band_intensity.at(n) = util::db_to_linear(settings->get_double(key));
   });
 
-  settings->signal_changed("mute-band" + nstr).connect([=, this](const auto& key) {
+  settings->signal_changed("mute-" + bandn).connect([=, this](const auto& key) {
     band_mute.at(n) = settings->get_boolean(key);
   });
 
-  settings->signal_changed("bypass-band" + nstr).connect([=, this](const auto& key) {
+  settings->signal_changed("bypass-" + bandn).connect([=, this](const auto& key) {
     band_bypass.at(n) = settings->get_boolean(key);
   });
 }

--- a/src/crystalizer_preset.cpp
+++ b/src/crystalizer_preset.cpp
@@ -35,16 +35,16 @@ void CrystalizerPreset::save(nlohmann::json& json,
   json[section]["crystalizer"]["output-gain"] = settings->get_double("output-gain");
 
   for (int n = 0; n < 13; n++) {
-    const auto& nstr = std::to_string(n);
+    const auto& bandn = "band" + std::to_string(n);
 
-    json[section]["crystalizer"]["band" + nstr]["intensity"] =
-        settings->get_double("intensity-band" + nstr);
+    json[section]["crystalizer"][bandn]["intensity"] =
+        settings->get_double("intensity-" + bandn);
 
-    json[section]["crystalizer"]["band" + nstr]["mute"] =
-        settings->get_boolean("mute-band" + nstr);
+    json[section]["crystalizer"][bandn]["mute"] =
+        settings->get_boolean("mute-" + bandn);
 
-    json[section]["crystalizer"]["band" + nstr]["bypass"] =
-        settings->get_boolean("bypass-band" + nstr);
+    json[section]["crystalizer"][bandn]["bypass"] =
+        settings->get_boolean("bypass-" + bandn);
   }
 }
 
@@ -56,15 +56,15 @@ void CrystalizerPreset::load(const nlohmann::json& json,
   update_key<double>(json.at(section).at("crystalizer"), settings, "output-gain", "output-gain");
 
   for (int n = 0; n < 13; n++) {
-    const auto& nstr = std::to_string(n);
+    const auto& bandn = "band" + std::to_string(n);
 
-    update_key<double>(json.at(section).at("crystalizer")["band" + nstr], settings,
-                       "intensity-band" + nstr, "intensity");
+    update_key<double>(json.at(section).at("crystalizer")[bandn], settings,
+                       "intensity-" + bandn, "intensity");
 
-    update_key<bool>(json.at(section).at("crystalizer")["band" + nstr], settings,
-                     "mute-band" + nstr, "mute");
+    update_key<bool>(json.at(section).at("crystalizer")[bandn], settings,
+                     "mute-" + bandn, "mute");
 
-    update_key<bool>(json.at(section).at("crystalizer")["band" + nstr], settings,
-                     "bypass-band" + nstr, "bypass");
+    update_key<bool>(json.at(section).at("crystalizer")[bandn], settings,
+                     "bypass-" + bandn, "bypass");
   }
 }

--- a/src/crystalizer_ui.cpp
+++ b/src/crystalizer_ui.cpp
@@ -51,7 +51,7 @@ CrystalizerUi::~CrystalizerUi() {
 auto CrystalizerUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> CrystalizerUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/crystalizer.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<CrystalizerUi>(
+  auto* const ui = Gtk::Builder::get_widget_derived<CrystalizerUi>(
       builder, "top_box", "com.github.wwmm.easyeffects.crystalizer", schema_path + "crystalizer/");
 
   stack->add(*ui, plugin_name::crystalizer);
@@ -67,13 +67,13 @@ void CrystalizerUi::reset() {
   settings->reset("output-gain");
 
   for (int n = 0; n < 13; n++) {
-    const auto& nstr = std::to_string(n);
+    const auto& bandn = "band" + std::to_string(n);
 
-    settings->reset("intensity-band" + nstr);
+    settings->reset("intensity-" + bandn);
 
-    settings->reset("mute-band" + nstr);
+    settings->reset("mute-" + bandn);
 
-    settings->reset("bypass-band" + nstr);
+    settings->reset("bypass-" + bandn);
   }
 }
 
@@ -102,11 +102,11 @@ void CrystalizerUi::build_bands(const int& nbands) {
       }
     }));
 
-    const auto& nstr = std::to_string(n);
+    const auto& bandn = "band" + std::to_string(n);
 
-    settings->bind(std::string("intensity-band" + nstr), band_intensity->get_adjustment().get(), "value");
-    settings->bind(std::string("mute-band" + nstr), band_mute, "active");
-    settings->bind(std::string("bypass-band" + nstr), band_bypass, "active");
+    settings->bind("intensity-" + bandn, band_intensity->get_adjustment().get(), "value");
+    settings->bind("mute-" + bandn, band_mute, "active");
+    settings->bind("bypass-" + bandn, band_bypass, "active");
 
     switch (n) {
       case 0:

--- a/src/deesser.cpp
+++ b/src/deesser.cpp
@@ -106,8 +106,10 @@ void Deesser::process(std::span<float>& left_in,
     notification_dt += sample_duration;
 
     if (notification_dt >= notification_time_window) {
-      float detected_value = lv2_wrapper->get_control_port_value("detected");
-      float compression_value = lv2_wrapper->get_control_port_value("compression");
+      // values needed as double for levelbars widget ui, so we convert them here
+
+      const double& detected_value = static_cast<double>(lv2_wrapper->get_control_port_value("detected"));
+      const double& compression_value = static_cast<double>(lv2_wrapper->get_control_port_value("compression"));
 
       Glib::signal_idle().connect_once([=, this] {
         detected.emit(detected_value);

--- a/src/deesser_ui.cpp
+++ b/src/deesser_ui.cpp
@@ -24,9 +24,9 @@ namespace {
 auto detection_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "RMS") == 0) {
+  if (g_strcmp0(v, "RMS") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Peak") == 0) {
+  } else if (g_strcmp0(v, "Peak") == 0) {
     g_value_set_int(value, 1);
   }
 
@@ -49,9 +49,9 @@ auto int_to_detection_enum(const GValue* value, const GVariantType* expected_typ
 auto mode_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "Wide") == 0) {
+  if (g_strcmp0(v, "Wide") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Split") == 0) {
+  } else if (g_strcmp0(v, "Split") == 0) {
     g_value_set_int(value, 1);
   }
 
@@ -149,7 +149,7 @@ DeesserUi::~DeesserUi() {
 auto DeesserUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> DeesserUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/deesser.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<DeesserUi>(builder, "top_box", "com.github.wwmm.easyeffects.deesser",
+  auto* const ui = Gtk::Builder::get_widget_derived<DeesserUi>(builder, "top_box", "com.github.wwmm.easyeffects.deesser",
                                                          schema_path + "deesser/");
 
   stack->add(*ui, plugin_name::deesser);
@@ -189,13 +189,13 @@ void DeesserUi::reset() {
   settings->reset("sc-listen");
 }
 
-void DeesserUi::on_new_compression(double value) {
+void DeesserUi::on_new_compression(const double& value) {
   compression->set_value(1.0 - value);
 
   compression_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
-void DeesserUi::on_new_detected(double value) {
+void DeesserUi::on_new_detected(const double& value) {
   detected->set_value(value);
 
   detected_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));

--- a/src/delay.cpp
+++ b/src/delay.cpp
@@ -86,12 +86,12 @@ void Delay::process(std::span<float>& left_in,
     This plugin gives the latency in number of samples
   */
 
-  uint lv = static_cast<uint>(lv2_wrapper->get_control_port_value("out_latency"));
+  const auto& lv = static_cast<uint>(lv2_wrapper->get_control_port_value("out_latency"));
 
   if (latency_n_frames != lv) {
     latency_n_frames = lv;
 
-    float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
     util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
 

--- a/src/delay_ui.cpp
+++ b/src/delay_ui.cpp
@@ -54,7 +54,7 @@ DelayUi::~DelayUi() {
 auto DelayUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> DelayUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/delay.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<DelayUi>(builder, "top_box", "com.github.wwmm.easyeffects.delay",
+  auto* const ui = Gtk::Builder::get_widget_derived<DelayUi>(builder, "top_box", "com.github.wwmm.easyeffects.delay",
                                                        schema_path + "delay/");
 
   stack->add(*ui, plugin_name::delay);

--- a/src/easyeffects.cpp
+++ b/src/easyeffects.cpp
@@ -23,7 +23,7 @@
 #include "gtkmm/window.h"
 
 auto sigterm(void* data) -> bool {
-  auto* app = static_cast<Application*>(data);
+  auto* const app = static_cast<Application*>(data);
 
   for (const auto& w : app->get_windows()) {
     w->hide();

--- a/src/echo_canceller.cpp
+++ b/src/echo_canceller.cpp
@@ -147,7 +147,7 @@ void EchoCanceller::process(std::span<float>& left_in,
       deque_out_R.pop_front();
     }
   } else {
-    uint offset = left_out.size() - deque_out_L.size();
+    const uint offset = left_out.size() - deque_out_L.size();
 
     if (offset != latency_n_frames) {
       latency_n_frames = offset;
@@ -172,7 +172,7 @@ void EchoCanceller::process(std::span<float>& left_in,
   apply_gain(left_out, right_out, output_gain);
 
   if (notify_latency) {
-    float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
     util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
 
@@ -225,7 +225,7 @@ void EchoCanceller::init_speex() {
   filtered_L.resize(blocksize);
   filtered_R.resize(blocksize);
 
-  uint filter_length = 0.001F * filter_length_ms * rate;
+  const uint filter_length = 0.001F * filter_length_ms * rate;
 
   util::debug(log_tag + name + " filter length: " + std::to_string(filter_length));
 

--- a/src/echo_canceller_ui.cpp
+++ b/src/echo_canceller_ui.cpp
@@ -55,7 +55,7 @@ EchoCancellerUi::~EchoCancellerUi() {
 auto EchoCancellerUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> EchoCancellerUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/echo_canceller.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<EchoCancellerUi>(
+  auto* const ui = Gtk::Builder::get_widget_derived<EchoCancellerUi>(
       builder, "top_box", "com.github.wwmm.easyeffects.echocanceller", schema_path + "echocanceller/");
 
   stack->add(*ui, plugin_name::echo_canceller);

--- a/src/effects_base.cpp
+++ b/src/effects_base.cpp
@@ -125,73 +125,73 @@ EffectsBase::EffectsBase(std::string tag, const std::string& schema, PipeManager
     plugins_latency[key] = 0.0F;
   }
 
-  compressor->latency.connect([=, this](const float& v) {
+  compressor->latency.connect([=, this](const auto& v) {
     plugins_latency[compressor->name] = v;
 
     broadcast_pipeline_latency();
   });
 
-  convolver->latency.connect([=, this](const float& v) {
+  convolver->latency.connect([=, this](const auto& v) {
     plugins_latency[convolver->name] = v;
 
     broadcast_pipeline_latency();
   });
 
-  crystalizer->latency.connect([=, this](const float& v) {
+  crystalizer->latency.connect([=, this](const auto& v) {
     plugins_latency[crystalizer->name] = v;
 
     broadcast_pipeline_latency();
   });
 
-  delay->latency.connect([=, this](const float& v) {
+  delay->latency.connect([=, this](const auto& v) {
     plugins_latency[delay->name] = v;
 
     broadcast_pipeline_latency();
   });
 
-  echo_canceller->latency.connect([=, this](const float& v) {
+  echo_canceller->latency.connect([=, this](const auto& v) {
     plugins_latency[echo_canceller->name] = v;
 
     broadcast_pipeline_latency();
   });
 
-  equalizer->latency.connect([=, this](const float& v) {
+  equalizer->latency.connect([=, this](const auto& v) {
     plugins_latency[equalizer->name] = v;
 
     broadcast_pipeline_latency();
   });
 
-  loudness->latency.connect([=, this](const float& v) {
+  loudness->latency.connect([=, this](const auto& v) {
     plugins_latency[loudness->name] = v;
 
     broadcast_pipeline_latency();
   });
 
-  limiter->latency.connect([=, this](const float& v) {
+  limiter->latency.connect([=, this](const auto& v) {
     plugins_latency[limiter->name] = v;
 
     broadcast_pipeline_latency();
   });
 
-  maximizer->latency.connect([=, this](const float& v) {
+  maximizer->latency.connect([=, this](const auto& v) {
     plugins_latency[maximizer->name] = v;
 
     broadcast_pipeline_latency();
   });
 
-  multiband_compressor->latency.connect([=, this](const float& v) {
+  multiband_compressor->latency.connect([=, this](const auto& v) {
     plugins_latency[multiband_compressor->name] = v;
 
     broadcast_pipeline_latency();
   });
 
-  pitch->latency.connect([=, this](const float& v) {
+  pitch->latency.connect([=, this](const auto& v) {
     plugins_latency[pitch->name] = v;
 
     broadcast_pipeline_latency();
   });
 
-  rnnoise->latency.connect([=, this](const float& v) {
+  rnnoise->latency.connect([=, this](const auto& v) {
     plugins_latency[rnnoise->name] = v;
 
     broadcast_pipeline_latency();
@@ -227,7 +227,7 @@ auto EffectsBase::get_pipeline_latency() -> float {
 }
 
 void EffectsBase::broadcast_pipeline_latency() {
-  float latency_value = get_pipeline_latency();
+  const auto& latency_value = get_pipeline_latency();
 
   util::debug(log_tag + "pipeline latency: " + std::to_string(latency_value) + " ms");
 

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -83,11 +83,9 @@ EffectsBaseUi::EffectsBaseUi(const Glib::RefPtr<Gtk::Builder>& builder,
   // signals connections
 
   stack_top->connect_property_changed("visible-child", [=, this]() {
-    if (const auto& name = stack_top->get_visible_child_name(); name == "page_players") {
-      menubutton_blocklist->set_visible(true);
-    } else {
-      menubutton_blocklist->set_visible(false);
-    }
+    const auto& name = stack_top->get_visible_child_name();
+
+    menubutton_blocklist->set_visible((name == "page_players") ? true : false);
   });
 
   toggle_players->signal_toggled().connect([&, this]() {
@@ -139,13 +137,13 @@ EffectsBaseUi::EffectsBaseUi(const Glib::RefPtr<Gtk::Builder>& builder,
       false);
 
   popover_blocklist->signal_show().connect([=, this]() {
-    int height = static_cast<int>(0.5F * static_cast<float>(stack_top->get_allocated_height()));
+    const int height = static_cast<int>(0.5F * static_cast<float>(stack_top->get_allocated_height()));
 
     blocklist_scrolled_window->set_max_content_height(height);
   });
 
   popover_plugins->signal_show().connect([=, this]() {
-    int height = static_cast<int>(0.5F * static_cast<float>(stack_top->get_allocated_height()));
+    const int height = static_cast<int>(0.5F * static_cast<float>(stack_top->get_allocated_height()));
 
     scrolled_window_plugins->set_max_content_height(height);
   });
@@ -178,23 +176,15 @@ EffectsBaseUi::EffectsBaseUi(const Glib::RefPtr<Gtk::Builder>& builder,
   effects_base->spectrum->post_messages = true;
   effects_base->stereo_tools->post_messages = true;
 
-  connections.emplace_back(effects_base->pipeline_latency.connect([=, this](const float& v) {
-    std::ostringstream str;
+  connections.emplace_back(effects_base->pipeline_latency.connect([=, this](const auto& v) {
+    const auto& lv = Glib::ustring::format(std::setprecision(1), std::fixed, v);
 
-    str.precision(1);
-
-    str << std::fixed << v << " ms" << std::string(5, ' ');
-
-    latency_status->set_text(str.str());
+    latency_status->set_text(lv + " ms" + Glib::ustring(5, ' '));
   }));
 
-  std::ostringstream str;
+  const auto& lv = Glib::ustring::format(std::setprecision(1), std::fixed, effects_base->get_pipeline_latency());
 
-  str.precision(1);
-
-  str << std::fixed << effects_base->get_pipeline_latency() << " ms" << std::string(5, ' ');
-
-  latency_status->set_text(str.str());
+  latency_status->set_text(lv + " ms" + Glib::ustring(5, ' '));
 }
 
 EffectsBaseUi::~EffectsBaseUi() {
@@ -269,7 +259,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
   // removing plugins that are not in the list
 
   for (auto* child = stack_plugins->get_first_child(); child != nullptr;) {
-    bool found = false;
+    auto found = false;
 
     for (const auto& name : settings->get_string_array("plugins")) {
       if (name == stack_plugins->get_page(*child)->get_name()) {
@@ -291,7 +281,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
   // Adding to the stack the plugins in the list that are not there yet
 
   for (const auto& name : settings->get_string_array("plugins")) {
-    bool found = false;
+    auto found = false;
 
     for (auto* child = stack_plugins->get_first_child(); child != nullptr; child = child->get_next_sibling()) {
       if (name == stack_plugins->get_page(*child)->get_name()) {
@@ -306,7 +296,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
     }
 
     if (name == plugin_name::autogain) {
-      auto* autogain_ui = AutoGainUi::add_to_stack(stack_plugins, path);
+      auto* const autogain_ui = AutoGainUi::add_to_stack(stack_plugins, path);
 
       autogain_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->autogain->bypass = autogain_ui->bypass->get_active(); });
@@ -317,7 +307,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->autogain->bypass = false;
     } else if (name == plugin_name::bass_enhancer) {
-      auto* bass_enhancer_ui = BassEnhancerUi::add_to_stack(stack_plugins, path);
+      auto* const bass_enhancer_ui = BassEnhancerUi::add_to_stack(stack_plugins, path);
 
       bass_enhancer_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->bass_enhancer->bypass = bass_enhancer_ui->bypass->get_active(); });
@@ -331,7 +321,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->bass_enhancer->bypass = false;
     } else if (name == plugin_name::bass_loudness) {
-      auto* bass_loudness_ui = BassLoudnessUi::add_to_stack(stack_plugins, path);
+      auto* const bass_loudness_ui = BassLoudnessUi::add_to_stack(stack_plugins, path);
 
       bass_loudness_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->bass_loudness->bypass = bass_loudness_ui->bypass->get_active(); });
@@ -343,7 +333,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->bass_loudness->bypass = false;
     } else if (name == plugin_name::compressor) {
-      auto* compressor_ui = CompressorUi::add_to_stack(stack_plugins, path);
+      auto* const compressor_ui = CompressorUi::add_to_stack(stack_plugins, path);
 
       compressor_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->compressor->bypass = compressor_ui->bypass->get_active(); });
@@ -359,7 +349,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->compressor->bypass = false;
     } else if (name == plugin_name::convolver) {
-      auto* convolver_ui = ConvolverUi::add_to_stack(stack_plugins, path);
+      auto* const convolver_ui = ConvolverUi::add_to_stack(stack_plugins, path);
 
       convolver_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->convolver->bypass = convolver_ui->bypass->get_active(); });
@@ -371,7 +361,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->convolver->bypass = false;
     } else if (name == plugin_name::crossfeed) {
-      auto* crossfeed_ui = CrossfeedUi::add_to_stack(stack_plugins, path);
+      auto* const crossfeed_ui = CrossfeedUi::add_to_stack(stack_plugins, path);
 
       crossfeed_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->crossfeed->bypass = crossfeed_ui->bypass->get_active(); });
@@ -381,7 +371,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->crossfeed->bypass = false;
     } else if (name == plugin_name::crystalizer) {
-      auto* crystalizer_ui = CrystalizerUi::add_to_stack(stack_plugins, path);
+      auto* const crystalizer_ui = CrystalizerUi::add_to_stack(stack_plugins, path);
 
       crystalizer_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->crystalizer->bypass = crystalizer_ui->bypass->get_active(); });
@@ -393,7 +383,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->crystalizer->bypass = false;
     } else if (name == plugin_name::deesser) {
-      auto* deesser_ui = DeesserUi::add_to_stack(stack_plugins, path);
+      auto* const deesser_ui = DeesserUi::add_to_stack(stack_plugins, path);
 
       deesser_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->deesser->bypass = deesser_ui->bypass->get_active(); });
@@ -405,7 +395,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->deesser->bypass = false;
     } else if (name == plugin_name::delay) {
-      auto* delay_ui = DelayUi::add_to_stack(stack_plugins, path);
+      auto* const delay_ui = DelayUi::add_to_stack(stack_plugins, path);
 
       delay_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->delay->bypass = delay_ui->bypass->get_active(); });
@@ -415,7 +405,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->delay->bypass = false;
     } else if (name == plugin_name::echo_canceller) {
-      auto* echo_canceller_ui = EchoCancellerUi::add_to_stack(stack_plugins, path);
+      auto* const echo_canceller_ui = EchoCancellerUi::add_to_stack(stack_plugins, path);
 
       echo_canceller_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->echo_canceller->bypass = echo_canceller_ui->bypass->get_active(); });
@@ -427,7 +417,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->echo_canceller->bypass = false;
     } else if (name == plugin_name::equalizer) {
-      auto* equalizer_ui = EqualizerUi::add_to_stack(stack_plugins, path);
+      auto* const equalizer_ui = EqualizerUi::add_to_stack(stack_plugins, path);
 
       equalizer_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->equalizer->bypass = equalizer_ui->bypass->get_active(); });
@@ -439,7 +429,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->equalizer->bypass = false;
     } else if (name == plugin_name::exciter) {
-      auto* exciter_ui = ExciterUi::add_to_stack(stack_plugins, path);
+      auto* const exciter_ui = ExciterUi::add_to_stack(stack_plugins, path);
 
       exciter_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->exciter->bypass = exciter_ui->bypass->get_active(); });
@@ -450,7 +440,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->exciter->bypass = false;
     } else if (name == plugin_name::filter) {
-      auto* filter_ui = FilterUi::add_to_stack(stack_plugins, path);
+      auto* const filter_ui = FilterUi::add_to_stack(stack_plugins, path);
 
       filter_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->filter->bypass = filter_ui->bypass->get_active(); });
@@ -460,7 +450,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->filter->bypass = false;
     } else if (name == plugin_name::gate) {
-      auto* gate_ui = GateUi::add_to_stack(stack_plugins, path);
+      auto* const gate_ui = GateUi::add_to_stack(stack_plugins, path);
 
       gate_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->gate->bypass = gate_ui->bypass->get_active(); });
@@ -471,7 +461,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->gate->bypass = false;
     } else if (name == plugin_name::limiter) {
-      auto* limiter_ui = LimiterUi::add_to_stack(stack_plugins, path);
+      auto* const limiter_ui = LimiterUi::add_to_stack(stack_plugins, path);
 
       limiter_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->limiter->bypass = limiter_ui->bypass->get_active(); });
@@ -487,7 +477,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->limiter->bypass = false;
     } else if (name == plugin_name::loudness) {
-      auto* loudness_ui = LoudnessUi::add_to_stack(stack_plugins, path);
+      auto* const loudness_ui = LoudnessUi::add_to_stack(stack_plugins, path);
 
       loudness_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->loudness->bypass = loudness_ui->bypass->get_active(); });
@@ -497,7 +487,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->loudness->bypass = false;
     } else if (name == plugin_name::maximizer) {
-      auto* maximizer_ui = MaximizerUi::add_to_stack(stack_plugins, path);
+      auto* const maximizer_ui = MaximizerUi::add_to_stack(stack_plugins, path);
 
       maximizer_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->maximizer->bypass = maximizer_ui->bypass->get_active(); });
@@ -508,7 +498,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->maximizer->bypass = false;
     } else if (name == plugin_name::multiband_compressor) {
-      auto* multiband_compressor_ui = MultibandCompressorUi::add_to_stack(stack_plugins, path);
+      auto* const multiband_compressor_ui = MultibandCompressorUi::add_to_stack(stack_plugins, path);
 
       multiband_compressor_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->multiband_compressor->bypass = multiband_compressor_ui->bypass->get_active(); });
@@ -520,19 +510,16 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->multiband_compressor->frequency_range.connect(
           sigc::mem_fun(*multiband_compressor_ui, &MultibandCompressorUi::on_new_frequency_range));
-
       effects_base->multiband_compressor->envelope.connect(
           sigc::mem_fun(*multiband_compressor_ui, &MultibandCompressorUi::on_new_envelope));
-
       effects_base->multiband_compressor->curve.connect(
           sigc::mem_fun(*multiband_compressor_ui, &MultibandCompressorUi::on_new_curve));
-
       effects_base->multiband_compressor->reduction.connect(
           sigc::mem_fun(*multiband_compressor_ui, &MultibandCompressorUi::on_new_reduction));
 
       effects_base->multiband_compressor->bypass = false;
     } else if (name == plugin_name::multiband_gate) {
-      auto* multiband_gate_ui = MultibandGateUi::add_to_stack(stack_plugins, path);
+      auto* const multiband_gate_ui = MultibandGateUi::add_to_stack(stack_plugins, path);
 
       multiband_gate_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->multiband_gate->bypass = multiband_gate_ui->bypass->get_active(); });
@@ -562,7 +549,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->multiband_gate->bypass = false;
     } else if (name == plugin_name::pitch) {
-      auto* pitch_ui = PitchUi::add_to_stack(stack_plugins, path);
+      auto* const pitch_ui = PitchUi::add_to_stack(stack_plugins, path);
 
       pitch_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->pitch->bypass = pitch_ui->bypass->get_active(); });
@@ -572,7 +559,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->pitch->bypass = false;
     } else if (name == plugin_name::reverb) {
-      auto* reverb_ui = ReverbUi::add_to_stack(stack_plugins, path);
+      auto* const reverb_ui = ReverbUi::add_to_stack(stack_plugins, path);
 
       reverb_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->reverb->bypass = reverb_ui->bypass->get_active(); });
@@ -582,7 +569,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->reverb->bypass = false;
     } else if (name == plugin_name::rnnoise) {
-      auto* rnnoise_ui = RNNoiseUi::add_to_stack(stack_plugins, path);
+      auto* const rnnoise_ui = RNNoiseUi::add_to_stack(stack_plugins, path);
 
       rnnoise_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->rnnoise->bypass = rnnoise_ui->bypass->get_active(); });
@@ -594,7 +581,7 @@ void EffectsBaseUi::add_plugins_to_stack_plugins() {
 
       effects_base->rnnoise->bypass = false;
     } else if (name == plugin_name::stereo_tools) {
-      auto* stereo_tools_ui = StereoToolsUi::add_to_stack(stack_plugins, path);
+      auto* const stereo_tools_ui = StereoToolsUi::add_to_stack(stack_plugins, path);
 
       stereo_tools_ui->bypass->signal_toggled().connect(
           [=, this]() { effects_base->stereo_tools->bypass = stereo_tools_ui->bypass->get_active(); });
@@ -625,7 +612,7 @@ void EffectsBaseUi::setup_listview_players() {
   factory->signal_setup().connect([=](const Glib::RefPtr<Gtk::ListItem>& list_item) {
     const auto& b = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/app_info.ui");
 
-    auto* top_box = b->get_widget<Gtk::Box>("top_box");
+    auto* const top_box = b->get_widget<Gtk::Box>("top_box");
 
     list_item->set_data("enable", b->get_widget<Gtk::Switch>("enable"));
     list_item->set_data("app_icon", b->get_widget<Gtk::Image>("app_icon"));
@@ -645,35 +632,31 @@ void EffectsBaseUi::setup_listview_players() {
   });
 
   factory->signal_bind().connect([=, this](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* app_name = static_cast<Gtk::Label*>(list_item->get_data("app_name"));
-    auto* media_name = static_cast<Gtk::Label*>(list_item->get_data("media_name"));
-    auto* format = static_cast<Gtk::Label*>(list_item->get_data("format"));
-    auto* rate = static_cast<Gtk::Label*>(list_item->get_data("rate"));
-    auto* channels = static_cast<Gtk::Label*>(list_item->get_data("channels"));
-    auto* latency = static_cast<Gtk::Label*>(list_item->get_data("latency"));
-    auto* state = static_cast<Gtk::Label*>(list_item->get_data("state"));
-    auto* enable = static_cast<Gtk::Switch*>(list_item->get_data("enable"));
-    auto* app_icon = static_cast<Gtk::Image*>(list_item->get_data("app_icon"));
-    auto* scale_volume = static_cast<Gtk::Scale*>(list_item->get_data("scale_volume"));
-    auto* volume = static_cast<Gtk::Adjustment*>(list_item->get_data("volume"));
-    auto* mute = static_cast<Gtk::ToggleButton*>(list_item->get_data("mute"));
-    auto* blocklist = static_cast<Gtk::CheckButton*>(list_item->get_data("blocklist"));
+    auto* const app_name = static_cast<Gtk::Label*>(list_item->get_data("app_name"));
+    auto* const media_name = static_cast<Gtk::Label*>(list_item->get_data("media_name"));
+    auto* const format = static_cast<Gtk::Label*>(list_item->get_data("format"));
+    auto* const rate = static_cast<Gtk::Label*>(list_item->get_data("rate"));
+    auto* const channels = static_cast<Gtk::Label*>(list_item->get_data("channels"));
+    auto* const latency = static_cast<Gtk::Label*>(list_item->get_data("latency"));
+    auto* const state = static_cast<Gtk::Label*>(list_item->get_data("state"));
+    auto* const enable = static_cast<Gtk::Switch*>(list_item->get_data("enable"));
+    auto* const app_icon = static_cast<Gtk::Image*>(list_item->get_data("app_icon"));
+    auto* const scale_volume = static_cast<Gtk::Scale*>(list_item->get_data("scale_volume"));
+    auto* const volume = static_cast<Gtk::Adjustment*>(list_item->get_data("volume"));
+    auto* const mute = static_cast<Gtk::ToggleButton*>(list_item->get_data("mute"));
+    auto* const blocklist = static_cast<Gtk::CheckButton*>(list_item->get_data("blocklist"));
 
     auto holder = std::dynamic_pointer_cast<NodeInfoHolder>(list_item->get_item());
 
     auto connection_enable = enable->signal_state_set().connect(
         [=, this](const auto& state) {
-          if (state) {
-            connect_stream(holder);
-          } else {
-            disconnect_stream(holder);
+          if (!app_is_blocklisted(holder->info.name)) {
+            (state) ? connect_stream(holder->info) : disconnect_stream(holder->info);
+
+            enabled_app_list.insert_or_assign(holder->info.id, state);
           }
 
-          holder->enabled = state;
-
-          if (!holder->app_blocklisted) {
-            holder->pre_blocklisted_state = state;
-          }
+          holder->info_updated.emit(holder->info);
 
           return false;
         },
@@ -683,7 +666,7 @@ void EffectsBaseUi::setup_listview_players() {
         [=]() { PipeManager::set_node_volume(holder->info, static_cast<float>(volume->get_value()) / 100.0F); });
 
     auto connection_mute = mute->signal_toggled().connect([=]() {
-      bool state = mute->get_active();
+      const auto& state = mute->get_active();
 
       if (state) {
         mute->property_icon_name().set_value("audio-volume-muted-symbolic");
@@ -698,143 +681,82 @@ void EffectsBaseUi::setup_listview_players() {
       PipeManager::set_node_mute(holder->info, state);
     });
 
-    auto connection_blocklist = blocklist->signal_toggled().connect([=, this]() {
+    auto connection_blocklist_checkbutton = blocklist->signal_toggled().connect([=, this]() {
       if (blocklist->get_active()) {
+        enabled_app_list.insert_or_assign(holder->info.id, enable->get_active());
+
         add_new_blocklist_entry(holder->info.name);
-
-        holder->app_blocklisted = true;
-
-        holder->pre_blocklisted_state = holder->enabled;
-
-        holder->enabled = false;
-
-        enable->set_active(false);
-
-        enable->set_sensitive(false);
       } else {
         remove_blocklist_entry(holder->info.name);
-
-        holder->app_blocklisted = false;
-
-        holder->enabled = holder->pre_blocklisted_state;
-
-        holder->pre_blocklisted_state = holder->enabled;
-
-        enable->set_sensitive(true);
-
-        enable->set_active(holder->enabled);
-
-        if (holder->enabled) {
-          // restore the state the app had before it was added to the blocklist
-
-          connect_stream(holder);
-        }
       }
+
+      // Stream connection/disconnection will be done in blocklist items signal changed
     });
 
     auto* pointer_connection_enable = new sigc::connection(connection_enable);
     auto* pointer_connection_volume = new sigc::connection(connection_volume);
     auto* pointer_connection_mute = new sigc::connection(connection_mute);
-    auto* pointer_connection_blocklist = new sigc::connection(connection_blocklist);
+    auto* pointer_connection_blocklist_checkbutton = new sigc::connection(connection_blocklist_checkbutton);
 
-    auto connection_info = holder->info_updated.connect([=, this](const NodeInfo& i) {
+    auto connection_info = holder->info_updated.connect([=, this](NodeInfo i) {
       app_name->set_text(i.name);
       media_name->set_text(i.media_name);
       format->set_text(i.format);
-      rate->set_text(std::to_string(i.rate) + " Hz");
-      channels->set_text(std::to_string(i.n_volume_channels));
-      latency->set_text(float_to_localized_string(i.latency, 2) + " s");
+      rate->set_text(Glib::ustring::format(i.rate) + " Hz");
+      channels->set_text(Glib::ustring::format(i.n_volume_channels));
+      latency->set_text(Glib::ustring::format(std::setprecision(2), std::fixed, i.latency) + " s");
+      state->set_text(node_state_to_ustring(i.state));
 
-      bool icon_available = false;
+      if (i.state != PW_NODE_STATE_CREATING) {
+        // For unknown reasons PW_NODE_STATE_CREATING causes icon name to be set even if it's empty,
+        // showing a broken image. Therefore we skip it's update on that state.
 
-      if (!i.app_icon_name.empty()) {
-        app_icon->set_from_icon_name(i.app_icon_name);
+        if (!i.app_icon_name.empty()) {
+          app_icon->set_from_icon_name(i.app_icon_name);
 
-        icon_available = true;
-      } else if (!i.media_icon_name.empty()) {
-        app_icon->set_from_icon_name(i.media_icon_name);
+          app_icon->set_visible(true);
+        } else if (!i.media_icon_name.empty()) {
+          app_icon->set_from_icon_name(i.media_icon_name);
 
-        icon_available = true;
-      } else {
-        auto str = i.name;
+          app_icon->set_visible(true);
+        } else {
+          app_icon->set_from_icon_name(Glib::ustring(i.name).lowercase());
 
-        // We need this to make Firefox icon visible =/
-
-        std::transform(str.begin(), str.end(), str.begin(), ::tolower);
-
-        app_icon->set_from_icon_name(str);
-
-        icon_available = true;
-      }
-
-      // Hide icon if not provided
-
-      app_icon->set_opacity((icon_available) ? 1.0 : 0.0);
-
-      switch (i.state) {
-        case PW_NODE_STATE_RUNNING:
-          state->set_text(_("running"));
-
-          break;
-        case PW_NODE_STATE_SUSPENDED:
-          state->set_text(_("suspended"));
-
-          break;
-        case PW_NODE_STATE_IDLE:
-          state->set_text(_("idle"));
-
-          break;
-        case PW_NODE_STATE_CREATING:
-          state->set_text(_("creating"));
-
-          break;
-        case PW_NODE_STATE_ERROR:
-          state->set_text(_("error"));
-
-          break;
-        default:
-          break;
+          app_icon->set_visible(true);
+        }
       }
 
       // initializing the switch
 
       pointer_connection_enable->block();
 
-      bool is_enabled = false;
+      const auto& is_enabled = app_is_enabled(holder->info);
+      const auto& is_blocklisted = app_is_blocklisted(holder->info.name);
 
-      if (holder->info.media_class == "Stream/Output/Audio") {
-        for (const auto& link : pm->list_links) {
-          if (link.output_node_id == holder->info.id && link.input_node_id == pm->pe_sink_node.id) {
-            is_enabled = true;
-
-            break;
-          }
-        }
-      } else if (holder->info.media_class == "Stream/Input/Audio") {
-        for (const auto& link : pm->list_links) {
-          if (link.output_node_id == pm->pe_source_node.id && link.input_node_id == holder->info.id) {
-            is_enabled = true;
-
-            break;
-          }
-        }
-      }
-
-      holder->app_blocklisted = app_is_blocklisted(holder->info.name);
-      holder->enabled = !holder->app_blocklisted && is_enabled;
-
-      enable->set_active(holder->enabled);
-      enable->set_sensitive(!holder->app_blocklisted);
+      enable->set_sensitive(is_enabled || !is_blocklisted);
+      enable->set_active(is_enabled);
 
       pointer_connection_enable->unblock();
 
+      // save app enabled state only the first time when is not preset in the map
+
+      enabled_app_list.try_emplace(holder->info.id, is_enabled);
+
       // initializing the volume slide
 
-      pointer_connection_volume->block();
+      if (i.state != PW_NODE_STATE_CREATING) {
+        // Volume can't be set on PW_NODE_STATE_CREATING, so we leave it hidden on this state
 
-      volume->set_value(100 * holder->info.volume);
+        pointer_connection_volume->block();
 
-      pointer_connection_volume->unblock();
+        scale_volume->set_visible(true);
+
+        scale_volume->set_sensitive(true);
+
+        volume->set_value(100 * holder->info.volume);
+
+        pointer_connection_volume->unblock();
+      }
 
       // initializing the mute button
 
@@ -856,14 +778,16 @@ void EffectsBaseUi::setup_listview_players() {
 
       // initializing the blocklist checkbutton
 
-      pointer_connection_blocklist->block();
+      pointer_connection_blocklist_checkbutton->block();
 
-      blocklist->set_active(holder->app_blocklisted);
+      blocklist->set_active(is_blocklisted);
 
-      pointer_connection_blocklist->unblock();
+      pointer_connection_blocklist_checkbutton->unblock();
     });
 
-    scale_volume->set_format_value_func([=](double v) { return std::to_string(static_cast<int>(v)) + " %"; });
+    scale_volume->set_format_value_func([=](const auto& v) {
+      return Glib::ustring::format(static_cast<int>(v)) + " %";
+    });
 
     holder->info_updated.emit(holder->info);
 
@@ -873,7 +797,7 @@ void EffectsBaseUi::setup_listview_players() {
 
     list_item->set_data("connection_mute", pointer_connection_mute, Glib::destroy_notify_delete<sigc::connection>);
 
-    list_item->set_data("connection_blocklist", pointer_connection_blocklist,
+    list_item->set_data("connection_blocklist_checkbutton", pointer_connection_blocklist_checkbutton,
                         Glib::destroy_notify_delete<sigc::connection>);
 
     list_item->set_data("connection_info", new sigc::connection(connection_info),
@@ -881,8 +805,12 @@ void EffectsBaseUi::setup_listview_players() {
   });
 
   factory->signal_unbind().connect([=](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    for (const auto* conn :
-         {"connection_enable", "connection_volume", "connection_mute", "connection_blocklist", "connection_info"}) {
+    const auto& connections_list = {
+      "connection_enable", "connection_volume", "connection_mute",
+      "connection_blocklist_checkbutton", "connection_info"
+    };
+
+    for (const auto* conn : connections_list) {
       if (auto* connection = static_cast<sigc::connection*>(list_item->get_data(conn))) {
         connection->disconnect();
 
@@ -892,19 +820,19 @@ void EffectsBaseUi::setup_listview_players() {
   });
 }
 
-void EffectsBaseUi::connect_stream(const std::shared_ptr<NodeInfoHolder>& holder) {
-  if (holder->info.media_class == "Stream/Output/Audio") {
-    pm->connect_stream_output(holder->info);
-  } else if (holder->info.media_class == "Stream/Input/Audio") {
-    pm->connect_stream_input(holder->info);
+void EffectsBaseUi::connect_stream(const NodeInfo& node_info) {
+  if (node_info.media_class == "Stream/Output/Audio") {
+    pm->connect_stream_output(node_info);
+  } else if (node_info.media_class == "Stream/Input/Audio") {
+    pm->connect_stream_input(node_info);
   }
 }
 
-void EffectsBaseUi::disconnect_stream(const std::shared_ptr<NodeInfoHolder>& holder) {
-  if (holder->info.media_class == "Stream/Output/Audio") {
-    pm->disconnect_stream_output(holder->info);
-  } else if (holder->info.media_class == "Stream/Input/Audio") {
-    pm->disconnect_stream_input(holder->info);
+void EffectsBaseUi::disconnect_stream(const NodeInfo& node_info) {
+  if (node_info.media_class == "Stream/Output/Audio") {
+    pm->disconnect_stream_output(node_info);
+  } else if (node_info.media_class == "Stream/Input/Audio") {
+    pm->disconnect_stream_input(node_info);
   }
 }
 
@@ -922,7 +850,11 @@ void EffectsBaseUi::setup_listview_blocklist() {
   });
 
   blocklist->signal_items_changed().connect([=, this](const guint& position, const guint& removed, const guint& added) {
+    util::debug("blocklist->signal_items_changed");
+
     if (removed > 0U) {
+      // Some items removed from the blocklist, so the listview_players might show an item hidden before
+
       players_model->remove_all();
 
       listview_players->set_model(nullptr);
@@ -933,14 +865,44 @@ void EffectsBaseUi::setup_listview_blocklist() {
 
       listview_players->set_model(Gtk::NoSelection::create(players_model));
     }
+
+    // Updating the enabled state of items added/removed to/from blocklist
+
+    for (guint n = 0U; n < all_players_model->get_n_items(); n++) {
+      auto holder = std::dynamic_pointer_cast<NodeInfoHolder>(all_players_model->get_item(n));
+
+      if (app_is_blocklisted(holder->info.name)) {
+        if (app_is_enabled(holder->info)) {
+          disconnect_stream(holder->info);
+        }
+      } else if (!app_is_enabled(holder->info)) {
+        // Try to restore the previous enabled state, if needed
+
+        try {
+          if (enabled_app_list.at(holder->info.id)) {
+            connect_stream(holder->info);
+          }
+        } catch (...) {
+          connect_stream(holder->info);
+
+          util::warning("Can't retrieve enabled state of node " + std::to_string(holder->info.id));
+
+          enabled_app_list.insert_or_assign(holder->info.id, true);
+        }
+      }
+
+      // enabled switch state will be updated in holder info_updated signal handler
+
+      holder->info_updated.emit(holder->info);
+    }
   });
 
   // sorter
 
-  auto sorter =
+  const auto& sorter =
       Gtk::StringSorter::create(Gtk::PropertyExpression<Glib::ustring>::create(GTK_TYPE_STRING_OBJECT, "string"));
 
-  auto sort_list_model = Gtk::SortListModel::create(blocklist, sorter);
+  const auto& sort_list_model = Gtk::SortListModel::create(blocklist, sorter);
 
   // setting the listview model and factory
 
@@ -953,9 +915,9 @@ void EffectsBaseUi::setup_listview_blocklist() {
   // setting the factory callbacks
 
   factory->signal_setup().connect([=](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* box = Gtk::make_managed<Gtk::Box>();
-    auto* label = Gtk::make_managed<Gtk::Label>();
-    auto* btn = Gtk::make_managed<Gtk::Button>();
+    auto* const box = Gtk::make_managed<Gtk::Box>();
+    auto* const label = Gtk::make_managed<Gtk::Label>();
+    auto* const btn = Gtk::make_managed<Gtk::Button>();
 
     label->set_hexpand(true);
     label->set_halign(Gtk::Align::START);
@@ -972,8 +934,8 @@ void EffectsBaseUi::setup_listview_blocklist() {
   });
 
   factory->signal_bind().connect([=, this](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* label = static_cast<Gtk::Label*>(list_item->get_data("name"));
-    auto* remove = static_cast<Gtk::Button*>(list_item->get_data("remove"));
+    auto* const label = static_cast<Gtk::Label*>(list_item->get_data("name"));
+    auto* const remove = static_cast<Gtk::Button*>(list_item->get_data("remove"));
 
     const auto& name = list_item->get_item()->get_property<Glib::ustring>("string");
 
@@ -1021,10 +983,10 @@ void EffectsBaseUi::setup_listview_plugins() {
 
   // sorter
 
-  auto sorter =
+  const auto& sorter =
       Gtk::StringSorter::create(Gtk::PropertyExpression<Glib::ustring>::create(GTK_TYPE_STRING_OBJECT, "string"));
 
-  auto sort_list_model = Gtk::SortListModel::create(filter_model, sorter);
+  const auto& sort_list_model = Gtk::SortListModel::create(filter_model, sorter);
 
   // setting the listview model and factory
 
@@ -1037,9 +999,9 @@ void EffectsBaseUi::setup_listview_plugins() {
   // setting the factory callbacks
 
   factory->signal_setup().connect([=](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* box = Gtk::make_managed<Gtk::Box>();
-    auto* label = Gtk::make_managed<Gtk::Label>();
-    auto* btn = Gtk::make_managed<Gtk::Button>();
+    auto* const box = Gtk::make_managed<Gtk::Box>();
+    auto* const label = Gtk::make_managed<Gtk::Label>();
+    auto* const btn = Gtk::make_managed<Gtk::Button>();
 
     label->set_hexpand(true);
     label->set_halign(Gtk::Align::START);
@@ -1056,16 +1018,15 @@ void EffectsBaseUi::setup_listview_plugins() {
   });
 
   factory->signal_bind().connect([=, this](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* label = static_cast<Gtk::Label*>(list_item->get_data("name"));
-    auto* add = static_cast<Gtk::Button*>(list_item->get_data("add"));
+    auto* const label = static_cast<Gtk::Label*>(list_item->get_data("name"));
+    auto* const add = static_cast<Gtk::Button*>(list_item->get_data("add"));
 
     const auto& translated_name = list_item->get_item()->get_property<Glib::ustring>("string");
-    const auto& translated_name_str = std::string(translated_name);
 
     Glib::ustring key_name;
 
     for (const auto& [key, value] : plugins_names) {
-      if (value == translated_name_str) {
+      if (translated_name == value.c_str()) {
         key_name = key;
       }
     }
@@ -1177,11 +1138,11 @@ void EffectsBaseUi::setup_listview_selected_plugins() {
   // setting the factory callbacks
 
   factory->signal_setup().connect([=, this](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* box = Gtk::make_managed<Gtk::Box>();
-    auto* label = Gtk::make_managed<Gtk::Label>();
-    auto* remove = Gtk::make_managed<Gtk::Button>();
-    auto* drag_handle = Gtk::make_managed<Gtk::Image>();
-    auto* plugin_icon = Gtk::make_managed<Gtk::Image>();
+    auto* const box = Gtk::make_managed<Gtk::Box>();
+    auto* const label = Gtk::make_managed<Gtk::Label>();
+    auto* const remove = Gtk::make_managed<Gtk::Button>();
+    auto* const drag_handle = Gtk::make_managed<Gtk::Image>();
+    auto* const plugin_icon = Gtk::make_managed<Gtk::Image>();
 
     label->set_hexpand(true);
     label->set_halign(Gtk::Align::START);
@@ -1227,9 +1188,9 @@ void EffectsBaseUi::setup_listview_selected_plugins() {
 
     drag_source->signal_prepare().connect(
         [=](const double& x, const double& y) {
-          auto* controller_widget = drag_source->get_widget();
+          auto* const controller_widget = drag_source->get_widget();
 
-          auto* item = controller_widget->get_ancestor(Gtk::Box::get_type());
+          auto* const item = controller_widget->get_ancestor(Gtk::Box::get_type());
 
           controller_widget->set_data("dragged-item", item);
 
@@ -1302,8 +1263,8 @@ void EffectsBaseUi::setup_listview_selected_plugins() {
   });
 
   factory->signal_bind().connect([=, this](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* label = static_cast<Gtk::Label*>(list_item->get_data("name"));
-    auto* remove = static_cast<Gtk::Button*>(list_item->get_data("remove"));
+    auto* const label = static_cast<Gtk::Label*>(list_item->get_data("name"));
+    auto* const remove = static_cast<Gtk::Button*>(list_item->get_data("remove"));
 
     const auto& name = list_item->get_item()->get_property<Glib::ustring>("string");
 
@@ -1350,6 +1311,8 @@ void EffectsBaseUi::on_app_added(NodeInfo node_info) {
   // Blocklist check
 
   if (app_is_blocklisted(node_info.name)) {
+    disconnect_stream(node_info);
+
     if (!settings->get_boolean("show-blocklisted-apps")) {
       return;
     }
@@ -1362,6 +1325,7 @@ void EffectsBaseUi::on_app_changed(NodeInfo node_info) {
   for (guint n = 0U; n < players_model->get_n_items(); n++) {
     if (auto* item = players_model->get_item(n).get(); item->info.id == node_info.id) {
       item->info = node_info;
+
       item->info_updated.emit(node_info);
 
       break;
@@ -1388,16 +1352,18 @@ void EffectsBaseUi::on_app_removed(NodeInfo node_info) {
 }
 
 void EffectsBaseUi::on_new_output_level_db(const float& left, const float& right) {
-  global_output_level_left->set_text(level_to_localized_string_showpos(left, 0));
+  global_output_level_left->set_text(((left > 0.0) ? "+" : "") +
+      Glib::ustring::format(std::setprecision(0), std::fixed, left));
 
-  global_output_level_right->set_text(level_to_localized_string_showpos(right, 0));
+  global_output_level_right->set_text(((right > 0.0) ? "+" : "") +
+      Glib::ustring::format(std::setprecision(0), std::fixed, right));
 
   // saturation icon notification
 
   saturation_icon->set_opacity((left > 0.0 || right > 0.0) ? 1.0 : 0.0);
 }
 
-auto EffectsBaseUi::node_state_to_string(const pw_node_state& state) -> std::string {
+auto EffectsBaseUi::node_state_to_ustring(const pw_node_state& state) -> Glib::ustring {
   switch (state) {
     case PW_NODE_STATE_RUNNING:
       return _("running");
@@ -1410,22 +1376,30 @@ auto EffectsBaseUi::node_state_to_string(const pw_node_state& state) -> std::str
     case PW_NODE_STATE_ERROR:
       return _("error");
     default:
-      return "";
+      return _("unknown");
   }
 }
 
-auto EffectsBaseUi::float_to_localized_string(const float& value, const int& places) -> std::string {
-  std::ostringstream msg;
+auto EffectsBaseUi::app_is_enabled(const NodeInfo& node_info) -> bool {
+  if (node_info.media_class == "Stream/Output/Audio") {
+    for (const auto& link : pm->list_links) {
+      if (link.output_node_id == node_info.id && link.input_node_id == pm->pe_sink_node.id) {
+        return true;
+      }
+    }
+  } else if (node_info.media_class == "Stream/Input/Audio") {
+    for (const auto& link : pm->list_links) {
+      if (link.output_node_id == pm->pe_source_node.id && link.input_node_id == node_info.id) {
+        return true;
+      }
+    }
+  }
 
-  msg.precision(places);
-
-  msg << std::fixed << value;
-
-  return msg.str();
+  return false;
 }
 
 auto EffectsBaseUi::app_is_blocklisted(const Glib::ustring& name) -> bool {
-  std::vector<Glib::ustring> bl = settings->get_string_array("blocklist");
+  const auto& bl = settings->get_string_array("blocklist");
 
   return std::ranges::find(bl, name) != bl.end();
 }
@@ -1435,7 +1409,7 @@ auto EffectsBaseUi::add_new_blocklist_entry(const Glib::ustring& name) -> bool {
     return false;
   }
 
-  std::vector<Glib::ustring> bl = settings->get_string_array("blocklist");
+  auto bl = settings->get_string_array("blocklist");
 
   if (std::any_of(bl.cbegin(), bl.cend(), [&](const auto& str) { return str == name; })) {
     util::debug("blocklist_settings_ui: entry already present in the list");
@@ -1453,7 +1427,7 @@ auto EffectsBaseUi::add_new_blocklist_entry(const Glib::ustring& name) -> bool {
 }
 
 void EffectsBaseUi::remove_blocklist_entry(const Glib::ustring& name) {
-  std::vector<Glib::ustring> bl = settings->get_string_array("blocklist");
+  auto bl = settings->get_string_array("blocklist");
 
   bl.erase(std::remove_if(bl.begin(), bl.end(), [=](const auto& a) { return a == name; }), bl.end());
 

--- a/src/equalizer.cpp
+++ b/src/equalizer.cpp
@@ -55,15 +55,15 @@ Equalizer::Equalizer(const std::string& tag,
     const uint& nbands = settings->get_int(key);
 
     for (uint n = 0U; n < max_bands; n++) {
-      const auto& nstr = std::to_string(n);
+      const auto& bandn = "band" + std::to_string(n);
 
       if (n < nbands) {
-        settings_left->set_enum("band" + nstr + "-type", 1);
-        settings_right->set_enum("band" + nstr + "-type", 1);
+        settings_left->set_enum(bandn + "-type", 1);
+        settings_right->set_enum(bandn + "-type", 1);
       } else {
         // turn off unused bands
-        settings_left->set_enum("band" + nstr + "-type", 0);
-        settings_right->set_enum("band" + nstr + "-type", 0);
+        settings_left->set_enum(bandn + "-type", 0);
+        settings_right->set_enum(bandn + "-type", 0);
       }
     }
   });
@@ -74,23 +74,23 @@ Equalizer::Equalizer(const std::string& tag,
     }
 
     for (uint n = 0U; n < max_bands; n++) {
-      const auto& nstr = std::to_string(n);
+      const auto& bandn = "band" + std::to_string(n);
 
-      settings_right->set_enum("band" + nstr + "-type", settings_left->get_enum("band" + nstr + "-type"));
+      settings_right->set_enum(bandn + "-type", settings_left->get_enum(bandn + "-type"));
 
-      settings_right->set_enum("band" + nstr + "-mode", settings_left->get_enum("band" + nstr + "-mode"));
+      settings_right->set_enum(bandn + "-mode", settings_left->get_enum(bandn + "-mode"));
 
-      settings_right->set_enum("band" + nstr + "-slope", settings_left->get_enum("band" + nstr + "-slope"));
+      settings_right->set_enum(bandn + "-slope", settings_left->get_enum(bandn + "-slope"));
 
-      settings_right->set_boolean("band" + nstr + "-solo", settings_left->get_boolean("band" + nstr + "-solo"));
+      settings_right->set_boolean(bandn + "-solo", settings_left->get_boolean(bandn + "-solo"));
 
-      settings_right->set_boolean("band" + nstr + "-mute", settings_left->get_boolean("band" + nstr + "-mute"));
+      settings_right->set_boolean(bandn + "-mute", settings_left->get_boolean(bandn + "-mute"));
 
-      settings_right->set_double("band" + nstr + "-frequency", settings_left->get_double("band" + nstr + "-frequency"));
+      settings_right->set_double(bandn + "-frequency", settings_left->get_double(bandn + "-frequency"));
 
-      settings_right->set_double("band" + nstr + "-gain", settings_left->get_double("band" + nstr + "-gain"));
+      settings_right->set_double(bandn + "-gain", settings_left->get_double(bandn + "-gain"));
 
-      settings_right->set_double("band" + nstr + "-q", settings_left->get_double("band" + nstr + "-q"));
+      settings_right->set_double(bandn + "-q", settings_left->get_double(bandn + "-q"));
     }
   });
 }
@@ -134,12 +134,12 @@ void Equalizer::process(std::span<float>& left_in,
     This plugin gives the latency in number of samples
   */
 
-  uint lv = static_cast<uint>(lv2_wrapper->get_control_port_value("out_latency"));
+  const auto& lv = static_cast<uint>(lv2_wrapper->get_control_port_value("out_latency"));
 
   if (latency_n_frames != lv) {
     latency_n_frames = lv;
 
-    float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
     util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
 

--- a/src/equalizer_preset.cpp
+++ b/src/equalizer_preset.cpp
@@ -18,7 +18,6 @@
  */
 
 #include "equalizer_preset.hpp"
-#include "util.hpp"
 
 EqualizerPreset::EqualizerPreset()
     : input_settings_left(Gio::Settings::create("com.github.wwmm.easyeffects.equalizer.channel",
@@ -65,23 +64,23 @@ void EqualizerPreset::save_channel(nlohmann::json& json,
                                    const Glib::RefPtr<Gio::Settings>& settings,
                                    const int& nbands) {
   for (int n = 0; n < nbands; n++) {
-    const auto& nstr = std::to_string(n);
+    const auto& bandn = "band" + std::to_string(n);
 
-    json["band" + nstr]["type"] = settings->get_string("band" + nstr + "-type").c_str();
+    json[bandn]["type"] = settings->get_string(bandn + "-type").c_str();
 
-    json["band" + nstr]["mode"] = settings->get_string("band" + nstr + "-mode").c_str();
+    json[bandn]["mode"] = settings->get_string(bandn + "-mode").c_str();
 
-    json["band" + nstr]["slope"] = settings->get_string("band" + nstr + "-slope").c_str();
+    json[bandn]["slope"] = settings->get_string(bandn + "-slope").c_str();
 
-    json["band" + nstr]["solo"] = settings->get_boolean("band" + nstr + "-solo");
+    json[bandn]["solo"] = settings->get_boolean(bandn + "-solo");
 
-    json["band" + nstr]["mute"] = settings->get_boolean("band" + nstr + "-mute");
+    json[bandn]["mute"] = settings->get_boolean(bandn + "-mute");
 
-    json["band" + nstr]["gain"] = settings->get_double("band" + nstr + "-gain");
+    json[bandn]["gain"] = settings->get_double(bandn + "-gain");
 
-    json["band" + nstr]["frequency"] = settings->get_double("band" + nstr + "-frequency");
+    json[bandn]["frequency"] = settings->get_double(bandn + "-frequency");
 
-    json["band" + nstr]["q"] = settings->get_double("band" + nstr + "-q");
+    json[bandn]["q"] = settings->get_double(bandn + "-q");
   }
 }
 
@@ -100,10 +99,10 @@ void EqualizerPreset::load(const nlohmann::json& json,
 
   const auto& nbands = settings->get_int("num-bands");
 
-  if (section == std::string("input")) {
+  if (section == "input") {
     load_channel(json.at(section).at("equalizer").at("left"), input_settings_left, nbands);
     load_channel(json.at(section).at("equalizer").at("right"), input_settings_right, nbands);
-  } else if (section == std::string("output")) {
+  } else if (section == "output") {
     load_channel(json.at(section).at("equalizer").at("left"), output_settings_left, nbands);
     load_channel(json.at(section).at("equalizer").at("right"), output_settings_right, nbands);
   }
@@ -113,23 +112,23 @@ void EqualizerPreset::load_channel(const nlohmann::json& json,
                                    const Glib::RefPtr<Gio::Settings>& settings,
                                    const int& nbands) {
   for (int n = 0; n < nbands; n++) {
-    const auto& nstr = std::to_string(n);
+    const auto& bandn = "band" + std::to_string(n);
 
-    update_string_key(json.at("band" + nstr), settings, "band" + nstr + "-type", "type");
+    update_string_key(json.at(bandn), settings, bandn + "-type", "type");
 
-    update_string_key(json.at("band" + nstr), settings, "band" + nstr + "-mode", "mode");
+    update_string_key(json.at(bandn), settings, bandn + "-mode", "mode");
 
-    update_string_key(json.at("band" + nstr), settings, "band" + nstr + "-slope", "slope");
+    update_string_key(json.at(bandn), settings, bandn + "-slope", "slope");
 
-    update_key<bool>(json.at("band" + nstr), settings, "band" + nstr + "-solo", "solo");
+    update_key<bool>(json.at(bandn), settings, bandn + "-solo", "solo");
 
-    update_key<bool>(json.at("band" + nstr), settings, "band" + nstr + "-mute", "mute");
+    update_key<bool>(json.at(bandn), settings, bandn + "-mute", "mute");
 
-    update_key<double>(json.at("band" + nstr), settings, "band" + nstr + "-gain", "gain");
+    update_key<double>(json.at(bandn), settings, bandn + "-gain", "gain");
 
-    update_key<double>(json.at("band" + nstr), settings, "band" + nstr + "-frequency",
+    update_key<double>(json.at(bandn), settings, bandn + "-frequency",
                        "frequency");
 
-    update_key<double>(json.at("band" + nstr), settings, "band" + nstr + "-q", "q");
+    update_key<double>(json.at(bandn), settings, bandn + "-q", "q");
   }
 }

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -24,23 +24,23 @@ namespace {
 auto bandtype_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "Off") == 0) {
+  if (g_strcmp0(v, "Off") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Bell") == 0) {
+  } else if (g_strcmp0(v, "Bell") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "Hi-pass") == 0) {
+  } else if (g_strcmp0(v, "Hi-pass") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "Hi-shelf") == 0) {
+  } else if (g_strcmp0(v, "Hi-shelf") == 0) {
     g_value_set_int(value, 3);
-  } else if (std::strcmp(v, "Lo-pass") == 0) {
+  } else if (g_strcmp0(v, "Lo-pass") == 0) {
     g_value_set_int(value, 4);
-  } else if (std::strcmp(v, "Lo-shelf") == 0) {
+  } else if (g_strcmp0(v, "Lo-shelf") == 0) {
     g_value_set_int(value, 5);
-  } else if (std::strcmp(v, "Notch") == 0) {
+  } else if (g_strcmp0(v, "Notch") == 0) {
     g_value_set_int(value, 6);
-  } else if (std::strcmp(v, "Resonance") == 0) {
+  } else if (g_strcmp0(v, "Resonance") == 0) {
     g_value_set_int(value, 7);
-  } else if (std::strcmp(v, "Allpass") == 0) {
+  } else if (g_strcmp0(v, "Allpass") == 0) {
     g_value_set_int(value, 8);
   }
 
@@ -84,13 +84,13 @@ auto int_to_bandtype_enum(const GValue* value, const GVariantType* expected_type
 auto mode_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "IIR") == 0) {
+  if (g_strcmp0(v, "IIR") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "FIR") == 0) {
+  } else if (g_strcmp0(v, "FIR") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "FFT") == 0) {
+  } else if (g_strcmp0(v, "FFT") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "SPM") == 0) {
+  } else if (g_strcmp0(v, "SPM") == 0) {
     g_value_set_int(value, 3);
   }
 
@@ -119,19 +119,19 @@ auto int_to_mode_enum(const GValue* value, const GVariantType* expected_type, gp
 auto bandmode_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "RLC (BT)") == 0) {
+  if (g_strcmp0(v, "RLC (BT)") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "RLC (MT)") == 0) {
+  } else if (g_strcmp0(v, "RLC (MT)") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "BWC (BT)") == 0) {
+  } else if (g_strcmp0(v, "BWC (BT)") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "BWC (MT)") == 0) {
+  } else if (g_strcmp0(v, "BWC (MT)") == 0) {
     g_value_set_int(value, 3);
-  } else if (std::strcmp(v, "LRX (BT)") == 0) {
+  } else if (g_strcmp0(v, "LRX (BT)") == 0) {
     g_value_set_int(value, 4);
-  } else if (std::strcmp(v, "LRX (MT)") == 0) {
+  } else if (g_strcmp0(v, "LRX (MT)") == 0) {
     g_value_set_int(value, 5);
-  } else if (std::strcmp(v, "APO (DR)") == 0) {
+  } else if (g_strcmp0(v, "APO (DR)") == 0) {
     g_value_set_int(value, 6);
   }
 
@@ -169,13 +169,13 @@ auto int_to_bandmode_enum(const GValue* value, const GVariantType* expected_type
 auto bandslope_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "x1") == 0) {
+  if (g_strcmp0(v, "x1") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "x2") == 0) {
+  } else if (g_strcmp0(v, "x2") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "x3") == 0) {
+  } else if (g_strcmp0(v, "x3") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "x4") == 0) {
+  } else if (g_strcmp0(v, "x4") == 0) {
     g_value_set_int(value, 3);
   }
 
@@ -294,7 +294,7 @@ EqualizerUi::~EqualizerUi() {
 auto EqualizerUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> EqualizerUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/equalizer.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<EqualizerUi>(
+  auto* const ui = Gtk::Builder::get_widget_derived<EqualizerUi>(
       builder, "top_box", "com.github.wwmm.easyeffects.equalizer", schema_path + "equalizer/",
       "com.github.wwmm.easyeffects.equalizer.channel", schema_path + "equalizer/leftchannel/",
       schema_path + "equalizer/rightchannel/");
@@ -319,7 +319,7 @@ void EqualizerUi::on_nbands_changed() {
 
   connections_bands.clear();
 
-  bool split = settings->get_boolean("split-channels");
+  const auto& split = settings->get_boolean("split-channels");
 
   const auto& nb = static_cast<int>(nbands->get_value());
 
@@ -335,7 +335,7 @@ void EqualizerUi::build_bands(Gtk::Box* bands_box,
                               const int& nbands,
                               const bool& split_mode) {
   for (int n = 0; n < nbands; n++) {
-    const auto& nstr = std::to_string(n);
+    const auto& bandn = "band" + std::to_string(n);
 
     const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/equalizer_band.ui");
 
@@ -397,10 +397,10 @@ void EqualizerUi::build_bands(Gtk::Box* bands_box,
       // split channels mode
 
       connections_bands.emplace_back(reset_frequency->signal_clicked().connect(
-          [=]() { cfg->reset(std::string("band" + nstr + "-frequency")); }));
+          [=]() { cfg->reset(bandn + "-frequency"); }));
 
       connections_bands.emplace_back(reset_quality->signal_clicked().connect(
-          [=]() { cfg->reset(std::string("band" + nstr + "-q")); }));
+          [=]() { cfg->reset(bandn + "-q"); }));
     } else {
       // unified mode
 
@@ -410,79 +410,76 @@ void EqualizerUi::build_bands(Gtk::Box* bands_box,
        */
 
       connections_bands.emplace_back(band_scale->signal_value_changed().connect([=, this]() {
-        settings_right->set_double(std::string("band" + nstr + "-gain"), band_scale->get_value());
+        settings_right->set_double(bandn + "-gain", band_scale->get_value());
       }));
 
       connections_bands.emplace_back(band_frequency->signal_value_changed().connect([=, this]() {
-        settings_right->set_double(std::string("band" + nstr + "-frequency"), band_frequency->get_value());
+        settings_right->set_double(bandn + "-frequency", band_frequency->get_value());
       }));
 
       connections_bands.emplace_back(band_quality->signal_value_changed().connect([=, this]() {
-        settings_right->set_double(std::string("band" + nstr + "-q"), band_quality->get_value());
+        settings_right->set_double(bandn + "-q", band_quality->get_value());
       }));
 
       connections_bands.emplace_back(band_type->signal_changed().connect([=, this]() {
-        settings_right->set_enum(std::string("band" + nstr + "-type"), band_type->get_active_row_number());
+        settings_right->set_enum(bandn + "-type", band_type->get_active_row_number());
       }));
 
       connections_bands.emplace_back(band_mode->signal_changed().connect([=, this]() {
-        settings_right->set_enum(std::string("band" + nstr + "-mode"), band_mode->get_active_row_number());
+        settings_right->set_enum(bandn + "-mode", band_mode->get_active_row_number());
       }));
 
       connections_bands.emplace_back(band_slope->signal_changed().connect([=, this]() {
-        settings_right->set_enum(std::string("band" + nstr + "-slope"),
-                                 band_slope->get_active_row_number());
+        settings_right->set_enum(bandn + "-slope", band_slope->get_active_row_number());
       }));
 
       connections_bands.emplace_back(band_solo->signal_toggled().connect([=, this]() {
-        settings_right->set_boolean(std::string("band" + nstr + "-solo"), band_solo->get_active());
+        settings_right->set_boolean(bandn + "-solo", band_solo->get_active());
       }));
 
       connections_bands.emplace_back(band_mute->signal_toggled().connect([=, this]() {
-        settings_right->set_boolean(std::string("band" + nstr + "-mute"), band_mute->get_active());
+        settings_right->set_boolean(bandn + "-mute", band_mute->get_active());
       }));
 
       // Left channel
 
       connections_bands.emplace_back(reset_frequency->signal_clicked().connect([=, this]() {
-        settings_left->reset(std::string("band" + nstr + "-frequency"));
+        settings_left->reset(bandn + "-frequency");
 
-        settings_right->reset(std::string("band" + nstr + "-frequency"));
+        settings_right->reset(bandn + "-frequency");
       }));
 
       connections_bands.emplace_back(reset_quality->signal_clicked().connect([=, this]() {
-        settings_left->reset(std::string("band" + nstr + "-q"));
+        settings_left->reset(bandn + "-q");
 
-        settings_right->reset(std::string("band" + nstr + "-q"));
+        settings_right->reset(bandn + "-q");
       }));
     }
 
     connections_bands.emplace_back(band_type->signal_changed().connect([=]() {
       // disable gain scale if type is "Off", "Hi-pass" or "Lo-pass"
 
-      if (const auto& row = band_type->get_active_row_number(); row == 0 || row == 2 || row == 4) {
-        band_scale->set_sensitive(false);
-      } else {
-        band_scale->set_sensitive(true);
-      }
+      const auto& row = band_type->get_active_row_number();
+
+      band_scale->set_sensitive((row == 0 || row == 2 || row == 4) ? false : true);
     }));
 
-    cfg->bind(std::string("band" + nstr + "-gain"), band_scale->get_adjustment().get(), "value");
-    cfg->bind(std::string("band" + nstr + "-frequency"), band_frequency->get_adjustment().get(), "value");
-    cfg->bind(std::string("band" + nstr + "-q"), band_quality->get_adjustment().get(), "value");
-    cfg->bind(std::string("band" + nstr + "-solo"), band_solo, "active");
-    cfg->bind(std::string("band" + nstr + "-mute"), band_mute, "active");
+    cfg->bind(bandn + "-gain", band_scale->get_adjustment().get(), "value");
+    cfg->bind(bandn + "-frequency", band_frequency->get_adjustment().get(), "value");
+    cfg->bind(bandn + "-q", band_quality->get_adjustment().get(), "value");
+    cfg->bind(bandn + "-solo", band_solo, "active");
+    cfg->bind(bandn + "-mute", band_mute, "active");
 
-    g_settings_bind_with_mapping(cfg->gobj(), std::string("band" + nstr + "-type").c_str(),
-                                 band_type->gobj(), "active", G_SETTINGS_BIND_DEFAULT, bandtype_enum_to_int,
+    g_settings_bind_with_mapping(cfg->gobj(), std::string(bandn + "-type").c_str(), band_type->gobj(),
+                                 "active", G_SETTINGS_BIND_DEFAULT, bandtype_enum_to_int,
                                  int_to_bandtype_enum, nullptr, nullptr);
 
-    g_settings_bind_with_mapping(cfg->gobj(), std::string("band" + nstr + "-mode").c_str(),
-                                 band_mode->gobj(), "active", G_SETTINGS_BIND_DEFAULT, bandmode_enum_to_int,
+    g_settings_bind_with_mapping(cfg->gobj(), std::string(bandn + "-mode").c_str(), band_mode->gobj(),
+                                 "active", G_SETTINGS_BIND_DEFAULT, bandmode_enum_to_int,
                                  int_to_bandmode_enum, nullptr, nullptr);
 
-    g_settings_bind_with_mapping(cfg->gobj(), std::string("band" + nstr + "-slope").c_str(),
-                                 band_slope->gobj(), "active", G_SETTINGS_BIND_DEFAULT, bandslope_enum_to_int,
+    g_settings_bind_with_mapping(cfg->gobj(), std::string(bandn + "-slope").c_str(), band_slope->gobj(),
+                                 "active", G_SETTINGS_BIND_DEFAULT, bandslope_enum_to_int,
                                  int_to_bandslope_enum, nullptr, nullptr);
 
     bands_box->append(*band_box);
@@ -493,47 +490,45 @@ void EqualizerUi::build_bands(Gtk::Box* bands_box,
 
 void EqualizerUi::on_flat_response() {
   for (int n = 0; n < max_bands; n++) {
-    const auto& nstr = std::to_string(n);
+    const auto& bandn = "band" + std::to_string(n);
 
     // left channel
 
-    settings_left->reset(std::string("band" + nstr + "-gain"));
+    settings_left->reset(bandn + "-gain");
 
     // right channel
 
-    settings_right->reset(std::string("band" + nstr + "-gain"));
+    settings_right->reset(bandn + "-gain");
   }
 }
 
 void EqualizerUi::on_calculate_frequencies() {
   const double min_freq = 20.0;
   const double max_freq = 20000.0;
-  double freq0 = 0.0;
+  double freq0 = min_freq;
   double freq1 = 0.0;
-  double step = 0.0;
 
   const auto& nbands = settings->get_int("num-bands");
 
   // code taken from gstreamer equalizer sources: gstiirequalizer.c
   // function: gst_iir_equalizer_compute_frequencies
 
-  step = pow(max_freq / min_freq, 1.0 / nbands);
-  freq0 = min_freq;
+  const double step = std::pow(max_freq / min_freq, 1.0 / static_cast<double>(nbands));
 
   auto config_band = [&](const auto& cfg, const auto& n, const auto& freq, const auto& q) {
-    const auto& nstr = std::to_string(n);
+    const auto& bandn = "band" + std::to_string(n);
 
-    cfg->set_double(std::string("band" + nstr + "-frequency"), freq);
+    cfg->set_double(bandn + "-frequency", freq);
 
-    cfg->set_double(std::string("band" + nstr + "-q"), q);
+    cfg->set_double(bandn + "-q", q);
   };
 
   for (int n = 0; n < nbands; n++) {
     freq1 = freq0 * step;
 
-    double freq = freq0 + 0.5 * (freq1 - freq0);
-    double width = freq1 - freq0;
-    double q = freq / width;
+    const double freq = freq0 + 0.5 * (freq1 - freq0);
+    const double width = freq1 - freq0;
+    const double q = freq / width;
 
     // std::cout << n << "\t" << freq << "\t" << width << std::endl;
 
@@ -556,29 +551,29 @@ void EqualizerUi::reset() {
   settings->reset("split-channels");
 
   for (int n = 0; n < max_bands; n++) {
-    const auto& nstr = std::to_string(n);
+    const auto& bandn = "band" + std::to_string(n);
 
     // left channel
 
-    settings_left->reset(std::string("band" + nstr + "-gain"));
-    settings_left->reset(std::string("band" + nstr + "-frequency"));
-    settings_left->reset(std::string("band" + nstr + "-q"));
-    settings_left->reset(std::string("band" + nstr + "-type"));
-    settings_left->reset(std::string("band" + nstr + "-mode"));
-    settings_left->reset(std::string("band" + nstr + "-slope"));
-    settings_left->reset(std::string("band" + nstr + "-solo"));
-    settings_left->reset(std::string("band" + nstr + "-mute"));
+    settings_left->reset(bandn + "-gain");
+    settings_left->reset(bandn + "-frequency");
+    settings_left->reset(bandn + "-q");
+    settings_left->reset(bandn + "-type");
+    settings_left->reset(bandn + "-mode");
+    settings_left->reset(bandn + "-slope");
+    settings_left->reset(bandn + "-solo");
+    settings_left->reset(bandn + "-mute");
 
     // right channel
 
-    settings_right->reset(std::string("band" + nstr + "-gain"));
-    settings_right->reset(std::string("band" + nstr + "-frequency"));
-    settings_right->reset(std::string("band" + nstr + "-q"));
-    settings_right->reset(std::string("band" + nstr + "-type"));
-    settings_right->reset(std::string("band" + nstr + "-mode"));
-    settings_right->reset(std::string("band" + nstr + "-slope"));
-    settings_right->reset(std::string("band" + nstr + "-solo"));
-    settings_right->reset(std::string("band" + nstr + "-mute"));
+    settings_right->reset(bandn + "-gain");
+    settings_right->reset(bandn + "-frequency");
+    settings_right->reset(bandn + "-q");
+    settings_right->reset(bandn + "-type");
+    settings_right->reset(bandn + "-mode");
+    settings_right->reset(bandn + "-slope");
+    settings_right->reset(bandn + "-solo");
+    settings_right->reset(bandn + "-mute");
   }
 }
 
@@ -711,7 +706,7 @@ void EqualizerUi::import_apo_preset(const std::string& file_path) {
     std::ifstream eq_file;
     std::vector<struct ImportedBand> bands;
 
-    eq_file.open(p.string());
+    eq_file.open(p.c_str());
 
     if (eq_file.is_open()) {
       std::string line;
@@ -734,38 +729,38 @@ void EqualizerUi::import_apo_preset(const std::string& file_path) {
     settings->set_int("num-bands", bands.size());
 
     for (int n = 0; n < max_bands; n++) {
-      const auto& nstr = std::to_string(n);
+      const auto& bandn = "band" + std::to_string(n);
 
       if (n < static_cast<int>(bands.size())) {
-        settings_left->set_string(std::string("band" + nstr + "-mode"), "APO (DR)");
+        settings_left->set_string(bandn + "-mode", "APO (DR)");
 
         if (!settings->get_boolean("split-channels")) {
-          settings_left->set_string(std::string("band" + nstr + "-type"), "Bell");
-          settings_left->set_double(std::string("band" + nstr + "-gain"), bands[n].gain);
-          settings_left->set_double(std::string("band" + nstr + "-frequency"), bands[n].freq);
-          settings_left->set_double(std::string("band" + nstr + "-q"), bands[n].quality_factor);
+          settings_left->set_string(bandn + "-type", "Bell");
+          settings_left->set_double(bandn + "-gain", bands[n].gain);
+          settings_left->set_double(bandn + "-frequency", bands[n].freq);
+          settings_left->set_double(bandn + "-q", bands[n].quality_factor);
 
-          settings_right->set_string(std::string("band" + nstr + "-type"), "Bell");
-          settings_right->set_double(std::string("band" + nstr + "-gain"), bands[n].gain);
-          settings_right->set_double(std::string("band" + nstr + "-frequency"), bands[n].freq);
-          settings_right->set_double(std::string("band" + nstr + "-q"), bands[n].quality_factor);
+          settings_right->set_string(bandn + "-type", "Bell");
+          settings_right->set_double(bandn + "-gain", bands[n].gain);
+          settings_right->set_double(bandn + "-frequency", bands[n].freq);
+          settings_right->set_double(bandn + "-q", bands[n].quality_factor);
         } else {
           if (stack->get_visible_child_name() == "page_left_channel") {
-            settings_left->set_string(std::string("band" + nstr + "-type"), "Bell");
-            settings_left->set_double(std::string("band" + nstr + "-gain"), bands[n].gain);
-            settings_left->set_double(std::string("band" + nstr + "-frequency"), bands[n].freq);
-            settings_left->set_double(std::string("band" + nstr + "-q"), bands[n].quality_factor);
+            settings_left->set_string(bandn + "-type", "Bell");
+            settings_left->set_double(bandn + "-gain", bands[n].gain);
+            settings_left->set_double(bandn + "-frequency", bands[n].freq);
+            settings_left->set_double(bandn + "-q", bands[n].quality_factor);
           } else {
-            settings_right->set_string(std::string("band" + nstr + "-type"), "Bell");
-            settings_right->set_double(std::string("band" + nstr + "-gain"), bands[n].gain);
-            settings_right->set_double(std::string("band" + nstr + "-frequency"), bands[n].freq);
-            settings_right->set_double(std::string("band" + nstr + "-q"), bands[n].quality_factor);
+            settings_right->set_string(bandn + "-type", "Bell");
+            settings_right->set_double(bandn + "-gain", bands[n].gain);
+            settings_right->set_double(bandn + "-frequency", bands[n].freq);
+            settings_right->set_double(bandn + "-q", bands[n].quality_factor);
           }
         }
       } else {
-        settings_left->set_string(std::string("band" + nstr + "-type"), "Off");
+        settings_left->set_string(bandn + "-type", "Off");
 
-        settings_right->set_string(std::string("band" + nstr + "-type"), "Off");
+        settings_right->set_string(bandn + "-type", "Off");
       }
     }
   }

--- a/src/exciter.cpp
+++ b/src/exciter.cpp
@@ -96,7 +96,9 @@ void Exciter::process(std::span<float>& left_in,
     notification_dt += sample_duration;
 
     if (notification_dt >= notification_time_window) {
-      float harmonics_value = lv2_wrapper->get_control_port_value("meter_drive");
+      /// harmonics needed as double for levelbar widget ui, so we convert it here
+
+      const double& harmonics_value = static_cast<double>(lv2_wrapper->get_control_port_value("meter_drive"));
 
       Glib::signal_idle().connect_once([=, this] { harmonics.emit(harmonics_value); });
 

--- a/src/exciter_ui.cpp
+++ b/src/exciter_ui.cpp
@@ -72,7 +72,7 @@ ExciterUi::~ExciterUi() {
 auto ExciterUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> ExciterUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/exciter.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<ExciterUi>(builder, "top_box", "com.github.wwmm.easyeffects.exciter",
+  auto* const ui = Gtk::Builder::get_widget_derived<ExciterUi>(builder, "top_box", "com.github.wwmm.easyeffects.exciter",
                                                          schema_path + "exciter/");
 
   stack->add(*ui, plugin_name::exciter);
@@ -102,7 +102,7 @@ void ExciterUi::reset() {
   settings->reset("listen");
 }
 
-void ExciterUi::on_new_harmonics_level(double value) {
+void ExciterUi::on_new_harmonics_level(const double& value) {
   harmonics_levelbar->set_value(value);
 
   harmonics_levelbar_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));

--- a/src/filter_ui.cpp
+++ b/src/filter_ui.cpp
@@ -24,29 +24,29 @@ namespace {
 auto filter_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "12dB/oct Lowpass") == 0) {
+  if (g_strcmp0(v, "12dB/oct Lowpass") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "24dB/oct Lowpass") == 0) {
+  } else if (g_strcmp0(v, "24dB/oct Lowpass") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "36dB/oct Lowpass") == 0) {
+  } else if (g_strcmp0(v, "36dB/oct Lowpass") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "12dB/oct Highpass") == 0) {
+  } else if (g_strcmp0(v, "12dB/oct Highpass") == 0) {
     g_value_set_int(value, 3);
-  } else if (std::strcmp(v, "24dB/oct Highpass") == 0) {
+  } else if (g_strcmp0(v, "24dB/oct Highpass") == 0) {
     g_value_set_int(value, 4);
-  } else if (std::strcmp(v, "36dB/oct Highpass") == 0) {
+  } else if (g_strcmp0(v, "36dB/oct Highpass") == 0) {
     g_value_set_int(value, 5);
-  } else if (std::strcmp(v, "6dB/oct Bandpass") == 0) {
+  } else if (g_strcmp0(v, "6dB/oct Bandpass") == 0) {
     g_value_set_int(value, 6);
-  } else if (std::strcmp(v, "12dB/oct Bandpass") == 0) {
+  } else if (g_strcmp0(v, "12dB/oct Bandpass") == 0) {
     g_value_set_int(value, 7);
-  } else if (std::strcmp(v, "18dB/oct Bandpass") == 0) {
+  } else if (g_strcmp0(v, "18dB/oct Bandpass") == 0) {
     g_value_set_int(value, 8);
-  } else if (std::strcmp(v, "6dB/oct Bandreject") == 0) {
+  } else if (g_strcmp0(v, "6dB/oct Bandreject") == 0) {
     g_value_set_int(value, 9);
-  } else if (std::strcmp(v, "12dB/oct Bandreject") == 0) {
+  } else if (g_strcmp0(v, "12dB/oct Bandreject") == 0) {
     g_value_set_int(value, 10);
-  } else if (std::strcmp(v, "18dB/oct Bandreject") == 0) {
+  } else if (g_strcmp0(v, "18dB/oct Bandreject") == 0) {
     g_value_set_int(value, 11);
   }
 
@@ -140,7 +140,7 @@ FilterUi::~FilterUi() {
 auto FilterUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> FilterUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/filter.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<FilterUi>(builder, "top_box", "com.github.wwmm.easyeffects.filter",
+  auto* const ui = Gtk::Builder::get_widget_derived<FilterUi>(builder, "top_box", "com.github.wwmm.easyeffects.filter",
                                                         schema_path + "filter/");
 
   stack->add(*ui, plugin_name::filter);

--- a/src/fir_filter_bandpass.cpp
+++ b/src/fir_filter_bandpass.cpp
@@ -30,9 +30,9 @@ void FirFilterBandpass::setup() {
 
   auto highpass_kernel = create_lowpass_kernel(min_frequency, transition_band);
 
-  std::ranges::for_each(highpass_kernel, [](auto& v) { v *= -1; });
+  std::ranges::for_each(highpass_kernel, [](auto& v) { v *= -1.0F; });
 
-  highpass_kernel[(highpass_kernel.size() - 1) / 2] += 1;
+  highpass_kernel[(highpass_kernel.size() - 1U) / 2U] += 1.0F;
 
   kernel.resize(highpass_kernel.size());
 
@@ -44,11 +44,11 @@ void FirFilterBandpass::setup() {
     kernel[n] = lowpass_kernel[n] + highpass_kernel[n];
   }
 
-  std::ranges::for_each(kernel, [](auto& v) { v *= -1; });
+  std::ranges::for_each(kernel, [](auto& v) { v *= -1.0F; });
 
-  kernel[(kernel.size() - 1) / 2] += 1;
+  kernel[(kernel.size() - 1U) / 2U] += 1.0F;
 
-  delay = 0.5F * static_cast<float>(kernel.size() - 1) / static_cast<float>(rate);
+  delay = 0.5F * static_cast<float>(kernel.size() - 1U) / static_cast<float>(rate);
 
   setup_zita();
 }

--- a/src/fir_filter_base.cpp
+++ b/src/fir_filter_base.cpp
@@ -75,7 +75,7 @@ auto FirFilterBase::create_lowpass_kernel(const float& cutoff, const float& tran
     transition band frequency as a fraction of the sample rate
   */
 
-  float b = transition_band / static_cast<float>(rate);
+  const float b = transition_band / static_cast<float>(rate);
 
   /*
       The kernel size must be odd: M + 1 where M is even. This is done so it can be symmetric around the main lobe
@@ -94,7 +94,7 @@ auto FirFilterBase::create_lowpass_kernel(const float& cutoff, const float& tran
     cutoff frequency as a fraction of the sample rate
   */
 
-  float fc = cutoff / static_cast<float>(rate);
+  const float fc = cutoff / static_cast<float>(rate);
 
   float sum = 0.0F;
 
@@ -114,9 +114,9 @@ auto FirFilterBase::create_lowpass_kernel(const float& cutoff, const float& tran
       Blackman window https://www.dspguide.com/ch16/1.htm
     */
 
-    const auto& w = 0.42F -
-                    0.5F * std::cos(2.0F * std::numbers::pi_v<float> * static_cast<float>(n) / static_cast<float>(M)) +
-                    0.08F * std::cos(4.0F * std::numbers::pi_v<float> * static_cast<float>(n) / static_cast<float>(M));
+    const float w =
+        0.42F - 0.5F * std::cos(2.0F * std::numbers::pi_v<float> * static_cast<float>(n) / static_cast<float>(M)) +
+        0.08F * std::cos(4.0F * std::numbers::pi_v<float> * static_cast<float>(n) / static_cast<float>(M));
 
     output[n] *= w;
 
@@ -147,7 +147,7 @@ void FirFilterBase::setup_zita() {
   conv->cleanup();
 
   int ret = 0;
-  float density = 0.0F;
+  const float density = 0.0F;
 
   conv->set_options(0);
 
@@ -192,7 +192,7 @@ void FirFilterBase::setup_zita() {
 }
 
 void FirFilterBase::direct_conv(const std::vector<float>& a, const std::vector<float>& b, std::vector<float>& c) {
-  uint M = (c.size() + 1U) / 2U;
+  const uint M = (c.size() + 1U) / 2U;
 
   for (uint n = 0U; n < c.size(); n++) {
     c[n] = 0.0F;

--- a/src/fir_filter_highpass.cpp
+++ b/src/fir_filter_highpass.cpp
@@ -26,11 +26,11 @@ FirFilterHighpass::~FirFilterHighpass() = default;
 void FirFilterHighpass::setup() {
   kernel = create_lowpass_kernel(min_frequency, transition_band);
 
-  std::ranges::for_each(kernel, [](auto& v) { v *= -1; });
+  std::ranges::for_each(kernel, [](auto& v) { v *= -1.0F; });
 
-  kernel[(kernel.size() - 1) / 2] += 1;
+  kernel[(kernel.size() - 1U) / 2U] += 1.0F;
 
-  delay = 0.5F * static_cast<float>(kernel.size() - 1) / static_cast<float>(rate);
+  delay = 0.5F * static_cast<float>(kernel.size() - 1U) / static_cast<float>(rate);
 
   setup_zita();
 }

--- a/src/fir_filter_lowpass.cpp
+++ b/src/fir_filter_lowpass.cpp
@@ -26,7 +26,7 @@ FirFilterLowpass::~FirFilterLowpass() = default;
 void FirFilterLowpass::setup() {
   kernel = create_lowpass_kernel(max_frequency, transition_band);
 
-  delay = 0.5F * static_cast<float>(kernel.size() - 1) / static_cast<float>(rate);
+  delay = 0.5F * static_cast<float>(kernel.size() - 1U) / static_cast<float>(rate);
 
   setup_zita();
 }

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -97,7 +97,9 @@ void Gate::process(std::span<float>& left_in,
     notification_dt += sample_duration;
 
     if (notification_dt >= notification_time_window) {
-      float gating_value = lv2_wrapper->get_control_port_value("gating");
+      // gating needed as double for levelbar widget ui, so we convert it here
+
+      const double& gating_value = static_cast<double>(lv2_wrapper->get_control_port_value("gating"));
 
       Glib::signal_idle().connect_once([=, this] { gating.emit(gating_value); });
 

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -18,16 +18,15 @@
  */
 
 #include "gate_ui.hpp"
-#include <cstring>
 
 namespace {
 
 auto detection_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "RMS") == 0) {
+  if (g_strcmp0(v, "RMS") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Peak") == 0) {
+  } else if (g_strcmp0(v, "Peak") == 0) {
     g_value_set_int(value, 1);
   }
 
@@ -50,9 +49,9 @@ auto int_to_detection_enum(const GValue* value, const GVariantType* expected_typ
 auto stereo_link_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "Average") == 0) {
+  if (g_strcmp0(v, "Average") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Maximum") == 0) {
+  } else if (g_strcmp0(v, "Maximum") == 0) {
     g_value_set_int(value, 1);
   }
 
@@ -138,7 +137,7 @@ GateUi::~GateUi() {
 auto GateUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> GateUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/gate.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<GateUi>(builder, "top_box", "com.github.wwmm.easyeffects.gate",
+  auto* const ui = Gtk::Builder::get_widget_derived<GateUi>(builder, "top_box", "com.github.wwmm.easyeffects.gate",
                                                       schema_path + "gate/");
 
   stack->add(*ui, plugin_name::gate);
@@ -172,7 +171,7 @@ void GateUi::reset() {
   settings->reset("makeup");
 }
 
-void GateUi::on_new_gating(double value) {
+void GateUi::on_new_gating(const double& value) {
   gating->set_value(1.0 - value);
 
   gating_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));

--- a/src/general_settings_ui.cpp
+++ b/src/general_settings_ui.cpp
@@ -61,7 +61,7 @@ GeneralSettingsUi::~GeneralSettingsUi() {
 void GeneralSettingsUi::add_to_stack(Gtk::Stack* stack, Application* app) {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/general_settings.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<GeneralSettingsUi>(builder, "top_box", app);
+  auto* const ui = Gtk::Builder::get_widget_derived<GeneralSettingsUi>(builder, "top_box", app);
 
   stack->add(*ui, "general_spectrum", _("General"));
 }
@@ -69,11 +69,7 @@ void GeneralSettingsUi::add_to_stack(Gtk::Stack* stack, Application* app) {
 void GeneralSettingsUi::init_autostart_switch() {
   const auto& path = Glib::get_user_config_dir() + "/autostart/easyeffects-service.desktop";
 
-  if (std::filesystem::is_regular_file(path)) {
-    enable_autostart->set_active(true);
-  } else {
-    enable_autostart->set_active(false);
-  }
+  enable_autostart->set_active(std::filesystem::is_regular_file(path) ? true : false);
 }
 
 auto GeneralSettingsUi::on_enable_autostart(bool state) -> bool {

--- a/src/limiter.cpp
+++ b/src/limiter.cpp
@@ -108,12 +108,12 @@ void Limiter::process(std::span<float>& left_in,
    This plugin gives the latency in number of samples
  */
 
-  uint lv = static_cast<uint>(lv2_wrapper->get_control_port_value("out_latency"));
+  const auto& lv = static_cast<uint>(lv2_wrapper->get_control_port_value("out_latency"));
 
   if (latency_n_frames != lv) {
     latency_n_frames = lv;
 
-    float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
     util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
 
@@ -140,10 +140,10 @@ void Limiter::process(std::span<float>& left_in,
     notification_dt += sample_duration;
 
     if (notification_dt >= notification_time_window) {
-      float gain_l = lv2_wrapper->get_control_port_value("grlm_l");
-      float gain_r = lv2_wrapper->get_control_port_value("grlm_r");
-      float sidechain_l = lv2_wrapper->get_control_port_value("sclm_l");
-      float sidechain_r = lv2_wrapper->get_control_port_value("sclm_r");
+      const float& gain_l = lv2_wrapper->get_control_port_value("grlm_l");
+      const float& gain_r = lv2_wrapper->get_control_port_value("grlm_r");
+      const float& sidechain_l = lv2_wrapper->get_control_port_value("sclm_l");
+      const float& sidechain_r = lv2_wrapper->get_control_port_value("sclm_r");
 
       Glib::signal_idle().connect_once([=, this] { gain_left.emit(gain_l); });
       Glib::signal_idle().connect_once([=, this] { gain_right.emit(gain_r); });

--- a/src/limiter_ui.cpp
+++ b/src/limiter_ui.cpp
@@ -24,29 +24,29 @@ namespace {
 auto mode_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "Herm Thin") == 0) {
+  if (g_strcmp0(v, "Herm Thin") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Herm Wide") == 0) {
+  } else if (g_strcmp0(v, "Herm Wide") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "Herm Tail") == 0) {
+  } else if (g_strcmp0(v, "Herm Tail") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "Herm Duck") == 0) {
+  } else if (g_strcmp0(v, "Herm Duck") == 0) {
     g_value_set_int(value, 3);
-  } else if (std::strcmp(v, "Exp Thin") == 0) {
+  } else if (g_strcmp0(v, "Exp Thin") == 0) {
     g_value_set_int(value, 4);
-  } else if (std::strcmp(v, "Exp Wide") == 0) {
+  } else if (g_strcmp0(v, "Exp Wide") == 0) {
     g_value_set_int(value, 5);
-  } else if (std::strcmp(v, "Exp Tail") == 0) {
+  } else if (g_strcmp0(v, "Exp Tail") == 0) {
     g_value_set_int(value, 6);
-  } else if (std::strcmp(v, "Exp Duck") == 0) {
+  } else if (g_strcmp0(v, "Exp Duck") == 0) {
     g_value_set_int(value, 7);
-  } else if (std::strcmp(v, "Line Thin") == 0) {
+  } else if (g_strcmp0(v, "Line Thin") == 0) {
     g_value_set_int(value, 8);
-  } else if (std::strcmp(v, "Line Wide") == 0) {
+  } else if (g_strcmp0(v, "Line Wide") == 0) {
     g_value_set_int(value, 9);
-  } else if (std::strcmp(v, "Line Tail") == 0) {
+  } else if (g_strcmp0(v, "Line Tail") == 0) {
     g_value_set_int(value, 10);
-  } else if (std::strcmp(v, "Line Duck") == 0) {
+  } else if (g_strcmp0(v, "Line Duck") == 0) {
     g_value_set_int(value, 11);
   }
 
@@ -99,47 +99,47 @@ auto int_to_mode_enum(const GValue* value, const GVariantType* expected_type, gp
 auto ovs_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "None") == 0) {
+  if (g_strcmp0(v, "None") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Half x2(2L)") == 0) {
+  } else if (g_strcmp0(v, "Half x2(2L)") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "Half x2(3L)") == 0) {
+  } else if (g_strcmp0(v, "Half x2(3L)") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "Half x3(2L)") == 0) {
+  } else if (g_strcmp0(v, "Half x3(2L)") == 0) {
     g_value_set_int(value, 3);
-  } else if (std::strcmp(v, "Half x3(3L)") == 0) {
+  } else if (g_strcmp0(v, "Half x3(3L)") == 0) {
     g_value_set_int(value, 4);
-  } else if (std::strcmp(v, "Half x4(2L)") == 0) {
+  } else if (g_strcmp0(v, "Half x4(2L)") == 0) {
     g_value_set_int(value, 5);
-  } else if (std::strcmp(v, "Half x4(3L)") == 0) {
+  } else if (g_strcmp0(v, "Half x4(3L)") == 0) {
     g_value_set_int(value, 6);
-  } else if (std::strcmp(v, "Half x6(2L)") == 0) {
+  } else if (g_strcmp0(v, "Half x6(2L)") == 0) {
     g_value_set_int(value, 7);
-  } else if (std::strcmp(v, "Half x6(3L)") == 0) {
+  } else if (g_strcmp0(v, "Half x6(3L)") == 0) {
     g_value_set_int(value, 8);
-  } else if (std::strcmp(v, "Half x8(2L)") == 0) {
+  } else if (g_strcmp0(v, "Half x8(2L)") == 0) {
     g_value_set_int(value, 9);
-  } else if (std::strcmp(v, "Half x8(3L)") == 0) {
+  } else if (g_strcmp0(v, "Half x8(3L)") == 0) {
     g_value_set_int(value, 10);
-  } else if (std::strcmp(v, "Full x2(2L)") == 0) {
+  } else if (g_strcmp0(v, "Full x2(2L)") == 0) {
     g_value_set_int(value, 11);
-  } else if (std::strcmp(v, "Full x2(3L)") == 0) {
+  } else if (g_strcmp0(v, "Full x2(3L)") == 0) {
     g_value_set_int(value, 12);
-  } else if (std::strcmp(v, "Full x3(2L)") == 0) {
+  } else if (g_strcmp0(v, "Full x3(2L)") == 0) {
     g_value_set_int(value, 13);
-  } else if (std::strcmp(v, "Full x3(3L)") == 0) {
+  } else if (g_strcmp0(v, "Full x3(3L)") == 0) {
     g_value_set_int(value, 14);
-  } else if (std::strcmp(v, "Full x4(2L)") == 0) {
+  } else if (g_strcmp0(v, "Full x4(2L)") == 0) {
     g_value_set_int(value, 15);
-  } else if (std::strcmp(v, "Full x4(3L)") == 0) {
+  } else if (g_strcmp0(v, "Full x4(3L)") == 0) {
     g_value_set_int(value, 16);
-  } else if (std::strcmp(v, "Full x6(2L)") == 0) {
+  } else if (g_strcmp0(v, "Full x6(2L)") == 0) {
     g_value_set_int(value, 17);
-  } else if (std::strcmp(v, "Full x6(3L)") == 0) {
+  } else if (g_strcmp0(v, "Full x6(3L)") == 0) {
     g_value_set_int(value, 18);
-  } else if (std::strcmp(v, "Full x8(2L)") == 0) {
+  } else if (g_strcmp0(v, "Full x8(2L)") == 0) {
     g_value_set_int(value, 19);
-  } else if (std::strcmp(v, "Full x8(3L)") == 0) {
+  } else if (g_strcmp0(v, "Full x8(3L)") == 0) {
     g_value_set_int(value, 20);
   }
 
@@ -219,23 +219,23 @@ auto int_to_ovs_enum(const GValue* value, const GVariantType* expected_type, gpo
 auto dither_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "None") == 0) {
+  if (g_strcmp0(v, "None") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "7bit") == 0) {
+  } else if (g_strcmp0(v, "7bit") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "8bit") == 0) {
+  } else if (g_strcmp0(v, "8bit") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "11bit") == 0) {
+  } else if (g_strcmp0(v, "11bit") == 0) {
     g_value_set_int(value, 3);
-  } else if (std::strcmp(v, "12bit") == 0) {
+  } else if (g_strcmp0(v, "12bit") == 0) {
     g_value_set_int(value, 4);
-  } else if (std::strcmp(v, "15bit") == 0) {
+  } else if (g_strcmp0(v, "15bit") == 0) {
     g_value_set_int(value, 5);
-  } else if (std::strcmp(v, "16bit") == 0) {
+  } else if (g_strcmp0(v, "16bit") == 0) {
     g_value_set_int(value, 6);
-  } else if (std::strcmp(v, "23bit") == 0) {
+  } else if (g_strcmp0(v, "23bit") == 0) {
     g_value_set_int(value, 7);
-  } else if (std::strcmp(v, "24bit") == 0) {
+  } else if (g_strcmp0(v, "24bit") == 0) {
     g_value_set_int(value, 8);
   }
 
@@ -374,7 +374,7 @@ LimiterUi::~LimiterUi() {
 auto LimiterUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> LimiterUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/limiter.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<LimiterUi>(builder, "top_box", "com.github.wwmm.easyeffects.limiter",
+  auto* const ui = Gtk::Builder::get_widget_derived<LimiterUi>(builder, "top_box", "com.github.wwmm.easyeffects.limiter",
                                                          schema_path + "limiter/");
 
   stack->add(*ui, plugin_name::limiter);
@@ -418,18 +418,18 @@ void LimiterUi::reset() {
   settings->reset("alr-knee");
 }
 
-void LimiterUi::on_new_left_gain(double value) {
+void LimiterUi::on_new_left_gain(const float& value) {
   gain_left->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
-void LimiterUi::on_new_right_gain(double value) {
+void LimiterUi::on_new_right_gain(const float& value) {
   gain_right->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
-void LimiterUi::on_new_left_sidechain(double value) {
+void LimiterUi::on_new_left_sidechain(const float& value) {
   sidechain_left->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
-void LimiterUi::on_new_right_sidechain(double value) {
+void LimiterUi::on_new_right_sidechain(const float& value) {
   sidechain_right->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }

--- a/src/loudness.cpp
+++ b/src/loudness.cpp
@@ -85,12 +85,12 @@ void Loudness::process(std::span<float>& left_in,
    This plugin gives the latency in number of samples
  */
 
-  uint lv = static_cast<uint>(lv2_wrapper->get_control_port_value("out_latency"));
+  const auto& lv = static_cast<uint>(lv2_wrapper->get_control_port_value("out_latency"));
 
   if (latency_n_frames != lv) {
     latency_n_frames = lv;
 
-    float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
     util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
 

--- a/src/loudness_ui.cpp
+++ b/src/loudness_ui.cpp
@@ -24,19 +24,19 @@ namespace {
 auto fft_size_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "256") == 0) {
+  if (g_strcmp0(v, "256") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "512") == 0) {
+  } else if (g_strcmp0(v, "512") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "1024") == 0) {
+  } else if (g_strcmp0(v, "1024") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "2048") == 0) {
+  } else if (g_strcmp0(v, "2048") == 0) {
     g_value_set_int(value, 3);
-  } else if (std::strcmp(v, "4096") == 0) {
+  } else if (g_strcmp0(v, "4096") == 0) {
     g_value_set_int(value, 4);
-  } else if (std::strcmp(v, "8192") == 0) {
+  } else if (g_strcmp0(v, "8192") == 0) {
     g_value_set_int(value, 5);
-  } else if (std::strcmp(v, "16384") == 0) {
+  } else if (g_strcmp0(v, "16384") == 0) {
     g_value_set_int(value, 6);
   }
 
@@ -74,13 +74,13 @@ auto int_to_fft_size_enum(const GValue* value, const GVariantType* expected_type
 auto standard_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "Flat") == 0) {
+  if (g_strcmp0(v, "Flat") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "ISO226-2003") == 0) {
+  } else if (g_strcmp0(v, "ISO226-2003") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "Fletcher-Munson") == 0) {
+  } else if (g_strcmp0(v, "Fletcher-Munson") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "Robinson-Dadson") == 0) {
+  } else if (g_strcmp0(v, "Robinson-Dadson") == 0) {
     g_value_set_int(value, 3);
   }
 
@@ -150,7 +150,7 @@ LoudnessUi::~LoudnessUi() {
 auto LoudnessUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> LoudnessUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/loudness.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<LoudnessUi>(builder, "top_box", "com.github.wwmm.easyeffects.loudness",
+  auto* const ui = Gtk::Builder::get_widget_derived<LoudnessUi>(builder, "top_box", "com.github.wwmm.easyeffects.loudness",
                                                           schema_path + "loudness/");
 
   stack->add(*ui, plugin_name::loudness);

--- a/src/lv2_wrapper.cpp
+++ b/src/lv2_wrapper.cpp
@@ -42,7 +42,7 @@ Lv2Wrapper::Lv2Wrapper(const std::string& plugin_uri) : plugin_uri(plugin_uri) {
     return;
   }
 
-  auto* uri = lilv_new_uri(world, plugin_uri.c_str());
+  auto* const uri = lilv_new_uri(world, plugin_uri.c_str());
 
   if (uri == nullptr) {
     util::warning(log_tag + "Invalid plugin URI: " + plugin_uri);
@@ -323,7 +323,7 @@ void Lv2Wrapper::deactivate() {
 }
 
 void Lv2Wrapper::set_control_port_value(const std::string& symbol, const float& value) {
-  bool found = false;
+  auto found = false;
 
   for (auto& p : ports) {
     if (p.type == PortType::TYPE_CONTROL && p.symbol == symbol) {
@@ -346,24 +346,15 @@ void Lv2Wrapper::set_control_port_value(const std::string& symbol, const float& 
   }
 }
 auto Lv2Wrapper::get_control_port_value(const std::string& symbol) -> float {
-  bool found = false;
-  float value = 0.0F;
-
-  for (auto& p : ports) {
+  for (const auto& p : ports) {
     if (p.type == PortType::TYPE_CONTROL && p.symbol == symbol) {
-      value = p.value;
-
-      found = true;
-
-      break;
+      return p.value;
     }
   }
 
-  if (!found) {
-    util::warning(log_tag + plugin_uri + " port symbol not found: " + symbol);
-  }
+  util::warning(log_tag + plugin_uri + " port symbol not found: " + symbol);
 
-  return value;
+  return 0.0F;
 }
 
 auto Lv2Wrapper::has_instance() -> bool {
@@ -371,7 +362,7 @@ auto Lv2Wrapper::has_instance() -> bool {
 }
 
 void Lv2Wrapper::bind_key_double(const Glib::RefPtr<Gio::Settings>& settings,
-                                 const std::string& gsettings_key,
+                                 const Glib::ustring& gsettings_key,
                                  const std::string& lv2_symbol) {
   set_control_port_value(lv2_symbol, static_cast<float>(settings->get_double(gsettings_key)));
 
@@ -381,7 +372,7 @@ void Lv2Wrapper::bind_key_double(const Glib::RefPtr<Gio::Settings>& settings,
 }
 
 void Lv2Wrapper::bind_key_double_db(const Glib::RefPtr<Gio::Settings>& settings,
-                                    const std::string& gsettings_key,
+                                    const Glib::ustring& gsettings_key,
                                     const std::string& lv2_symbol) {
   set_control_port_value(lv2_symbol, static_cast<float>(util::db_to_linear(settings->get_double(gsettings_key))));
 
@@ -391,7 +382,7 @@ void Lv2Wrapper::bind_key_double_db(const Glib::RefPtr<Gio::Settings>& settings,
 }
 
 void Lv2Wrapper::bind_key_bool(const Glib::RefPtr<Gio::Settings>& settings,
-                               const std::string& gsettings_key,
+                               const Glib::ustring& gsettings_key,
                                const std::string& lv2_symbol) {
   set_control_port_value(lv2_symbol, static_cast<float>(settings->get_boolean(gsettings_key)));
 
@@ -401,7 +392,7 @@ void Lv2Wrapper::bind_key_bool(const Glib::RefPtr<Gio::Settings>& settings,
 }
 
 void Lv2Wrapper::bind_key_enum(const Glib::RefPtr<Gio::Settings>& settings,
-                               const std::string& gsettings_key,
+                               const Glib::ustring& gsettings_key,
                                const std::string& lv2_symbol) {
   set_control_port_value(lv2_symbol, static_cast<float>(settings->get_enum(gsettings_key)));
 
@@ -411,7 +402,7 @@ void Lv2Wrapper::bind_key_enum(const Glib::RefPtr<Gio::Settings>& settings,
 }
 
 void Lv2Wrapper::bind_key_int(const Glib::RefPtr<Gio::Settings>& settings,
-                              const std::string& gsettings_key,
+                              const Glib::ustring& gsettings_key,
                               const std::string& lv2_symbol) {
   set_control_port_value(lv2_symbol, static_cast<float>(settings->get_int(gsettings_key)));
 

--- a/src/maximizer.cpp
+++ b/src/maximizer.cpp
@@ -76,12 +76,12 @@ void Maximizer::process(std::span<float>& left_in,
     This plugin gives the latency in number of samples
   */
 
-  uint lv = static_cast<uint>(lv2_wrapper->get_control_port_value("lv2_latency"));
+  const auto& lv = static_cast<uint>(lv2_wrapper->get_control_port_value("lv2_latency"));
 
   if (latency_n_frames != lv) {
     latency_n_frames = lv;
 
-    float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
     util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
 
@@ -108,7 +108,9 @@ void Maximizer::process(std::span<float>& left_in,
     notification_dt += sample_duration;
 
     if (notification_dt >= notification_time_window) {
-      float reduction_value = lv2_wrapper->get_control_port_value("gr");
+      // reduction needed as double for levelbar widget ui, so we convert it here
+
+      const double& reduction_value = static_cast<double>(lv2_wrapper->get_control_port_value("gr"));
 
       Glib::signal_idle().connect_once([=, this] { reduction.emit(reduction_value); });
 

--- a/src/maximizer_ui.cpp
+++ b/src/maximizer_ui.cpp
@@ -52,7 +52,7 @@ MaximizerUi::~MaximizerUi() {
 auto MaximizerUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> MaximizerUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/maximizer.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<MaximizerUi>(builder, "top_box", "com.github.wwmm.easyeffects.maximizer",
+  auto* const ui = Gtk::Builder::get_widget_derived<MaximizerUi>(builder, "top_box", "com.github.wwmm.easyeffects.maximizer",
                                                            schema_path + "maximizer/");
 
   stack->add(*ui, plugin_name::maximizer);
@@ -70,7 +70,7 @@ void MaximizerUi::reset() {
   settings->reset("threshold");
 }
 
-void MaximizerUi::on_new_reduction(double value) {
+void MaximizerUi::on_new_reduction(const double& value) {
   reduction_levelbar->set_value(value);
 
   reduction_label->set_text(level_to_localized_string(value, 0));

--- a/src/multiband_compressor.cpp
+++ b/src/multiband_compressor.cpp
@@ -138,12 +138,12 @@ void MultibandCompressor::process(std::span<float>& left_in,
    This plugin gives the latency in number of samples
  */
 
-  uint lv = static_cast<uint>(lv2_wrapper->get_control_port_value("out_latency"));
+  const auto& lv = static_cast<uint>(lv2_wrapper->get_control_port_value("out_latency"));
 
   if (latency_n_frames != lv) {
     latency_n_frames = lv;
 
-    float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
     util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
 
@@ -170,30 +170,24 @@ void MultibandCompressor::process(std::span<float>& left_in,
     notification_dt += sample_duration;
 
     if (notification_dt >= notification_time_window) {
-      std::array<double, n_bands> frequency_range_end_array{};
-      std::array<double, n_bands> envelope_array{};
-      std::array<double, n_bands> curve_array{};
-      std::array<double, n_bands> reduction_array{};
+      std::array<float, n_bands> frequency_range_end_array{};
+      std::array<float, n_bands> envelope_array{};
+      std::array<float, n_bands> curve_array{};
+      std::array<float, n_bands> reduction_array{};
 
       for (uint n = 0U; n < n_bands; n++) {
         const auto& nstr = std::to_string(n);
 
         frequency_range_end_array.at(n) = lv2_wrapper->get_control_port_value("fre_" + nstr);
-
         envelope_array.at(n) = lv2_wrapper->get_control_port_value("elm_" + nstr);
-
         curve_array.at(n) = lv2_wrapper->get_control_port_value("clm_" + nstr);
-
         reduction_array.at(n) = lv2_wrapper->get_control_port_value("rlm_" + nstr);
       }
 
       Glib::signal_idle().connect_once([=, this] {
         frequency_range.emit(frequency_range_end_array);
-
         envelope.emit(envelope_array);
-
         curve.emit(curve_array);
-
         reduction.emit(reduction_array);
       });
 

--- a/src/multiband_compressor_preset.cpp
+++ b/src/multiband_compressor_preset.cpp
@@ -40,71 +40,71 @@ void MultibandCompressorPreset::save(nlohmann::json& json,
 
   for (uint n = 0U; n < n_bands; n++) {
     const auto& nstr = std::to_string(n);
+    const auto& bandn = "band" + nstr;
 
     if (n > 0U) {
-      json[section]["multiband_compressor"]["band" + nstr]["enable-band"] = settings->get_boolean("enable-band" + nstr);
+      json[section]["multiband_compressor"][bandn]["enable-band"] = settings->get_boolean("enable-band" + nstr);
 
-      json[section]["multiband_compressor"]["band" + nstr]["split-frequency"] =
-          settings->get_double("split-frequency" + nstr);
+      json[section]["multiband_compressor"][bandn]["split-frequency"] = settings->get_double("split-frequency" + nstr);
     }
 
-    json[section]["multiband_compressor"]["band" + nstr]["compressor-enable"] =
+    json[section]["multiband_compressor"][bandn]["compressor-enable"] =
         settings->get_boolean("compressor-enable" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["solo"] = settings->get_boolean("solo" + nstr);
+    json[section]["multiband_compressor"][bandn]["solo"] = settings->get_boolean("solo" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["mute"] = settings->get_boolean("mute" + nstr);
+    json[section]["multiband_compressor"][bandn]["mute"] = settings->get_boolean("mute" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["attack-threshold"] =
+    json[section]["multiband_compressor"][bandn]["attack-threshold"] =
         settings->get_double("attack-threshold" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["attack-time"] = settings->get_double("attack-time" + nstr);
+    json[section]["multiband_compressor"][bandn]["attack-time"] = settings->get_double("attack-time" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["release-threshold"] =
+    json[section]["multiband_compressor"][bandn]["release-threshold"] =
         settings->get_double("release-threshold" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["release-time"] = settings->get_double("release-time" + nstr);
+    json[section]["multiband_compressor"][bandn]["release-time"] = settings->get_double("release-time" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["ratio"] = settings->get_double("ratio" + nstr);
+    json[section]["multiband_compressor"][bandn]["ratio"] = settings->get_double("ratio" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["knee"] = settings->get_double("knee" + nstr);
+    json[section]["multiband_compressor"][bandn]["knee"] = settings->get_double("knee" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["makeup"] = settings->get_double("makeup" + nstr);
+    json[section]["multiband_compressor"][bandn]["makeup"] = settings->get_double("makeup" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["compression-mode"] =
+    json[section]["multiband_compressor"][bandn]["compression-mode"] =
         settings->get_string("compression-mode" + nstr).c_str();
 
-    json[section]["multiband_compressor"]["band" + nstr]["sidechain-mode"] =
+    json[section]["multiband_compressor"][bandn]["sidechain-mode"] =
         settings->get_string("sidechain-mode" + nstr).c_str();
 
-    json[section]["multiband_compressor"]["band" + nstr]["sidechain-source"] =
+    json[section]["multiband_compressor"][bandn]["sidechain-source"] =
         settings->get_string("sidechain-source" + nstr).c_str();
 
-    json[section]["multiband_compressor"]["band" + nstr]["sidechain-lookahead"] =
+    json[section]["multiband_compressor"][bandn]["sidechain-lookahead"] =
         settings->get_double("sidechain-lookahead" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["sidechain-reactivity"] =
+    json[section]["multiband_compressor"][bandn]["sidechain-reactivity"] =
         settings->get_double("sidechain-reactivity" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["sidechain-preamp"] =
+    json[section]["multiband_compressor"][bandn]["sidechain-preamp"] =
         settings->get_double("sidechain-preamp" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["sidechain-custom-lowcut-filter"] =
+    json[section]["multiband_compressor"][bandn]["sidechain-custom-lowcut-filter"] =
         settings->get_boolean("sidechain-custom-lowcut-filter" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["sidechain-custom-highcut-filter"] =
+    json[section]["multiband_compressor"][bandn]["sidechain-custom-highcut-filter"] =
         settings->get_boolean("sidechain-custom-highcut-filter" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["sidechain-lowcut-frequency"] =
+    json[section]["multiband_compressor"][bandn]["sidechain-lowcut-frequency"] =
         settings->get_double("sidechain-lowcut-frequency" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["sidechain-highcut-frequency"] =
+    json[section]["multiband_compressor"][bandn]["sidechain-highcut-frequency"] =
         settings->get_double("sidechain-highcut-frequency" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["boost-threshold"] =
+    json[section]["multiband_compressor"][bandn]["boost-threshold"] =
         settings->get_double("boost-threshold" + nstr);
 
-    json[section]["multiband_compressor"]["band" + nstr]["boost-amount"] = settings->get_double("boost-amount" + nstr);
+    json[section]["multiband_compressor"][bandn]["boost-amount"] = settings->get_double("boost-amount" + nstr);
   }
 }
 
@@ -121,76 +121,77 @@ void MultibandCompressorPreset::load(const nlohmann::json& json,
 
   for (uint n = 0U; n < n_bands; n++) {
     const auto& nstr = std::to_string(n);
+    const auto& bandn = "band" + nstr;
 
     if (n > 0U) {
-      update_key<bool>(json.at(section).at("multiband_compressor").at("band" + nstr), settings, "enable-band" + nstr,
+      update_key<bool>(json.at(section).at("multiband_compressor").at(bandn), settings, "enable-band" + nstr,
                        "enable-band");
 
-      update_key<double>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+      update_key<double>(json.at(section).at("multiband_compressor").at(bandn), settings,
                          "split-frequency" + nstr, "split-frequency");
     }
 
-    update_key<bool>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+    update_key<bool>(json.at(section).at("multiband_compressor").at(bandn), settings,
                      "compressor-enable" + nstr, "compressor-enable");
 
-    update_key<bool>(json.at(section).at("multiband_compressor").at("band" + nstr), settings, "solo" + nstr, "solo");
+    update_key<bool>(json.at(section).at("multiband_compressor").at(bandn), settings, "solo" + nstr, "solo");
 
-    update_key<bool>(json.at(section).at("multiband_compressor").at("band" + nstr), settings, "mute" + nstr, "mute");
+    update_key<bool>(json.at(section).at("multiband_compressor").at(bandn), settings, "mute" + nstr, "mute");
 
-    update_key<double>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+    update_key<double>(json.at(section).at("multiband_compressor").at(bandn), settings,
                        "attack-threshold" + nstr, "attack-threshold");
 
-    update_key<double>(json.at(section).at("multiband_compressor").at("band" + nstr), settings, "attack-time" + nstr,
+    update_key<double>(json.at(section).at("multiband_compressor").at(bandn), settings, "attack-time" + nstr,
                        "attack-time");
 
-    update_key<double>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+    update_key<double>(json.at(section).at("multiband_compressor").at(bandn), settings,
                        "release-threshold" + nstr, "release-threshold");
 
-    update_key<double>(json.at(section).at("multiband_compressor").at("band" + nstr), settings, "release-time" + nstr,
+    update_key<double>(json.at(section).at("multiband_compressor").at(bandn), settings, "release-time" + nstr,
                        "release-time");
 
-    update_key<double>(json.at(section).at("multiband_compressor").at("band" + nstr), settings, "ratio" + nstr,
+    update_key<double>(json.at(section).at("multiband_compressor").at(bandn), settings, "ratio" + nstr,
                        "ratio");
 
-    update_key<double>(json.at(section).at("multiband_compressor").at("band" + nstr), settings, "knee" + nstr, "knee");
+    update_key<double>(json.at(section).at("multiband_compressor").at(bandn), settings, "knee" + nstr, "knee");
 
-    update_key<double>(json.at(section).at("multiband_compressor").at("band" + nstr), settings, "makeup" + nstr,
+    update_key<double>(json.at(section).at("multiband_compressor").at(bandn), settings, "makeup" + nstr,
                        "makeup");
 
-    update_string_key(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+    update_string_key(json.at(section).at("multiband_compressor").at(bandn), settings,
                       "compression-mode" + nstr, "compression-mode");
 
-    update_string_key(json.at(section).at("multiband_compressor").at("band" + nstr), settings, "sidechain-mode" + nstr,
+    update_string_key(json.at(section).at("multiband_compressor").at(bandn), settings, "sidechain-mode" + nstr,
                       "sidechain-mode");
 
-    update_string_key(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+    update_string_key(json.at(section).at("multiband_compressor").at(bandn), settings,
                       "sidechain-source" + nstr, "sidechain-source");
 
-    update_key<double>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+    update_key<double>(json.at(section).at("multiband_compressor").at(bandn), settings,
                        "sidechain-lookahead" + nstr, "sidechain-lookahead");
 
-    update_key<double>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+    update_key<double>(json.at(section).at("multiband_compressor").at(bandn), settings,
                        "sidechain-reactivity" + nstr, "sidechain-reactivity");
 
-    update_key<double>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+    update_key<double>(json.at(section).at("multiband_compressor").at(bandn), settings,
                        "sidechain-preamp" + nstr, "sidechain-preamp");
 
-    update_key<bool>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+    update_key<bool>(json.at(section).at("multiband_compressor").at(bandn), settings,
                      "sidechain-custom-lowcut-filter" + nstr, "sidechain-custom-lowcut-filter");
 
-    update_key<bool>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+    update_key<bool>(json.at(section).at("multiband_compressor").at(bandn), settings,
                      "sidechain-custom-highcut-filter" + nstr, "sidechain-custom-highcut-filter");
 
-    update_key<double>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+    update_key<double>(json.at(section).at("multiband_compressor").at(bandn), settings,
                        "sidechain-lowcut-frequency" + nstr, "sidechain-lowcut-frequency");
 
-    update_key<double>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+    update_key<double>(json.at(section).at("multiband_compressor").at(bandn), settings,
                        "sidechain-highcut-frequency" + nstr, "sidechain-highcut-frequency");
 
-    update_key<double>(json.at(section).at("multiband_compressor").at("band" + nstr), settings,
+    update_key<double>(json.at(section).at("multiband_compressor").at(bandn), settings,
                        "boost-threshold" + nstr, "boost-threshold");
 
-    update_key<double>(json.at(section).at("multiband_compressor").at("band" + nstr), settings, "boost-amount" + nstr,
+    update_key<double>(json.at(section).at("multiband_compressor").at(bandn), settings, "boost-amount" + nstr,
                        "boost-amount");
   }
 }

--- a/src/multiband_compressor_ui.cpp
+++ b/src/multiband_compressor_ui.cpp
@@ -24,9 +24,9 @@ namespace {
 auto compressor_mode_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "Classic") == 0) {
+  if (g_strcmp0(v, "Classic") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Modern") == 0) {
+  } else if (g_strcmp0(v, "Modern") == 0) {
     g_value_set_int(value, 1);
   }
 
@@ -50,15 +50,15 @@ auto int_to_compressor_mode_enum(const GValue* value, const GVariantType* expect
 auto envelope_boost_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "None") == 0) {
+  if (g_strcmp0(v, "None") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Pink BT") == 0) {
+  } else if (g_strcmp0(v, "Pink BT") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "Pink MT") == 0) {
+  } else if (g_strcmp0(v, "Pink MT") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "Brown BT") == 0) {
+  } else if (g_strcmp0(v, "Brown BT") == 0) {
     g_value_set_int(value, 3);
-  } else if (std::strcmp(v, "Brown MT") == 0) {
+  } else if (g_strcmp0(v, "Brown MT") == 0) {
     g_value_set_int(value, 4);
   }
 
@@ -91,11 +91,11 @@ auto int_to_envelope_boost_enum(const GValue* value, const GVariantType* expecte
 auto compression_mode_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "Downward") == 0) {
+  if (g_strcmp0(v, "Downward") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Upward") == 0) {
+  } else if (g_strcmp0(v, "Upward") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "Boosting") == 0) {
+  } else if (g_strcmp0(v, "Boosting") == 0) {
     g_value_set_int(value, 2);
   }
 
@@ -122,13 +122,13 @@ auto int_to_compression_mode_enum(const GValue* value, const GVariantType* expec
 auto sidechain_mode_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "Peak") == 0) {
+  if (g_strcmp0(v, "Peak") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "RMS") == 0) {
+  } else if (g_strcmp0(v, "RMS") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "Low-Pass") == 0) {
+  } else if (g_strcmp0(v, "Low-Pass") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "Uniform") == 0) {
+  } else if (g_strcmp0(v, "Uniform") == 0) {
     g_value_set_int(value, 3);
   }
 
@@ -158,13 +158,13 @@ auto int_to_sidechain_mode_enum(const GValue* value, const GVariantType* expecte
 auto sidechain_source_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "Middle") == 0) {
+  if (g_strcmp0(v, "Middle") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Side") == 0) {
+  } else if (g_strcmp0(v, "Side") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "Left") == 0) {
+  } else if (g_strcmp0(v, "Left") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "Right") == 0) {
+  } else if (g_strcmp0(v, "Right") == 0) {
     g_value_set_int(value, 3);
   }
 
@@ -247,7 +247,7 @@ MultibandCompressorUi::MultibandCompressorUi(BaseObjectType* cobject,
   for (uint n = 1U; n < n_bands; n++) {
     const auto& nstr = std::to_string(n);
 
-    auto* enable_band = builder->get_widget<Gtk::CheckButton>("enable_band" + nstr);
+    auto* const enable_band = builder->get_widget<Gtk::CheckButton>("enable_band" + nstr);
 
     settings->bind("enable-band" + nstr, enable_band, "active");
   }
@@ -262,7 +262,7 @@ MultibandCompressorUi::~MultibandCompressorUi() {
 auto MultibandCompressorUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> MultibandCompressorUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/multiband_compressor.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<MultibandCompressorUi>(
+  auto* const ui = Gtk::Builder::get_widget_derived<MultibandCompressorUi>(
       builder, "top_box", "com.github.wwmm.easyeffects.multibandcompressor", schema_path + "multibandcompressor/");
 
   stack->add(*ui, plugin_name::multiband_compressor);
@@ -277,7 +277,7 @@ void MultibandCompressorUi::prepare_bands() {
     const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/multiband_compressor_band.ui");
 
     if (n > 0U) {
-      auto* split_frequency = builder->get_widget<Gtk::SpinButton>("split_frequency");
+      auto* const split_frequency = builder->get_widget<Gtk::SpinButton>("split_frequency");
 
       settings->bind("split-frequency" + nstr, split_frequency->get_adjustment().get(), "value");
 
@@ -285,7 +285,7 @@ void MultibandCompressorUi::prepare_bands() {
     } else {
       // removing split frequency from band 0
 
-      auto* sf_box = builder->get_widget<Gtk::Box>("split_frequency_box");
+      auto* const sf_box = builder->get_widget<Gtk::Box>("split_frequency_box");
 
       for (auto* child = sf_box->get_last_child(); child != nullptr; child = sf_box->get_last_child()) {
         sf_box->remove(*child);
@@ -306,49 +306,49 @@ void MultibandCompressorUi::prepare_bands() {
 
     bands_curve_label.at(n) = builder->get_widget<Gtk::Label>("band_curve_label");
 
-    auto* band_bypass = builder->get_widget<Gtk::ToggleButton>("bypass");
+    auto* const band_bypass = builder->get_widget<Gtk::ToggleButton>("bypass");
 
-    auto* mute = builder->get_widget<Gtk::ToggleButton>("mute");
+    auto* const mute = builder->get_widget<Gtk::ToggleButton>("mute");
 
-    auto* solo = builder->get_widget<Gtk::ToggleButton>("solo");
+    auto* const solo = builder->get_widget<Gtk::ToggleButton>("solo");
 
-    auto* lowcut_filter = builder->get_widget<Gtk::CheckButton>("lowcut_filter");
+    auto* const lowcut_filter = builder->get_widget<Gtk::CheckButton>("lowcut_filter");
 
-    auto* highcut_filter = builder->get_widget<Gtk::CheckButton>("highcut_filter");
+    auto* const highcut_filter = builder->get_widget<Gtk::CheckButton>("highcut_filter");
 
-    auto* lowcut_filter_frequency = builder->get_widget<Gtk::SpinButton>("lowcut_filter_frequency");
+    auto* const lowcut_filter_frequency = builder->get_widget<Gtk::SpinButton>("lowcut_filter_frequency");
 
-    auto* highcut_filter_frequency = builder->get_widget<Gtk::SpinButton>("highcut_filter_frequency");
+    auto* const highcut_filter_frequency = builder->get_widget<Gtk::SpinButton>("highcut_filter_frequency");
 
-    auto* attack_time = builder->get_widget<Gtk::SpinButton>("attack_time");
+    auto* const attack_time = builder->get_widget<Gtk::SpinButton>("attack_time");
 
-    auto* attack_threshold = builder->get_widget<Gtk::SpinButton>("attack_threshold");
+    auto* const attack_threshold = builder->get_widget<Gtk::SpinButton>("attack_threshold");
 
-    auto* release_time = builder->get_widget<Gtk::SpinButton>("release_time");
+    auto* const release_time = builder->get_widget<Gtk::SpinButton>("release_time");
 
-    auto* release_threshold = builder->get_widget<Gtk::SpinButton>("release_threshold");
+    auto* const release_threshold = builder->get_widget<Gtk::SpinButton>("release_threshold");
 
-    auto* ratio = builder->get_widget<Gtk::SpinButton>("ratio");
+    auto* const ratio = builder->get_widget<Gtk::SpinButton>("ratio");
 
-    auto* knee = builder->get_widget<Gtk::SpinButton>("knee");
+    auto* const knee = builder->get_widget<Gtk::SpinButton>("knee");
 
-    auto* makeup = builder->get_widget<Gtk::SpinButton>("makeup");
+    auto* const makeup = builder->get_widget<Gtk::SpinButton>("makeup");
 
-    auto* sidechain_preamp = builder->get_widget<Gtk::SpinButton>("sidechain_preamp");
+    auto* const sidechain_preamp = builder->get_widget<Gtk::SpinButton>("sidechain_preamp");
 
-    auto* sidechain_reactivity = builder->get_widget<Gtk::SpinButton>("sidechain_reactivity");
+    auto* const sidechain_reactivity = builder->get_widget<Gtk::SpinButton>("sidechain_reactivity");
 
-    auto* sidechain_lookahead = builder->get_widget<Gtk::SpinButton>("sidechain_lookahead");
+    auto* const sidechain_lookahead = builder->get_widget<Gtk::SpinButton>("sidechain_lookahead");
 
-    auto* boost_amount = builder->get_widget<Gtk::SpinButton>("boost_amount");
+    auto* const boost_amount = builder->get_widget<Gtk::SpinButton>("boost_amount");
 
-    auto* boost_threshold = builder->get_widget<Gtk::SpinButton>("boost_threshold");
+    auto* const boost_threshold = builder->get_widget<Gtk::SpinButton>("boost_threshold");
 
-    auto* compression_mode = builder->get_widget<Gtk::ComboBoxText>("compression_mode");
+    auto* const compression_mode = builder->get_widget<Gtk::ComboBoxText>("compression_mode");
 
-    auto* sidechain_mode = builder->get_widget<Gtk::ComboBoxText>("sidechain_mode");
+    auto* const sidechain_mode = builder->get_widget<Gtk::ComboBoxText>("sidechain_mode");
 
-    auto* sidechain_source = builder->get_widget<Gtk::ComboBoxText>("sidechain_source");
+    auto* const sidechain_source = builder->get_widget<Gtk::ComboBoxText>("sidechain_source");
 
     // gsettings bindings
 
@@ -458,7 +458,7 @@ void MultibandCompressorUi::prepare_bands() {
 
     // add to stack
 
-    auto* top_box = builder->get_widget<Gtk::Box>("top_box");
+    auto* const top_box = builder->get_widget<Gtk::Box>("top_box");
 
     stack->add(*top_box, "band" + nstr);
   }
@@ -530,25 +530,25 @@ void MultibandCompressorUi::reset() {
   }
 }
 
-void MultibandCompressorUi::on_new_frequency_range(std::array<double, n_bands> values) {
+void MultibandCompressorUi::on_new_frequency_range(const std::array<float, n_bands>& values) {
   for (size_t n = 0U, m = values.size(); n < m; n++) {
     bands_end.at(n)->set_text(level_to_localized_string(values.at(n), 0));
   }
 }
 
-void MultibandCompressorUi::on_new_envelope(std::array<double, n_bands> values) {
+void MultibandCompressorUi::on_new_envelope(const std::array<float, n_bands>& values) {
   for (size_t n = 0U, m = values.size(); n < m; n++) {
     bands_envelope_label.at(n)->set_text(level_to_localized_string(util::linear_to_db(values.at(n)), 0));
   }
 }
 
-void MultibandCompressorUi::on_new_curve(std::array<double, n_bands> values) {
+void MultibandCompressorUi::on_new_curve(const std::array<float, n_bands>& values) {
   for (size_t n = 0U, m = values.size(); n < m; n++) {
     bands_curve_label.at(n)->set_text(level_to_localized_string(util::linear_to_db(values.at(n)), 0));
   }
 }
 
-void MultibandCompressorUi::on_new_reduction(std::array<double, n_bands> values) {
+void MultibandCompressorUi::on_new_reduction(const std::array<float, n_bands>& values) {
   for (size_t n = 0U, m = values.size(); n < m; n++) {
     bands_gain_label.at(n)->set_text(level_to_localized_string(util::linear_to_db(values.at(n)), 0));
   }

--- a/src/multiband_gate.cpp
+++ b/src/multiband_gate.cpp
@@ -178,15 +178,17 @@ void MultibandGate::process(std::span<float>& left_in,
     notification_dt += sample_duration;
 
     if (notification_dt >= notification_time_window) {
-      float output0_value = lv2_wrapper->get_control_port_value("output0");
-      float output1_value = lv2_wrapper->get_control_port_value("output1");
-      float output2_value = lv2_wrapper->get_control_port_value("output2");
-      float output3_value = lv2_wrapper->get_control_port_value("output3");
+      // values needed as double for levelbars widget ui, so we convert them here
 
-      float gating0_value = lv2_wrapper->get_control_port_value("gating0");
-      float gating1_value = lv2_wrapper->get_control_port_value("gating1");
-      float gating2_value = lv2_wrapper->get_control_port_value("gating2");
-      float gating3_value = lv2_wrapper->get_control_port_value("gating3");
+      const double& output0_value = static_cast<double>(lv2_wrapper->get_control_port_value("output0"));
+      const double& output1_value = static_cast<double>(lv2_wrapper->get_control_port_value("output1"));
+      const double& output2_value = static_cast<double>(lv2_wrapper->get_control_port_value("output2"));
+      const double& output3_value = static_cast<double>(lv2_wrapper->get_control_port_value("output3"));
+
+      const double& gating0_value = static_cast<double>(lv2_wrapper->get_control_port_value("gating0"));
+      const double& gating1_value = static_cast<double>(lv2_wrapper->get_control_port_value("gating1"));
+      const double& gating2_value = static_cast<double>(lv2_wrapper->get_control_port_value("gating2"));
+      const double& gating3_value = static_cast<double>(lv2_wrapper->get_control_port_value("gating3"));
 
       Glib::signal_idle().connect_once([=, this] {
         output0.emit(output0_value);

--- a/src/multiband_gate_ui.cpp
+++ b/src/multiband_gate_ui.cpp
@@ -24,9 +24,9 @@ namespace {
 auto detection_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "RMS") == 0) {
+  if (g_strcmp0(v, "RMS") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Peak") == 0) {
+  } else if (g_strcmp0(v, "Peak") == 0) {
     g_value_set_int(value, 1);
   }
 
@@ -49,9 +49,9 @@ auto int_to_detection_enum(const GValue* value, const GVariantType* expected_typ
 auto mode_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "LR4") == 0) {
+  if (g_strcmp0(v, "LR4") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "LR8") == 0) {
+  } else if (g_strcmp0(v, "LR8") == 0) {
     g_value_set_int(value, 1);
   }
 
@@ -258,7 +258,7 @@ MultibandGateUi::~MultibandGateUi() {
 auto MultibandGateUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> MultibandGateUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/multiband_gate.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<MultibandGateUi>(
+  auto* const ui = Gtk::Builder::get_widget_derived<MultibandGateUi>(
       builder, "top_box", "com.github.wwmm.easyeffects.multibandgate", schema_path + "multibandgate/");
 
   stack->add(*ui, plugin_name::multiband_gate);
@@ -370,49 +370,49 @@ void MultibandGateUi::reset() {
   settings->reset("solo3");
 }
 
-void MultibandGateUi::on_new_output0(double value) {
+void MultibandGateUi::on_new_output0(const double& value) {
   output0->set_value(value);
 
   output0_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
-void MultibandGateUi::on_new_output1(double value) {
+void MultibandGateUi::on_new_output1(const double& value) {
   output1->set_value(value);
 
   output1_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
-void MultibandGateUi::on_new_output2(double value) {
+void MultibandGateUi::on_new_output2(const double& value) {
   output2->set_value(value);
 
   output2_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
-void MultibandGateUi::on_new_output3(double value) {
+void MultibandGateUi::on_new_output3(const double& value) {
   output3->set_value(value);
 
   output3_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
-void MultibandGateUi::on_new_gating0(double value) {
+void MultibandGateUi::on_new_gating0(const double& value) {
   gating0->set_value(1.0 - value);
 
   gating0_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
-void MultibandGateUi::on_new_gating1(double value) {
+void MultibandGateUi::on_new_gating1(const double& value) {
   gating1->set_value(1.0 - value);
 
   gating1_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
-void MultibandGateUi::on_new_gating2(double value) {
+void MultibandGateUi::on_new_gating2(const double& value) {
   gating2->set_value(1.0 - value);
 
   gating2_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));
 }
 
-void MultibandGateUi::on_new_gating3(double value) {
+void MultibandGateUi::on_new_gating3(const double& value) {
   gating3->set_value(1.0 - value);
 
   gating3_label->set_text(level_to_localized_string(util::linear_to_db(value), 0));

--- a/src/pipe_info_ui.cpp
+++ b/src/pipe_info_ui.cpp
@@ -127,13 +127,11 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
     auto holder_selected = std::dynamic_pointer_cast<NodeInfoHolder>(dropdown_input_devices->get_selected_item());
 
     if (holder_selected != nullptr) {
-      const auto& input_device_name = std::string(sie_settings->get_string("input-device"));
+      const auto* input_device_name = sie_settings->get_string("input-device").c_str();
 
       if (holder_selected->info.name != input_device_name) {
         for (guint n = 0U, m = input_devices_model->get_n_items(); n < m; n++) {
-          auto holder = input_devices_model->get_item(n);
-
-          if (holder->info.name == input_device_name) {
+          if (input_devices_model->get_item(n)->info.name == input_device_name) {
             dropdown_input_devices->set_selected(n);
           }
         }
@@ -145,13 +143,11 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
     auto holder_selected = std::dynamic_pointer_cast<NodeInfoHolder>(dropdown_output_devices->get_selected_item());
 
     if (holder_selected != nullptr) {
-      const auto& output_device_name = std::string(soe_settings->get_string("output-device"));
+      const auto* output_device_name = soe_settings->get_string("output-device").c_str();
 
       if (holder_selected->info.name != output_device_name) {
         for (guint n = 0U, m = output_devices_model->get_n_items(); n < m; n++) {
-          auto holder = output_devices_model->get_item(n);
-
-          if (holder->info.name == output_device_name) {
+          if (output_devices_model->get_item(n)->info.name == output_device_name) {
             dropdown_output_devices->set_selected(n);
           }
         }
@@ -170,9 +166,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
       if (holder != nullptr) {
         if (holder->info.name != pm->default_input_device.name) {
           for (guint n = 0U, m = input_devices_model->get_n_items(); n < m; n++) {
-            auto holder = input_devices_model->get_item(n);
-
-            if (holder->info.name == pm->default_input_device.name) {
+            if (input_devices_model->get_item(n)->info.name == pm->default_input_device.name) {
               dropdown_input_devices->set_selected(n);
 
               break;
@@ -192,9 +186,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
       if (holder_selected != nullptr) {
         if (holder_selected->info.name != pm->default_output_device.name) {
           for (guint n = 0U, m = output_devices_model->get_n_items(); n < m; n++) {
-            auto holder = output_devices_model->get_item(n);
-
-            if (holder->info.name == pm->default_output_device.name) {
+            if (output_devices_model->get_item(n)->info.name == pm->default_output_device.name) {
               dropdown_output_devices->set_selected(n);
 
               break;
@@ -228,7 +220,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
     // first we remove any autoloading profile associated to the target device so that our ui is updated
 
     for (guint n = 0; n < autoloading_output_model->get_n_items(); n++) {
-      auto item = autoloading_output_model->get_item(n);
+      const auto& item = autoloading_output_model->get_item(n);
 
       if (holder->info.name == item->device) {
         presets_manager->remove_autoload(PresetType::output, item->preset_name, item->device, item->device_profile);
@@ -239,8 +231,8 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
 
     const auto& id = dropdown_autoloading_output_presets->get_selected();
 
-    presets_manager->add_autoload(PresetType::output, output_presets_string_list->get_string(id), holder->info.name,
-                                  device_profile);
+    presets_manager->add_autoload(PresetType::output, output_presets_string_list->get_string(id).raw(),
+                                  holder->info.name, device_profile);
   });
 
   autoloading_add_input_profile->signal_clicked().connect([=, this]() {
@@ -263,7 +255,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
     // first we remove any autoloading profile associated to the target device so that our ui is updated
 
     for (guint n = 0; n < autoloading_input_model->get_n_items(); n++) {
-      auto item = autoloading_input_model->get_item(n);
+      const auto& item = autoloading_input_model->get_item(n);
 
       if (holder->info.name == item->device) {
         presets_manager->remove_autoload(PresetType::input, item->preset_name, item->device, item->device_profile);
@@ -274,8 +266,8 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
 
     const auto& id = dropdown_autoloading_input_presets->get_selected();
 
-    presets_manager->add_autoload(PresetType::input, input_presets_string_list->get_string(id), holder->info.name,
-                                  device_profile);
+    presets_manager->add_autoload(PresetType::input, input_presets_string_list->get_string(id).raw(),
+                                  holder->info.name, device_profile);
   });
 
   spinbutton_test_signal_frequency->signal_output().connect(
@@ -342,7 +334,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
   soe_settings->bind("use-default-output-device", dropdown_output_devices, "sensitive",
                      Gio::Settings::BindFlags::INVERT_BOOLEAN);
 
-  connections.emplace_back(pm->sink_added.connect([=, this](const NodeInfo& info) {
+  connections.emplace_back(pm->sink_added.connect([=, this](NodeInfo info) {
     for (guint n = 0U, m = output_devices_model->get_n_items(); n < m; n++) {
       if (output_devices_model->get_item(n)->info.id == info.id) {
         return;
@@ -352,7 +344,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
     output_devices_model->append(NodeInfoHolder::create(info));
   }));
 
-  connections.emplace_back(pm->sink_removed.connect([=, this](const NodeInfo& info) {
+  connections.emplace_back(pm->sink_removed.connect([=, this](NodeInfo info) {
     for (guint n = 0U, m = output_devices_model->get_n_items(); n < m; n++) {
       if (output_devices_model->get_item(n)->info.id == info.id) {
         output_devices_model->remove(n);
@@ -362,7 +354,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
     }
   }));
 
-  connections.emplace_back(pm->source_added.connect([=, this](const NodeInfo& info) {
+  connections.emplace_back(pm->source_added.connect([=, this](NodeInfo info) {
     for (guint n = 0U, m = input_devices_model->get_n_items(); n < m; n++) {
       if (input_devices_model->get_item(n)->info.id == info.id) {
         return;
@@ -372,7 +364,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
     input_devices_model->append(NodeInfoHolder::create(info));
   }));
 
-  connections.emplace_back(pm->source_removed.connect([=, this](const NodeInfo& info) {
+  connections.emplace_back(pm->source_removed.connect([=, this](NodeInfo info) {
     for (guint n = 0U, m = input_devices_model->get_n_items(); n < m; n++) {
       if (input_devices_model->get_item(n)->info.id == info.id) {
         input_devices_model->remove(n);
@@ -384,7 +376,13 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
 
   connections.emplace_back(
       presets_manager->user_output_preset_created.connect([=, this](const Glib::RefPtr<Gio::File>& file) {
-        const auto& preset_name = Glib::ustring(util::remove_filename_extension(file->get_basename()));
+        const auto& preset_name = util::remove_filename_extension(file->get_basename());
+
+        if (preset_name.empty()) {
+          util::warning("Can't retrieve information about the preset file");
+
+          return;
+        }
 
         for (guint n = 0, list_size = output_presets_string_list->get_n_items(); n < list_size; n++) {
           if (output_presets_string_list->get_string(n) == preset_name) {
@@ -397,7 +395,13 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
 
   connections.emplace_back(
       presets_manager->user_output_preset_removed.connect([=, this](const Glib::RefPtr<Gio::File>& file) {
-        const auto& preset_name = Glib::ustring(util::remove_filename_extension(file->get_basename()));
+        const auto& preset_name = util::remove_filename_extension(file->get_basename());
+
+        if (preset_name.empty()) {
+          util::warning("Can't retrieve information about the preset file");
+
+          return;
+        }
 
         for (guint n = 0, list_size = output_presets_string_list->get_n_items(); n < list_size; n++) {
           if (output_presets_string_list->get_string(n) == preset_name) {
@@ -410,7 +414,13 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
 
   connections.emplace_back(
       presets_manager->user_input_preset_created.connect([=, this](const Glib::RefPtr<Gio::File>& file) {
-        const auto& preset_name = Glib::ustring(util::remove_filename_extension(file->get_basename()));
+        const auto& preset_name = util::remove_filename_extension(file->get_basename());
+
+        if (preset_name.empty()) {
+          util::warning("Can't retrieve information about the preset file");
+
+          return;
+        }
 
         for (guint n = 0, list_size = input_presets_string_list->get_n_items(); n < list_size; n++) {
           if (input_presets_string_list->get_string(n) == preset_name) {
@@ -423,7 +433,13 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
 
   connections.emplace_back(
       presets_manager->user_input_preset_removed.connect([=, this](const Glib::RefPtr<Gio::File>& file) {
-        const auto& preset_name = Glib::ustring(util::remove_filename_extension(file->get_basename()));
+        const auto& preset_name = util::remove_filename_extension(file->get_basename());
+
+        if (preset_name.empty()) {
+          util::warning("Can't retrieve information about the preset file");
+
+          return;
+        }
 
         for (guint n = 0, list_size = input_presets_string_list->get_n_items(); n < list_size; n++) {
           if (input_presets_string_list->get_string(n) == preset_name) {
@@ -439,9 +455,9 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
         std::vector<Glib::RefPtr<PresetsAutoloadingHolder>> list;
 
         for (const auto& json : profiles) {
-          std::string device = json.value("device", "");
-          std::string device_profile = json.value("device-profile", "");
-          std::string preset_name = json.value("preset-name", "");
+          const auto& device = json.value("device", "");
+          const auto& device_profile = json.value("device-profile", "");
+          const auto& preset_name = json.value("preset-name", "");
 
           list.emplace_back(PresetsAutoloadingHolder::create(device, device_profile, preset_name));
         }
@@ -454,9 +470,9 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
         std::vector<Glib::RefPtr<PresetsAutoloadingHolder>> list;
 
         for (const auto& json : profiles) {
-          std::string device = json.value("device", "");
-          std::string device_profile = json.value("device-profile", "");
-          std::string preset_name = json.value("preset-name", "");
+          const auto& device = json.value("device", "");
+          const auto& device_profile = json.value("device-profile", "");
+          const auto& preset_name = json.value("preset-name", "");
 
           list.emplace_back(PresetsAutoloadingHolder::create(device, device_profile, preset_name));
         }
@@ -486,7 +502,7 @@ PipeInfoUi::~PipeInfoUi() {
 auto PipeInfoUi::add_to_stack(Gtk::Stack* stack, PipeManager* pm, PresetsManager* presets_manager) -> PipeInfoUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/pipe_info.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<PipeInfoUi>(builder, "top_box", pm, presets_manager);
+  auto* const ui = Gtk::Builder::get_widget_derived<PipeInfoUi>(builder, "top_box", pm, presets_manager);
 
   stack->add(*ui, "pipe_info");
 
@@ -497,7 +513,7 @@ void PipeInfoUi::setup_dropdown_devices(Gtk::DropDown* dropdown,
                                         const Glib::RefPtr<Gio::ListStore<NodeInfoHolder>>& model) {
   // setting the dropdown model and factory
 
-  auto selection_model = Gtk::SingleSelection::create(model);
+  const auto& selection_model = Gtk::SingleSelection::create(model);
 
   dropdown->set_model(selection_model);
 
@@ -508,9 +524,9 @@ void PipeInfoUi::setup_dropdown_devices(Gtk::DropDown* dropdown,
   // setting the factory callbacks
 
   factory->signal_setup().connect([=](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* box = Gtk::make_managed<Gtk::Box>();
-    auto* label = Gtk::make_managed<Gtk::Label>();
-    auto* icon = Gtk::make_managed<Gtk::Image>();
+    auto* const box = Gtk::make_managed<Gtk::Box>();
+    auto* const label = Gtk::make_managed<Gtk::Label>();
+    auto* const icon = Gtk::make_managed<Gtk::Image>();
 
     label->set_hexpand(true);
     label->set_halign(Gtk::Align::START);
@@ -530,8 +546,8 @@ void PipeInfoUi::setup_dropdown_devices(Gtk::DropDown* dropdown,
   });
 
   factory->signal_bind().connect([=](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* label = static_cast<Gtk::Label*>(list_item->get_data("name"));
-    auto* icon = static_cast<Gtk::Image*>(list_item->get_data("icon"));
+    auto* const label = static_cast<Gtk::Label*>(list_item->get_data("name"));
+    auto* const icon = static_cast<Gtk::Image*>(list_item->get_data("icon"));
 
     auto holder = std::dynamic_pointer_cast<NodeInfoHolder>(list_item->get_item());
 
@@ -568,14 +584,14 @@ void PipeInfoUi::setup_dropdown_presets(PresetType preset_type, const Glib::RefP
 
   // sorter
 
-  auto sorter =
+  const auto& sorter =
       Gtk::StringSorter::create(Gtk::PropertyExpression<Glib::ustring>::create(GTK_TYPE_STRING_OBJECT, "string"));
 
-  auto sort_list_model = Gtk::SortListModel::create(string_list, sorter);
+  const auto& sort_list_model = Gtk::SortListModel::create(string_list, sorter);
 
   // setting the dropdown model and factory
 
-  auto selection_model = Gtk::SingleSelection::create(sort_list_model);
+  const auto& selection_model = Gtk::SingleSelection::create(sort_list_model);
 
   dropdown->set_model(selection_model);
 
@@ -586,9 +602,9 @@ void PipeInfoUi::setup_dropdown_presets(PresetType preset_type, const Glib::RefP
   // setting the factory callbacks
 
   factory->signal_setup().connect([=](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* box = Gtk::make_managed<Gtk::Box>();
-    auto* label = Gtk::make_managed<Gtk::Label>();
-    auto* icon = Gtk::make_managed<Gtk::Image>();
+    auto* const box = Gtk::make_managed<Gtk::Box>();
+    auto* const label = Gtk::make_managed<Gtk::Label>();
+    auto* const icon = Gtk::make_managed<Gtk::Image>();
 
     label->set_hexpand(true);
     label->set_halign(Gtk::Align::START);
@@ -607,7 +623,7 @@ void PipeInfoUi::setup_dropdown_presets(PresetType preset_type, const Glib::RefP
   });
 
   factory->signal_bind().connect([=](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* label = static_cast<Gtk::Label*>(list_item->get_data("name"));
+    auto* const label = static_cast<Gtk::Label*>(list_item->get_data("name"));
 
     const auto& name = list_item->get_item()->get_property<Glib::ustring>("string");
 
@@ -619,12 +635,12 @@ void PipeInfoUi::setup_dropdown_presets(PresetType preset_type, const Glib::RefP
 void PipeInfoUi::setup_listview_autoloading(PresetType preset_type,
                                             Gtk::ListView* listview,
                                             const Glib::RefPtr<Gio::ListStore<PresetsAutoloadingHolder>>& model) {
-  auto profiles = presets_manager->get_autoload_profiles(preset_type);
+  const auto& profiles = presets_manager->get_autoload_profiles(preset_type);
 
   for (const auto& json : profiles) {
-    std::string device = json.value("device", "");
-    std::string device_profile = json.value("device-profile", "");
-    std::string preset_name = json.value("preset-name", "");
+    const auto& device = json.value("device", "");
+    const auto& device_profile = json.value("device-profile", "");
+    const auto& preset_name = json.value("preset-name", "");
 
     model->append(PresetsAutoloadingHolder::create(device, device_profile, preset_name));
   }
@@ -642,7 +658,7 @@ void PipeInfoUi::setup_listview_autoloading(PresetType preset_type,
   factory->signal_setup().connect([=](const Glib::RefPtr<Gtk::ListItem>& list_item) {
     const auto& b = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/autoload_row.ui");
 
-    auto* top_box = b->get_widget<Gtk::Box>("top_box");
+    auto* const top_box = b->get_widget<Gtk::Box>("top_box");
 
     list_item->set_data("device", b->get_widget<Gtk::Label>("device"));
     list_item->set_data("device_profile", b->get_widget<Gtk::Label>("device_profile"));
@@ -653,10 +669,10 @@ void PipeInfoUi::setup_listview_autoloading(PresetType preset_type,
   });
 
   factory->signal_bind().connect([=, this](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* device = static_cast<Gtk::Label*>(list_item->get_data("device"));
-    auto* device_profile = static_cast<Gtk::Label*>(list_item->get_data("device_profile"));
-    auto* preset_name = static_cast<Gtk::Label*>(list_item->get_data("preset_name"));
-    auto* remove = static_cast<Gtk::Button*>(list_item->get_data("remove"));
+    auto* const device = static_cast<Gtk::Label*>(list_item->get_data("device"));
+    auto* const device_profile = static_cast<Gtk::Label*>(list_item->get_data("device_profile"));
+    auto* const preset_name = static_cast<Gtk::Label*>(list_item->get_data("preset_name"));
+    auto* const remove = static_cast<Gtk::Button*>(list_item->get_data("remove"));
 
     auto holder = std::dynamic_pointer_cast<PresetsAutoloadingHolder>(list_item->get_item());
 
@@ -695,7 +711,7 @@ void PipeInfoUi::setup_listview_modules() {
   factory->signal_setup().connect([](const Glib::RefPtr<Gtk::ListItem>& list_item) {
     const auto& b = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/module_info.ui");
 
-    auto* top_box = b->get_widget<Gtk::Box>("top_box");
+    auto* const top_box = b->get_widget<Gtk::Box>("top_box");
 
     list_item->set_data("id", b->get_widget<Gtk::Label>("id"));
     list_item->set_data("name", b->get_widget<Gtk::Label>("name"));
@@ -705,13 +721,13 @@ void PipeInfoUi::setup_listview_modules() {
   });
 
   factory->signal_bind().connect([](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* id = static_cast<Gtk::Label*>(list_item->get_data("id"));
-    auto* name = static_cast<Gtk::Label*>(list_item->get_data("name"));
-    auto* description = static_cast<Gtk::Label*>(list_item->get_data("description"));
+    auto* const id = static_cast<Gtk::Label*>(list_item->get_data("id"));
+    auto* const name = static_cast<Gtk::Label*>(list_item->get_data("name"));
+    auto* const description = static_cast<Gtk::Label*>(list_item->get_data("description"));
 
     auto holder = std::dynamic_pointer_cast<ModuleInfoHolder>(list_item->get_item());
 
-    id->set_text(std::to_string(holder->info.id));
+    id->set_text(Glib::ustring::format(holder->info.id));
     name->set_text(holder->info.name);
     description->set_text(holder->info.description);
   });
@@ -731,7 +747,7 @@ void PipeInfoUi::setup_listview_clients() {
   factory->signal_setup().connect([](const Glib::RefPtr<Gtk::ListItem>& list_item) {
     const auto& b = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/client_info.ui");
 
-    auto* top_box = b->get_widget<Gtk::Box>("top_box");
+    auto* const top_box = b->get_widget<Gtk::Box>("top_box");
 
     list_item->set_data("id", b->get_widget<Gtk::Label>("id"));
     list_item->set_data("name", b->get_widget<Gtk::Label>("name"));
@@ -742,14 +758,14 @@ void PipeInfoUi::setup_listview_clients() {
   });
 
   factory->signal_bind().connect([](const Glib::RefPtr<Gtk::ListItem>& list_item) {
-    auto* id = static_cast<Gtk::Label*>(list_item->get_data("id"));
-    auto* name = static_cast<Gtk::Label*>(list_item->get_data("name"));
-    auto* api = static_cast<Gtk::Label*>(list_item->get_data("api"));
-    auto* access = static_cast<Gtk::Label*>(list_item->get_data("access"));
+    auto* const id = static_cast<Gtk::Label*>(list_item->get_data("id"));
+    auto* const name = static_cast<Gtk::Label*>(list_item->get_data("name"));
+    auto* const api = static_cast<Gtk::Label*>(list_item->get_data("api"));
+    auto* const access = static_cast<Gtk::Label*>(list_item->get_data("access"));
 
     auto holder = std::dynamic_pointer_cast<ClientInfoHolder>(list_item->get_item());
 
-    id->set_text(std::to_string(holder->info.id));
+    id->set_text(Glib::ustring::format(holder->info.id));
     name->set_text(holder->info.name);
     api->set_text(holder->info.api);
     access->set_text(holder->info.access);

--- a/src/pipe_info_ui.cpp
+++ b/src/pipe_info_ui.cpp
@@ -384,10 +384,10 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
 
   connections.emplace_back(
       presets_manager->user_output_preset_created.connect([=, this](const Glib::RefPtr<Gio::File>& file) {
-        auto preset_name = util::remove_filename_extension(file->get_basename());
+        const auto& preset_name = Glib::ustring(util::remove_filename_extension(file->get_basename()));
 
-        for (guint n = 0; n < output_presets_string_list->get_n_items(); n++) {
-          if (preset_name == std::string(output_presets_string_list->get_string(n))) {
+        for (guint n = 0, list_size = output_presets_string_list->get_n_items(); n < list_size; n++) {
+          if (output_presets_string_list->get_string(n) == preset_name) {
             return;
           }
         }
@@ -397,12 +397,11 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
 
   connections.emplace_back(
       presets_manager->user_output_preset_removed.connect([=, this](const Glib::RefPtr<Gio::File>& file) {
-        int count = 0;
+        const auto& preset_name = Glib::ustring(util::remove_filename_extension(file->get_basename()));
 
-        for (auto name = output_presets_string_list->get_string(count); name.c_str() != nullptr;
-             name = output_presets_string_list->get_string(++count)) {
-          if (util::remove_filename_extension(file->get_basename()) == std::string(name)) {
-            output_presets_string_list->remove(count);
+        for (guint n = 0, list_size = output_presets_string_list->get_n_items(); n < list_size; n++) {
+          if (output_presets_string_list->get_string(n) == preset_name) {
+            output_presets_string_list->remove(n);
 
             return;
           }
@@ -411,10 +410,10 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
 
   connections.emplace_back(
       presets_manager->user_input_preset_created.connect([=, this](const Glib::RefPtr<Gio::File>& file) {
-        auto preset_name = util::remove_filename_extension(file->get_basename());
+        const auto& preset_name = Glib::ustring(util::remove_filename_extension(file->get_basename()));
 
-        for (guint n = 0; n < input_presets_string_list->get_n_items(); n++) {
-          if (preset_name == std::string(input_presets_string_list->get_string(n))) {
+        for (guint n = 0, list_size = input_presets_string_list->get_n_items(); n < list_size; n++) {
+          if (input_presets_string_list->get_string(n) == preset_name) {
             return;
           }
         }
@@ -424,12 +423,11 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
 
   connections.emplace_back(
       presets_manager->user_input_preset_removed.connect([=, this](const Glib::RefPtr<Gio::File>& file) {
-        int count = 0;
+        const auto& preset_name = Glib::ustring(util::remove_filename_extension(file->get_basename()));
 
-        for (auto name = input_presets_string_list->get_string(count); name.c_str() != nullptr;
-             name = input_presets_string_list->get_string(++count)) {
-          if (util::remove_filename_extension(file->get_basename()) == std::string(name)) {
-            input_presets_string_list->remove(count);
+        for (guint n = 0, list_size = input_presets_string_list->get_n_items(); n < list_size; n++) {
+          if (input_presets_string_list->get_string(n) == preset_name) {
+            input_presets_string_list->remove(n);
 
             return;
           }

--- a/src/pitch.cpp
+++ b/src/pitch.cpp
@@ -181,7 +181,7 @@ void Pitch::process(std::span<float>& left_in,
       deque_out_R.pop_front();
     }
   } else {
-    uint offset = left_out.size() - deque_out_L.size();
+    const uint offset = left_out.size() - deque_out_L.size();
 
     if (offset != latency_n_frames) {
       latency_n_frames = offset;
@@ -206,7 +206,7 @@ void Pitch::process(std::span<float>& left_in,
   apply_gain(left_out, right_out, output_gain);
 
   if (notify_latency) {
-    float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
     util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
 
@@ -304,9 +304,9 @@ void Pitch::update_pitch_scale() {
     return;
   }
 
-  double n_octaves = octaves + static_cast<double>(semitones) / 12.0 + static_cast<double>(cents) / 1200.0;
+  const double n_octaves = octaves + static_cast<double>(semitones) / 12.0 + static_cast<double>(cents) / 1200.0;
 
-  double ratio = std::pow(2, n_octaves);
+  const double ratio = std::pow(2.0, n_octaves);
 
   stretcher->setPitchScale(ratio);
 }

--- a/src/pitch_ui.cpp
+++ b/src/pitch_ui.cpp
@@ -61,7 +61,7 @@ PitchUi::~PitchUi() {
 auto PitchUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> PitchUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/pitch.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<PitchUi>(builder, "top_box", "com.github.wwmm.easyeffects.pitch",
+  auto* const ui = Gtk::Builder::get_widget_derived<PitchUi>(builder, "top_box", "com.github.wwmm.easyeffects.pitch",
                                                        schema_path + "pitch/");
 
   stack->add(*ui, plugin_name::pitch);

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -38,8 +38,8 @@ Plot::Plot(Gtk::DrawingArea* drawing_area)
     if (const auto& usable_height = height - x_axis_height; y < usable_height) {
       switch (plot_scale) {
         case PlotScale::logarithmic: {
-          const double& x_min_log = log10(x_min);
-          const double& x_max_log = log10(x_max);
+          const double& x_min_log = std::log10(x_min);
+          const double& x_max_log = std::log10(x_max);
 
           const double& mouse_x_log = x / static_cast<double>(width) * (x_max_log - x_min_log) + x_min_log;
 
@@ -147,11 +147,11 @@ void Plot::set_n_y_decimals(const int& v) {
   n_y_decimals = v;
 }
 
-void Plot::set_x_unit(const std::string& value) {
+void Plot::set_x_unit(const Glib::ustring& value) {
   x_unit = value;
 }
 
-void Plot::set_y_unit(const std::string& value) {
+void Plot::set_y_unit(const Glib::ustring& value) {
   y_unit = value;
 }
 
@@ -211,8 +211,9 @@ void Plot::on_draw(const Cairo::RefPtr<Cairo::Context>& ctx, const int& width, c
     }
 
     if (controller_motion->contains_pointer()) {
-      const auto& msg = "x = " + value_to_localized_string(mouse_x, n_x_decimals) + " " + x_unit +
-                 "  y = " + value_to_localized_string(mouse_y, n_y_decimals) + " " + y_unit;
+      const auto& msg = "x = " + Glib::ustring::format(std::setprecision(n_x_decimals), std::fixed, mouse_x) +
+                        " " + x_unit + "  y = " +
+                        Glib::ustring::format(std::setprecision(n_y_decimals), std::fixed, mouse_y) + " " + y_unit;
 
       Pango::FontDescription font;
       font.set_family("Monospace");
@@ -232,13 +233,13 @@ void Plot::on_draw(const Cairo::RefPtr<Cairo::Context>& ctx, const int& width, c
 }
 
 auto Plot::draw_x_labels(const Cairo::RefPtr<Cairo::Context>& ctx, const int& width, const int& height) -> int {
-  double labels_offset = width / static_cast<double>(n_x_labels);
+  const double labels_offset = width / static_cast<double>(n_x_labels);
 
   std::vector<float> labels;
 
   switch (plot_scale) {
     case PlotScale::logarithmic: {
-      labels = util::logspace(log10f(static_cast<float>(x_min)), log10f(static_cast<float>(x_max)), n_x_labels);
+      labels = util::logspace(std::log10(static_cast<float>(x_min)), std::log10(static_cast<float>(x_max)), n_x_labels);
 
       break;
     }
@@ -258,7 +259,7 @@ auto Plot::draw_x_labels(const Cairo::RefPtr<Cairo::Context>& ctx, const int& wi
   */
 
   for (size_t n = 0U, m = labels.size(); n < m - 1U; n++) {
-    const auto& msg = value_to_localized_string(labels[n], n_x_decimals) + " " + x_unit;
+    const auto& msg = Glib::ustring::format(std::setprecision(n_x_decimals), std::fixed, labels[n]) + " " + x_unit;
 
     Pango::FontDescription font;
     font.set_family("Monospace");

--- a/src/plugin_base.cpp
+++ b/src/plugin_base.cpp
@@ -179,7 +179,7 @@ PluginBase::~PluginBase() {
 }
 
 auto PluginBase::connect_to_pw() -> bool {
-  bool success = false;
+  auto success = false;
 
   pw_thread_loop_lock(pm->thread_loop);
 
@@ -287,14 +287,18 @@ void PluginBase::apply_gain(std::span<float>& left, std::span<float>& right, con
 }
 
 void PluginBase::notify() {
-  float input_peak_db_l = util::linear_to_db(input_peak_left);
-  float input_peak_db_r = util::linear_to_db(input_peak_right);
+  const auto& input_peak_db_l = util::linear_to_db(input_peak_left);
+  const auto& input_peak_db_r = util::linear_to_db(input_peak_right);
 
-  float output_peak_db_l = util::linear_to_db(output_peak_left);
-  float output_peak_db_r = util::linear_to_db(output_peak_right);
+  const auto& output_peak_db_l = util::linear_to_db(output_peak_left);
+  const auto& output_peak_db_r = util::linear_to_db(output_peak_right);
 
-  Glib::signal_idle().connect_once([=, this] { input_level.emit(input_peak_db_l, input_peak_db_r); });
-  Glib::signal_idle().connect_once([=, this] { output_level.emit(output_peak_db_l, output_peak_db_r); });
+  Glib::signal_idle().connect_once([=, this] {
+    input_level.emit(input_peak_db_l, input_peak_db_r);
+  });
+  Glib::signal_idle().connect_once([=, this] {
+    output_level.emit(output_peak_db_l, output_peak_db_r);
+  });
 
   input_peak_left = util::minimum_linear_level;
   input_peak_right = util::minimum_linear_level;

--- a/src/plugin_ui_base.cpp
+++ b/src/plugin_ui_base.cpp
@@ -55,7 +55,7 @@ void PluginUiBase::on_new_output_level(const float& left, const float& right) {
   update_level(output_level_left, output_level_left_label, output_level_right, output_level_right_label, left, right);
 }
 
-void PluginUiBase::prepare_spinbutton(Gtk::SpinButton* button, const std::string& unit) {
+void PluginUiBase::prepare_spinbutton(Gtk::SpinButton* button, const Glib::ustring& unit) {
   button->signal_output().connect([=]() { return parse_spinbutton_output(button, unit); }, true);
   button->signal_input().connect([=](double& new_value) { return parse_spinbutton_input(button, new_value); }, true);
 }
@@ -63,15 +63,7 @@ void PluginUiBase::prepare_spinbutton(Gtk::SpinButton* button, const std::string
 auto PluginUiBase::string_to_float(const std::string& value) -> float {
   // this conversion must be locale independent
 
-  std::stringstream ss;
-  ss.imbue(std::locale::classic());
-
-  float fv = 0.0F;
-
-  ss << value;
-  ss >> fv;
-
-  return fv;
+  return std::stof(value);
 }
 
 void PluginUiBase::set_transient_window(Gtk::Window* transient_window) {

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -229,7 +229,7 @@ auto PresetsManager::search_names(std::filesystem::directory_iterator& it) -> st
         }
       }
 
-      it++;
+      ++it;
     }
   } catch (std::exception& e) {
     util::warning(e.what());
@@ -752,7 +752,7 @@ auto PresetsManager::get_autoload_profiles(const PresetType& preset_type) -> std
         }
       }
 
-      it++;
+      ++it;
     }
 
     return list;

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -184,9 +184,10 @@ void PresetsManager::create_user_directory(const std::filesystem::path& path) {
 auto PresetsManager::get_names(const PresetType& preset_type) -> std::vector<Glib::ustring> {
   std::filesystem::directory_iterator it;
   std::vector<Glib::ustring> names;
-  std::vector<std::filesystem::path> sys_dirs;
 
   // system directories search
+  std::vector<std::filesystem::path> sys_dirs;
+
   switch (preset_type) {
     case PresetType::output:
       sys_dirs.insert(sys_dirs.end(), system_output_dir.begin(), system_output_dir.end());
@@ -199,6 +200,7 @@ auto PresetsManager::get_names(const PresetType& preset_type) -> std::vector<Gli
   for (const auto& dir : sys_dirs) {
     if (std::filesystem::exists(dir)) {
       it = std::filesystem::directory_iterator{dir};
+
       const auto& vn = search_names(it);
       names.insert(names.end(), vn.begin(), vn.end());
     }
@@ -218,20 +220,22 @@ auto PresetsManager::get_names(const PresetType& preset_type) -> std::vector<Gli
   return names;
 }
 
-auto PresetsManager::search_names(std::filesystem::directory_iterator& it) -> std::vector<std::string> {
-  std::vector<std::string> names;
+auto PresetsManager::search_names(std::filesystem::directory_iterator& it) -> std::vector<Glib::ustring> {
+  std::vector<Glib::ustring> names;
+
+  const std::string json_ext = ".json";
 
   try {
     while (it != std::filesystem::directory_iterator{}) {
       if (std::filesystem::is_regular_file(it->status())) {
-        if (it->path().extension().string() == ".json") {
-          names.emplace_back(it->path().stem().string());
+        if (it->path().extension().c_str() == json_ext) {
+          names.emplace_back(it->path().stem().c_str());
         }
       }
 
       ++it;
     }
-  } catch (std::exception& e) {
+  } catch (const std::exception& e) {
     util::warning(e.what());
   }
 
@@ -254,7 +258,7 @@ void PresetsManager::save_blocklist(const PresetType& preset_type, nlohmann::jso
   switch (preset_type) {
     case PresetType::output: {
       for (const auto& l : soe_settings->get_string_array("blocklist")) {
-        blocklist.emplace_back(l);
+        blocklist.emplace_back(l.c_str());
       }
 
       json["output"]["blocklist"] = blocklist;
@@ -263,7 +267,7 @@ void PresetsManager::save_blocklist(const PresetType& preset_type, nlohmann::jso
     }
     case PresetType::input: {
       for (const auto& l : sie_settings->get_string_array("blocklist")) {
-        blocklist.emplace_back(l);
+        blocklist.emplace_back(l.c_str());
       }
 
       json["input"]["blocklist"] = blocklist;
@@ -310,7 +314,7 @@ void PresetsManager::load_blocklist(const PresetType& preset_type, const nlohman
   }
 }
 
-void PresetsManager::save_preset_file(const PresetType& preset_type, const std::string& name) {
+void PresetsManager::save_preset_file(const PresetType& preset_type, const Glib::ustring& name) {
   nlohmann::json json;
 
   std::filesystem::path output_file;
@@ -326,14 +330,14 @@ void PresetsManager::save_preset_file(const PresetType& preset_type, const std::
       list.reserve(plugins.size());
 
       for (const auto& p : plugins) {
-        list.emplace_back(p);
+        list.emplace_back(p.raw());
       }
 
       json["output"]["plugins_order"] = list;
 
       write_plugins_preset(preset_type, plugins, json);
 
-      output_file = user_output_dir / std::filesystem::path{name + ".json"};
+      output_file = user_output_dir / std::filesystem::path{name.c_str() + json_ext};
 
       break;
     }
@@ -345,20 +349,20 @@ void PresetsManager::save_preset_file(const PresetType& preset_type, const std::
       list.reserve(plugins.size());
 
       for (const auto& p : plugins) {
-        list.emplace_back(p);
+        list.emplace_back(p.raw());
       }
 
       json["input"]["plugins_order"] = list;
 
       write_plugins_preset(preset_type, plugins, json);
 
-      output_file = user_input_dir / std::filesystem::path{name + ".json"};
+      output_file = user_input_dir / std::filesystem::path{name.c_str() + json_ext};
 
       break;
     }
   }
 
-  std::ofstream o(output_file.string());
+  std::ofstream o(output_file.c_str());
 
   o << std::setw(4) << json << std::endl;
 
@@ -420,12 +424,12 @@ void PresetsManager::write_plugins_preset(const PresetType& preset_type, const s
   }
 }
 
-void PresetsManager::remove(const PresetType& preset_type, const std::string& name) {
+void PresetsManager::remove(const PresetType& preset_type, const Glib::ustring& name) {
   std::filesystem::path preset_file;
 
   const auto& user_dir = (preset_type == PresetType::output) ? user_output_dir : user_input_dir;
 
-  preset_file = user_dir / std::filesystem::path{name + ".json"};
+  preset_file = user_dir / std::filesystem::path{name.c_str() + json_ext};
 
   if (std::filesystem::exists(preset_file)) {
     std::filesystem::remove(preset_file);
@@ -434,7 +438,7 @@ void PresetsManager::remove(const PresetType& preset_type, const std::string& na
   }
 }
 
-void PresetsManager::load_preset_file(const PresetType& preset_type, const std::string& name) {
+void PresetsManager::load_preset_file(const PresetType& preset_type, const Glib::ustring& name) {
   nlohmann::json json;
 
   std::vector<Glib::ustring> plugins;
@@ -443,7 +447,7 @@ void PresetsManager::load_preset_file(const PresetType& preset_type, const std::
 
   std::filesystem::path input_file;
 
-  bool preset_found = false;
+  auto preset_found = false;
 
   switch (preset_type) {
     case PresetType::output: {
@@ -452,7 +456,7 @@ void PresetsManager::load_preset_file(const PresetType& preset_type, const std::
       conf_dirs.insert(conf_dirs.end(), system_output_dir.begin(), system_output_dir.end());
 
       for (const auto& dir : conf_dirs) {
-        input_file = dir / std::filesystem::path{name + ".json"};
+        input_file = dir / std::filesystem::path{name.c_str() + json_ext};
 
         if (std::filesystem::exists(input_file)) {
           preset_found = true;
@@ -496,7 +500,7 @@ void PresetsManager::load_preset_file(const PresetType& preset_type, const std::
       conf_dirs.insert(conf_dirs.end(), system_input_dir.begin(), system_input_dir.end());
 
       for (const auto& dir : conf_dirs) {
-        input_file = dir / std::filesystem::path{name + ".json"};
+        input_file = dir / std::filesystem::path{name.c_str() + json_ext};
 
         if (std::filesystem::exists(input_file)) {
           preset_found = true;
@@ -600,7 +604,7 @@ void PresetsManager::import(const PresetType& preset_type, const std::string& fi
   std::filesystem::path p{file_path};
 
   if (std::filesystem::is_regular_file(p)) {
-    if (p.extension().string() == ".json") {
+    if (p.extension().c_str() == json_ext) {
       std::filesystem::path out_path;
 
       const auto& user_dir = (preset_type == PresetType::output) ? user_output_dir : user_input_dir;
@@ -626,14 +630,14 @@ void PresetsManager::add_autoload(const PresetType& preset_type,
 
   switch (preset_type) {
     case PresetType::output:
-      output_file = autoload_output_dir / std::filesystem::path{device_name + ":" + device_profile + ".json"};
+      output_file = autoload_output_dir / std::filesystem::path{device_name + ":" + device_profile + json_ext};
       break;
     case PresetType::input:
-      output_file = autoload_input_dir / std::filesystem::path{device_name + ":" + device_profile + ".json"};
+      output_file = autoload_input_dir / std::filesystem::path{device_name + ":" + device_profile + json_ext};
       break;
   }
 
-  std::ofstream o(output_file.string());
+  std::ofstream o(output_file.c_str());
 
   json["device"] = device_name;
   json["device-profile"] = device_profile;
@@ -652,10 +656,10 @@ void PresetsManager::remove_autoload(const PresetType& preset_type,
 
   switch (preset_type) {
     case PresetType::output:
-      input_file = autoload_output_dir / std::filesystem::path{device_name + ":" + device_profile + ".json"};
+      input_file = autoload_output_dir / std::filesystem::path{device_name + ":" + device_profile + json_ext};
       break;
     case PresetType::input:
-      input_file = autoload_input_dir / std::filesystem::path{device_name + ":" + device_profile + ".json"};
+      input_file = autoload_input_dir / std::filesystem::path{device_name + ":" + device_profile + json_ext};
       break;
   }
 
@@ -676,15 +680,15 @@ void PresetsManager::remove_autoload(const PresetType& preset_type,
 
 auto PresetsManager::find_autoload(const PresetType& preset_type,
                                    const std::string& device_name,
-                                   const std::string& device_profile) -> std::string {
+                                   const std::string& device_profile) -> Glib::ustring {
   std::filesystem::path input_file;
 
   switch (preset_type) {
     case PresetType::output:
-      input_file = autoload_output_dir / std::filesystem::path{device_name + ":" + device_profile + ".json"};
+      input_file = autoload_output_dir / std::filesystem::path{device_name + ":" + device_profile + json_ext};
       break;
     case PresetType::input:
-      input_file = autoload_input_dir / std::filesystem::path{device_name + ":" + device_profile + ".json"};
+      input_file = autoload_input_dir / std::filesystem::path{device_name + ":" + device_profile + json_ext};
       break;
   }
 
@@ -741,7 +745,7 @@ auto PresetsManager::get_autoload_profiles(const PresetType& preset_type) -> std
   try {
     while (it != std::filesystem::directory_iterator{}) {
       if (std::filesystem::is_regular_file(it->status())) {
-        if (it->path().extension().string() == ".json") {
+        if (it->path().extension().c_str() == json_ext) {
           nlohmann::json json;
 
           std::ifstream is(autoload_dir / it->path());
@@ -756,14 +760,14 @@ auto PresetsManager::get_autoload_profiles(const PresetType& preset_type) -> std
     }
 
     return list;
-  } catch (std::exception& e) {
+  } catch (const std::exception& e) {
     util::warning(log_tag + e.what());
 
     return list;
   }
 }
 
-auto PresetsManager::preset_file_exists(const PresetType& preset_type, const std::string& name) -> bool {
+auto PresetsManager::preset_file_exists(const PresetType& preset_type, const Glib::ustring& name) -> bool {
   std::filesystem::path input_file;
   std::vector<std::filesystem::path> conf_dirs;
 
@@ -774,7 +778,7 @@ auto PresetsManager::preset_file_exists(const PresetType& preset_type, const std
       conf_dirs.insert(conf_dirs.end(), system_output_dir.begin(), system_output_dir.end());
 
       for (const auto& dir : conf_dirs) {
-        input_file = dir / std::filesystem::path{name + ".json"};
+        input_file = dir / std::filesystem::path{name.c_str() + json_ext};
 
         if (std::filesystem::exists(input_file)) {
           return true;
@@ -789,7 +793,7 @@ auto PresetsManager::preset_file_exists(const PresetType& preset_type, const std
       conf_dirs.insert(conf_dirs.end(), system_input_dir.begin(), system_input_dir.end());
 
       for (const auto& dir : conf_dirs) {
-        input_file = dir / std::filesystem::path{name + ".json"};
+        input_file = dir / std::filesystem::path{name.c_str() + json_ext};
 
         if (std::filesystem::exists(input_file)) {
           return true;

--- a/src/presets_menu_ui.cpp
+++ b/src/presets_menu_ui.cpp
@@ -92,10 +92,10 @@ PresetsMenuUi::PresetsMenuUi(BaseObjectType* cobject,
   });
 
   app->presets_manager->user_output_preset_created.connect([=, this](const Glib::RefPtr<Gio::File>& file) {
-    auto preset_name = util::remove_filename_extension(file->get_basename());
+    const auto& preset_name = Glib::ustring(util::remove_filename_extension(file->get_basename()));
 
-    for (guint n = 0; n < output_string_list->get_n_items(); n++) {
-      if (preset_name == std::string(output_string_list->get_string(n))) {
+    for (guint n = 0, list_size = output_string_list->get_n_items(); n < list_size; n++) {
+      if (output_string_list->get_string(n) == preset_name) {
         return;
       }
     }
@@ -104,23 +104,22 @@ PresetsMenuUi::PresetsMenuUi(BaseObjectType* cobject,
   });
 
   app->presets_manager->user_output_preset_removed.connect([=, this](const Glib::RefPtr<Gio::File>& file) {
-    int count = 0;
+    const auto& preset_name = Glib::ustring(util::remove_filename_extension(file->get_basename()));
 
-    for (auto name = output_string_list->get_string(count); name.c_str() != nullptr;) {
-      if (util::remove_filename_extension(file->get_basename()) == std::string(name)) {
-        output_string_list->remove(count);
+    for (guint n = 0, list_size = output_string_list->get_n_items(); n < list_size; n++) {
+      if (output_string_list->get_string(n) == preset_name) {
+        output_string_list->remove(n);
+
         return;
       }
-
-      name = output_string_list->get_string(++count);
     }
   });
 
   app->presets_manager->user_input_preset_created.connect([=, this](const Glib::RefPtr<Gio::File>& file) {
-    auto preset_name = util::remove_filename_extension(file->get_basename());
+    const auto& preset_name = Glib::ustring(util::remove_filename_extension(file->get_basename()));
 
-    for (guint n = 0; n < input_string_list->get_n_items(); n++) {
-      if (preset_name == std::string(input_string_list->get_string(n))) {
+    for (guint n = 0, list_size = input_string_list->get_n_items(); n < list_size; n++) {
+      if (input_string_list->get_string(n) == preset_name) {
         return;
       }
     }
@@ -129,15 +128,14 @@ PresetsMenuUi::PresetsMenuUi(BaseObjectType* cobject,
   });
 
   app->presets_manager->user_input_preset_removed.connect([=, this](const Glib::RefPtr<Gio::File>& file) {
-    int count = 0;
+    const auto& preset_name = Glib::ustring(util::remove_filename_extension(file->get_basename()));
 
-    for (auto name = input_string_list->get_string(count); name.c_str() != nullptr;) {
-      if (util::remove_filename_extension(file->get_basename()) == std::string(name)) {
-        input_string_list->remove(count);
+    for (guint n = 0, list_size = input_string_list->get_n_items(); n < list_size; n++) {
+      if (input_string_list->get_string(n) == preset_name) {
+        input_string_list->remove(n);
+
         return;
       }
-
-      name = input_string_list->get_string(++count);
     }
   });
 

--- a/src/reverb_ui.cpp
+++ b/src/reverb_ui.cpp
@@ -18,24 +18,23 @@
  */
 
 #include "reverb_ui.hpp"
-#include <cstring>
 
 namespace {
 
 auto room_size_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "Small") == 0) {
+  if (g_strcmp0(v, "Small") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Medium") == 0) {
+  } else if (g_strcmp0(v, "Medium") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "Large") == 0) {
+  } else if (g_strcmp0(v, "Large") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "Tunnel-like") == 0) {
+  } else if (g_strcmp0(v, "Tunnel-like") == 0) {
     g_value_set_int(value, 3);
-  } else if (std::strcmp(v, "Large/smooth") == 0) {
+  } else if (g_strcmp0(v, "Large/smooth") == 0) {
     g_value_set_int(value, 4);
-  } else if (std::strcmp(v, "Experimental") == 0) {
+  } else if (g_strcmp0(v, "Experimental") == 0) {
     g_value_set_int(value, 5);
   }
 
@@ -138,7 +137,7 @@ ReverbUi::~ReverbUi() {
 auto ReverbUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> ReverbUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/reverb.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<ReverbUi>(builder, "top_box", "com.github.wwmm.easyeffects.reverb",
+  auto* const ui = Gtk::Builder::get_widget_derived<ReverbUi>(builder, "top_box", "com.github.wwmm.easyeffects.reverb",
                                                         schema_path + "reverb/");
 
   stack->add(*ui, plugin_name::reverb);

--- a/src/rnnoise.cpp
+++ b/src/rnnoise.cpp
@@ -166,7 +166,7 @@ void RNNoise::process(std::span<float>& left_in,
       deque_out_R.pop_front();
     }
   } else {
-    uint offset = 2U * (left_out.size() - deque_out_L.size());
+    const uint offset = 2U * (left_out.size() - deque_out_L.size());
 
     if (offset != latency_n_frames) {
       latency_n_frames = offset;
@@ -191,7 +191,7 @@ void RNNoise::process(std::span<float>& left_in,
   apply_gain(left_out, right_out, output_gain);
 
   if (notify_latency) {
-    float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
     util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
 

--- a/src/rnnoise.cpp
+++ b/src/rnnoise.cpp
@@ -166,7 +166,7 @@ void RNNoise::process(std::span<float>& left_in,
       deque_out_R.pop_front();
     }
   } else {
-    uint offset = 2 * (left_out.size() - deque_out_L.size());
+    uint offset = 2U * (left_out.size() - deque_out_L.size());
 
     if (offset != latency_n_frames) {
       latency_n_frames = offset;

--- a/src/rnnoise_ui.cpp
+++ b/src/rnnoise_ui.cpp
@@ -80,26 +80,32 @@ RNNoiseUi::RNNoiseUi(BaseObjectType* cobject,
       [=, this](const Glib::RefPtr<Gio::File>& file, const auto& other_f, const auto& event) {
         switch (event) {
           case Gio::FileMonitor::Event::CREATED: {
-            string_list->append(util::remove_filename_extension(file->get_basename()));
+            const auto& new_name = Glib::ustring(util::remove_filename_extension(file->get_basename()));
+
+            for (guint n = 0, list_size = string_list->get_n_items(); n < list_size; n++) {
+              if (string_list->get_string(n) == new_name) {
+                return;
+              }
+            }
+
+            string_list->append(new_name);
 
             break;
           }
           case Gio::FileMonitor::Event::DELETED: {
-            const Glib::ustring& name_removed = util::remove_filename_extension(file->get_basename());
+            const auto& name_to_remove = Glib::ustring(util::remove_filename_extension(file->get_basename()));
 
-            int count = 0;
+            for (guint n = 0, list_size = string_list->get_n_items(); n < list_size; n++) {
+              if (string_list->get_string(n) == name_to_remove) {
+                string_list->remove(n);
 
-            for (auto name = string_list->get_string(count); name.c_str() != nullptr;) {
-              if (name_removed == name) {
-                string_list->remove(count);
+                // Workaround for GTK not calling the listview signal_selection_changed (issue #1110)
+
+                on_selection_changed();
 
                 break;
               }
-
-              name = string_list->get_string(++count);
             }
-
-            on_selection_changed();
 
             break;
           }

--- a/src/rnnoise_ui.cpp
+++ b/src/rnnoise_ui.cpp
@@ -285,7 +285,7 @@ auto RNNoiseUi::get_model_names() -> std::vector<std::string> {
       }
     }
 
-    it++;
+    ++it;
   }
 
   return names;

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -69,16 +69,15 @@ void Spectrum::process(std::span<float>& left_in,
 
   uint count = 0U;
 
-  for (uint n = 0U, m = left_in.size(); n < m; n++) {
+  for (uint n = 0U, m = left_in.size(); n < m; n++, count++) {
     if (const uint& k = total_count + n; k < real_input.size()) {
       // https://en.wikipedia.org/wiki/Hann_function
 
-      const auto& w = 0.5F *
-                      (1.0F - cosf(2.0F * std::numbers::pi_v<float> * k / static_cast<float>(real_input.size() - 1U)));
+      const float w =
+          0.5F * (1.0F - std::cos(2.0F * std::numbers::pi_v<float> * static_cast<float>(k) /
+          static_cast<float>(real_input.size() - 1U)));
 
       real_input[k] = 0.5F * (left_in[n] + right_in[n]) * w;
-
-      count++;
     } else {
       break;
     }

--- a/src/spectrum_settings_ui.cpp
+++ b/src/spectrum_settings_ui.cpp
@@ -24,9 +24,9 @@ namespace {
 auto spectrum_type_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "Bars") == 0) {
+  if (g_strcmp0(v, "Bars") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "Lines") == 0) {
+  } else if (g_strcmp0(v, "Lines") == 0) {
     g_value_set_int(value, 1);
   }
 
@@ -156,7 +156,7 @@ SpectrumSettingsUi::~SpectrumSettingsUi() {
 void SpectrumSettingsUi::add_to_stack(Gtk::Stack* stack, Application* app) {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/spectrum_settings.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<SpectrumSettingsUi>(builder, "top_box", app);
+  auto* const ui = Gtk::Builder::get_widget_derived<SpectrumSettingsUi>(builder, "top_box", app);
 
   stack->add(*ui, "settings_spectrum", _("Spectrum"));
 }

--- a/src/spectrum_ui.cpp
+++ b/src/spectrum_ui.cpp
@@ -86,14 +86,14 @@ SpectrumUi::~SpectrumUi() {
 auto SpectrumUi::add_to_box(Gtk::Box* box) -> SpectrumUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/spectrum.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<SpectrumUi>(builder, "drawing_area");
+  auto* const ui = Gtk::Builder::get_widget_derived<SpectrumUi>(builder, "drawing_area");
 
   box->append(*ui);
 
   return ui;
 }
 
-void SpectrumUi::on_new_spectrum(const uint& rate, const uint& n_bands, const std::vector<float>& magnitudes) {
+void SpectrumUi::on_new_spectrum(uint rate, uint n_bands, std::vector<float> magnitudes) {
   if (!settings->get_boolean("show")) {
     return;
   }
@@ -157,7 +157,7 @@ void SpectrumUi::on_new_spectrum(const uint& rate, const uint& n_bands, const st
   }
 
   std::ranges::for_each(spectrum_mag, [](auto& v) {
-    v = 10.0F * log10f(v);
+    v = 10.0F * std::log10(v);
 
     if (!std::isinf(v)) {
       v = (v > util::minimum_db_level) ? v : util::minimum_db_level;
@@ -191,12 +191,12 @@ void SpectrumUi::init_frequency_axis() {
   spectrum_freqs.resize(n_bands);
 
   for (uint n = 0U; n < n_bands; n++) {
-    spectrum_freqs[n] = 0.5F * rate * n / n_bands;
+    spectrum_freqs[n] = 0.5F * rate * static_cast<float>(n) / static_cast<float>(n_bands);
   }
 
   if (!spectrum_freqs.empty()) {
-    spectrum_x_axis = util::logspace(log10f(static_cast<float>(settings->get_int("minimum-frequency"))),
-                                     log10f(static_cast<float>(settings->get_int("maximum-frequency"))),
+    spectrum_x_axis = util::logspace(std::log10(static_cast<float>(settings->get_int("minimum-frequency"))),
+                                     std::log10(static_cast<float>(settings->get_int("maximum-frequency"))),
                                      settings->get_int("n-points"));
 
     spectrum_mag.resize(spectrum_x_axis.size());

--- a/src/stereo_tools.cpp
+++ b/src/stereo_tools.cpp
@@ -114,7 +114,9 @@ void StereoTools::process(std::span<float>& left_in,
     notification_dt += sample_duration;
 
     if (notification_dt >= notification_time_window) {
-      float correlation = lv2_wrapper->get_control_port_value("meter_phase");
+      // correlation needed as double for levelbar widget ui, so we convert it here
+
+      const double& correlation = static_cast<double>(lv2_wrapper->get_control_port_value("meter_phase"));
 
       Glib::signal_idle().connect_once([=, this] { new_correlation.emit(correlation); });
 

--- a/src/stereo_tools_ui.cpp
+++ b/src/stereo_tools_ui.cpp
@@ -18,26 +18,25 @@
  */
 
 #include "stereo_tools_ui.hpp"
-#include <cstring>
 
 namespace {
 
 auto stereo_tools_enum_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
   const auto* v = g_variant_get_string(variant, nullptr);
 
-  if (std::strcmp(v, "LR > LR (Stereo Default)") == 0) {
+  if (g_strcmp0(v, "LR > LR (Stereo Default)") == 0) {
     g_value_set_int(value, 0);
-  } else if (std::strcmp(v, "LR > MS (Stereo to Mid-Side)") == 0) {
+  } else if (g_strcmp0(v, "LR > MS (Stereo to Mid-Side)") == 0) {
     g_value_set_int(value, 1);
-  } else if (std::strcmp(v, "MS > LR (Mid-Side to Stereo)") == 0) {
+  } else if (g_strcmp0(v, "MS > LR (Mid-Side to Stereo)") == 0) {
     g_value_set_int(value, 2);
-  } else if (std::strcmp(v, "LR > LL (Mono Left Channel)") == 0) {
+  } else if (g_strcmp0(v, "LR > LL (Mono Left Channel)") == 0) {
     g_value_set_int(value, 3);
-  } else if (std::strcmp(v, "LR > RR (Mono Right Channel)") == 0) {
+  } else if (g_strcmp0(v, "LR > RR (Mono Right Channel)") == 0) {
     g_value_set_int(value, 4);
-  } else if (std::strcmp(v, "LR > L+R (Mono Sum L+R)") == 0) {
+  } else if (g_strcmp0(v, "LR > L+R (Mono Sum L+R)") == 0) {
     g_value_set_int(value, 5);
-  } else if (std::strcmp(v, "LR > RL (Stereo Flip Channels)") == 0) {
+  } else if (g_strcmp0(v, "LR > RL (Stereo Flip Channels)") == 0) {
     g_value_set_int(value, 6);
   }
 
@@ -151,7 +150,7 @@ StereoToolsUi::~StereoToolsUi() {
 auto StereoToolsUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> StereoToolsUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/stereo_tools.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<StereoToolsUi>(
+  auto* const ui = Gtk::Builder::get_widget_derived<StereoToolsUi>(
       builder, "top_box", "com.github.wwmm.easyeffects.stereotools", schema_path + "stereotools/");
 
   stack->add(*ui, plugin_name::stereo_tools);
@@ -199,7 +198,7 @@ void StereoToolsUi::reset() {
   settings->reset("stereo-phase");
 }
 
-void StereoToolsUi::on_new_phase_correlation(double value) {
+void StereoToolsUi::on_new_phase_correlation(const double& value) {
   meter_phase_levelbar->set_value(value);
 
   meter_phase_label->set_text(level_to_localized_string(value, 0));

--- a/src/stream_output_effects_ui.cpp
+++ b/src/stream_output_effects_ui.cpp
@@ -42,29 +42,19 @@ StreamOutputEffectsUi::StreamOutputEffectsUi(BaseObjectType* cobject,
   connections.emplace_back(
       soe->pm->stream_output_removed.connect(sigc::mem_fun(*this, &StreamOutputEffectsUi::on_app_removed)));
 
-  connections.emplace_back(soe->pm->sink_changed.connect([&](const auto& nd_info) {
+  connections.emplace_back(soe->pm->sink_changed.connect([&](auto nd_info) {
     if (nd_info.id == soe->pm->pe_sink_node.id) {
-      std::ostringstream str;
+      const auto& v = Glib::ustring::format(std::setprecision(1), std::fixed,
+                                            static_cast<float>(soe->pm->pe_sink_node.rate) * 0.001F);
 
-      str << node_state_to_string(soe->pm->pe_sink_node.state) << std::string(5, ' ');
-
-      str.precision(1);
-
-      str << std::fixed << static_cast<float>(soe->pm->pe_sink_node.rate) * 0.001F << " kHz" << std::string(5, ' ');
-
-      device_state->set_text(str.str());
+      device_state->set_text(v + " kHz" + Glib::ustring(5, ' '));
     }
   }));
 
-  std::ostringstream str;
+  const auto& v = Glib::ustring::format(std::setprecision(1), std::fixed,
+                                        static_cast<float>(soe->pm->pe_sink_node.rate) * 0.001F);
 
-  str << node_state_to_string(soe->pm->pe_sink_node.state) << std::string(5, ' ');
-
-  str.precision(1);
-
-  str << std::fixed << static_cast<float>(soe->pm->pe_sink_node.rate) * 0.001F << " kHz" << std::string(5, ' ');
-
-  device_state->set_text(str.str());
+  device_state->set_text(v + " kHz" + Glib::ustring(5, ' '));
 }
 
 StreamOutputEffectsUi::~StreamOutputEffectsUi() {
@@ -74,7 +64,7 @@ StreamOutputEffectsUi::~StreamOutputEffectsUi() {
 auto StreamOutputEffectsUi::add_to_stack(Gtk::Stack* stack, StreamOutputEffects* soe_ptr) -> StreamOutputEffectsUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/effects_base.ui");
 
-  auto* ui = Gtk::Builder::get_widget_derived<StreamOutputEffectsUi>(builder, "top_box", soe_ptr,
+  auto* const ui = Gtk::Builder::get_widget_derived<StreamOutputEffectsUi>(builder, "top_box", soe_ptr,
                                                                      "com.github.wwmm.easyeffects.streamoutputs");
 
   auto stack_page = stack->add(*ui, "stream_output");

--- a/src/test_signals.cpp
+++ b/src/test_signals.cpp
@@ -55,7 +55,7 @@ void on_process(void* userdata, spa_io_position* position) {
       case TestSignalType::sine_wave: {
         d->ts->sine_phase += 2.0F * std::numbers::pi_v<float> * d->ts->sine_frequency / static_cast<float>(rate);
 
-        signal = 0.5F * sinf(d->ts->sine_phase);
+        signal = 0.5F * std::sin(d->ts->sine_phase);
 
         break;
       }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -52,12 +52,12 @@ auto logspace(const float& start, const float& stop, const uint& npoints) -> std
     return output;
   }
 
-  float delta = (stop - start) / npoints;
+  const float delta = (stop - start) / static_cast<float>(npoints);
 
   float v = start;
 
   while (v <= stop) {
-    output.emplace_back(powf(10.0F, v));
+    output.emplace_back(std::pow(10.0F, v));
 
     v += delta;
   }
@@ -72,7 +72,7 @@ auto linspace(const float& start, const float& stop, const uint& npoints) -> std
     return output;
   }
 
-  float delta = (stop - start) / npoints;
+  const float delta = (stop - start) / static_cast<float>(npoints);
 
   float v = start;
 
@@ -87,7 +87,7 @@ auto linspace(const float& start, const float& stop, const uint& npoints) -> std
 
 auto linear_to_db(const float& amp) -> float {
   if (amp >= minimum_linear_level) {
-    return 20.0F * log10f(amp);
+    return 20.0F * std::log10(amp);
   }
 
   return minimum_db_level;
@@ -95,24 +95,22 @@ auto linear_to_db(const float& amp) -> float {
 
 auto linear_to_db(const double& amp) -> double {
   if (amp >= minimum_linear_d_level) {
-    return 20.0 * log10(amp);
+    return 20.0 * std::log10(amp);
   }
 
   return minimum_db_d_level;
 }
 
 auto db_to_linear(const float& db) -> float {
-  return expf((db / 20.0F) * logf(10.0F));
+  return std::exp((db / 20.0F) * std::log(10.0F));
 }
 
 auto db_to_linear(const double& db) -> double {
-  return exp((db / 20.0) * log(10.0));
+  return std::exp((db / 20.0) * std::log(10.0));
 }
 
 auto db20_gain_to_linear(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
-  double v_db = g_variant_get_double(variant);
-
-  float v_linear = powf(10.0F, static_cast<float>(v_db) / 20.0F);
+  const gfloat v_linear = std::pow(10.0F, static_cast<float>(g_variant_get_double(variant)) / 20.0F);
 
   g_value_set_float(value, v_linear);
 
@@ -120,17 +118,13 @@ auto db20_gain_to_linear(GValue* value, GVariant* variant, gpointer user_data) -
 }
 
 auto linear_gain_to_db20(const GValue* value, const GVariantType* expected_type, gpointer user_data) -> GVariant* {
-  float v_linear = g_value_get_float(value);
-
-  double v_db = 20.0 * log10(static_cast<double>(v_linear));
+  const gdouble v_db = 20.0 * std::log10(static_cast<double>(g_value_get_float(value)));
 
   return g_variant_new_double(v_db);
 }
 
 auto db10_gain_to_linear(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
-  double v_db = g_variant_get_double(variant);
-
-  float v_linear = powf(10.0F, static_cast<float>(v_db) / 10.0F);
+  const gfloat v_linear = std::pow(10.0F, static_cast<float>(g_variant_get_double(variant)) / 10.0F);
 
   g_value_set_float(value, v_linear);
 
@@ -138,17 +132,13 @@ auto db10_gain_to_linear(GValue* value, GVariant* variant, gpointer user_data) -
 }
 
 auto double_to_float(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
-  float v_d = g_variant_get_double(variant);
-
-  g_value_set_float(value, v_d);
+  g_value_set_float(value, static_cast<gfloat>(g_variant_get_double(variant)));
 
   return 1;
 }
 
 auto db20_gain_to_linear_double(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
-  double v_db = g_variant_get_double(variant);
-
-  double v_linear = pow(10.0, v_db / 20.0);
+  const gdouble v_linear = std::pow(10.0, g_variant_get_double(variant) / 20.0);
 
   g_value_set_double(value, v_linear);
 
@@ -157,31 +147,25 @@ auto db20_gain_to_linear_double(GValue* value, GVariant* variant, gpointer user_
 
 auto linear_double_gain_to_db20(const GValue* value, const GVariantType* expected_type, gpointer user_data)
     -> GVariant* {
-  double v_linear = g_value_get_double(value);
-
-  double v_db = 20.0 * log10(v_linear);
+  const gdouble v_db = 20.0 * std::log10(g_value_get_double(value));
 
   return g_variant_new_double(v_db);
 }
 
 auto double_x10_to_int(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
-  double v_d = g_variant_get_double(variant);
-
-  g_value_set_int(value, v_d * 10);
+  g_value_set_int(value, static_cast<gint>(g_variant_get_double(variant) * 10.0));
 
   return 1;
 }
 
 auto ms_to_ns(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {
-  guint64 v_ns = g_variant_get_double(variant) * 1000000.0;
-
-  g_value_set_uint64(value, v_ns);
+  g_value_set_uint64(value, static_cast<guint64>(g_variant_get_double(variant) * 1000000.0));
 
   return 1;
 }
 
-auto remove_filename_extension(const std::string& basename) -> std::string {
-  return basename.substr(0, basename.find_last_of('.'));
+auto remove_filename_extension(const Glib::ustring& basename) -> Glib::ustring {
+  return basename.substr(0, basename.find_last_of("."));
 }
 
 }  // namespace util


### PR DESCRIPTION
I apologize for the last commit being so huge. The problem is that I kept changing the code and forgot to commit, then I found myself with a big one.

So this is the list of changes:

- in folder monitor signal handler, always check for existing items in the list before appending
- prefer pre-increment rather than post-increment for iterators
- preferer references and const references where is possible
- avoid temporary local variables where possible
- if possible, innest local variables in if statements rather than having them on the outside scope
- variables that do not change are marked as const
- if pointers to const are not possible, we do const pointers
- use more `Glib::ustring` rather than `std::string` since Glib widgets most of the time expect this type (unfortunately lots of implicit conversions can't be avoided, but we try to reduce them)
- if we need `std::string` explicitly, convert with `raw` or `c_str` in assignments or comparisons (but when setting text in labels, always avoid c_str)
- parameters passed to signals were mismatched in some parts of the code doing unnecessary conversions: now we try to reduce conversions, set const references for plugins parameters and copy NodeInfo (because Pipewire can unset the data before the signal handler use it)
- cstring header removed: it was used only for `strcmp`, now we use `g_strcmp0` of Glib that perform the same task
- removed other unneeded headers
- we now use `Glib::ustring::format` for string formatting, getting rid of stringstreams that were longer to write and manage
- level_to_localized_string_showpos and float_to_localized_string mothods removed and substituted in place with the more powerful and short Glib::ustring::format
- `std::stof` is locale independent even if cplusplus.com states the opposite, so we use it rather than stringstreams
- values without unit in plugin interfaces now don't show a useless final whitespace
- validate user input text for new presets and truncate to 100 characters if longer
- the app icon name is unset when node info state is `PW_NODE_STATE_CREATING` (it happens sometimes when the application is disabled and then it's removed from the blocklist), however we can't check if the icon name is empty in that case because Pipewire fill it with some whitespaces, so we hide it from the app info UI 
- use node_state_to_string method (that was unused) to set the stream state in app info UI
- removed blocklist_in and blocklist_out from pipe_manager: they were unused
- now the previous state of blocklisted apps removed from the blocklist is correctly restored saving the state in a map and associating it to the node id (previously it was saved in NodeInfoHolder structure that was not storing the state correctly)
- now the blocklist management is more robust: the app is added/removed to/from the blocklist even on new presets that have non-empty blocklist

I tested it, it's working. I had some issues on strings not showing due to the changes, but then I fixed it. @wmm I only ask you to test the input pipeline, the input blocklist and the external sidechain that I can't test.

For other known issues we talked about, I'm working on them in the next days.