### PR TITLE
Fix Equalizer UI, blocklist management and other optimizations

### DIFF
--- a/data/ui/convolver.ui
+++ b/data/ui/convolver.ui
@@ -100,7 +100,7 @@
                                         <property name="upper">200</property>
                                         <property name="value">100</property>
                                         <property name="step-increment">1</property>
-                                        <property name="page-increment">1</property>
+                                        <property name="page-increment">10</property>
                                     </object>
                                 </property>
                             </object>

--- a/data/ui/deesser.ui
+++ b/data/ui/deesser.ui
@@ -275,7 +275,7 @@
                                 <property name="upper">100</property>
                                 <property name="value">15</property>
                                 <property name="step-increment">1</property>
-                                <property name="page-increment">1</property>
+                                <property name="page-increment">10</property>
                             </object>
                         </property>
                         <layout>

--- a/data/ui/equalizer_band.ui
+++ b/data/ui/equalizer_band.ui
@@ -126,7 +126,7 @@
                                                 <property name="lower">10</property>
                                                 <property name="upper">24000</property>
                                                 <property name="step-increment">1</property>
-                                                <property name="page-increment">10</property>
+                                                <property name="page-increment">100</property>
                                             </object>
                                         </property>
                                     </object>
@@ -188,7 +188,7 @@
                                                 <property name="upper">100</property>
                                                 <property name="value">4</property>
                                                 <property name="step-increment">0.01</property>
-                                                <property name="page-increment">0.10</property>
+                                                <property name="page-increment">0.1</property>
                                             </object>
                                         </property>
                                     </object>
@@ -271,7 +271,7 @@
                         <property name="lower">-35</property>
                         <property name="upper">35</property>
                         <property name="step-increment">0.01</property>
-                        <property name="page-increment">0.01</property>
+                        <property name="page-increment">0.1</property>
                     </object>
                 </property>
             </object>

--- a/data/ui/equalizer_band.ui
+++ b/data/ui/equalizer_band.ui
@@ -239,6 +239,7 @@
 
         <child>
             <object class="GtkLabel" id="band_label">
+                <property name="width-chars">10</property>
                 <property name="label">band</property>
                 <style>
                     <class name="dim-label" />
@@ -248,6 +249,7 @@
 
         <child>
             <object class="GtkLabel" id="band_quality_label">
+                <property name="width-chars">10</property>
                 <property name="label">Q</property>
                 <style>
                     <class name="dim-label" />

--- a/data/ui/multiband_compressor_band.ui
+++ b/data/ui/multiband_compressor_band.ui
@@ -49,7 +49,7 @@
                                         <property name="upper">20000</property>
                                         <property name="value">10</property>
                                         <property name="step-increment">1</property>
-                                        <property name="page-increment">10</property>
+                                        <property name="page-increment">100</property>
                                     </object>
                                 </property>
                             </object>
@@ -593,7 +593,7 @@
                                                 <property name="upper">20000</property>
                                                 <property name="value">10</property>
                                                 <property name="step-increment">1</property>
-                                                <property name="page-increment">10</property>
+                                                <property name="page-increment">100</property>
                                             </object>
                                         </property>
 
@@ -644,7 +644,7 @@
                                                 <property name="upper">20000</property>
                                                 <property name="value">20000</property>
                                                 <property name="step-increment">1</property>
-                                                <property name="page-increment">10</property>
+                                                <property name="page-increment">100</property>
                                             </object>
                                         </property>
 

--- a/data/ui/pitch.ui
+++ b/data/ui/pitch.ui
@@ -62,7 +62,7 @@
                                 <property name="lower">-100</property>
                                 <property name="upper">100</property>
                                 <property name="step-increment">1</property>
-                                <property name="page-increment">1</property>
+                                <property name="page-increment">10</property>
                             </object>
                         </property>
                         <layout>

--- a/include/effects_base_ui.hpp
+++ b/include/effects_base_ui.hpp
@@ -168,8 +168,6 @@ class EffectsBaseUi {
 
   void setup_listview_selected_plugins();
 
-  auto app_is_enabled(const NodeInfo& node_info) -> bool;
-
   auto app_is_blocklisted(const Glib::ustring& name) -> bool;
 
   auto add_new_blocklist_entry(const Glib::ustring& name) -> bool;

--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -210,6 +210,8 @@ class PipeManager {
   std::string header_version, library_version, core_name, default_clock_rate, default_min_quantum, default_max_quantum,
       default_quantum;
 
+  auto stream_is_connected(const std::string& media_class, const uint& node_id) -> bool;
+
   void connect_stream_output(const NodeInfo& nd_info) const;
 
   void connect_stream_input(const NodeInfo& nd_info) const;

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -787,8 +787,6 @@ void EffectsBaseUi::setup_listview_players() {
       return Glib::ustring::format(static_cast<int>(v)) + " %";
     });
 
-    holder->info_updated.emit(holder->info);
-
     list_item->set_data("connection_enable", pointer_connection_enable, Glib::destroy_notify_delete<sigc::connection>);
 
     list_item->set_data("connection_volume", pointer_connection_volume, Glib::destroy_notify_delete<sigc::connection>);

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -616,16 +616,11 @@ void EqualizerUi::on_import_apo_preset_clicked() {
 auto EqualizerUi::parse_apo_filter(const std::string& line, struct ImportedBand& filter) -> bool {
   std::smatch matches;
 
-  const auto& i = std::regex::icase;
-  std::regex re_filter_type(R"(filter\s++\d*+:\s*+on\s++([a-z]++))", i);
-  std::regex re_freq(R"(fc\s++(\d++\.?+\d*+)\s*+hz)", i);
-  std::regex re_dB_per_octave(R"(filter\s++\d*+:\s*+on\s++[a-z]++\s++([\+-]?+\d++\.?+\d*+)\s*+db)", i);
-  std::regex re_gain(R"(gain\s++([\+-]?+\d++\.?+\d*+)\s*+db)", i);
-  std::regex re_quality_factor(R"(q\s++(\d++\.?+\d*+))", i);
+  const auto i = std::regex::icase;
 
   // get filter type
 
-  std::regex_search(line, matches, re_filter_type);
+  std::regex_search(line, matches, std::regex(R"(filter\s++\d*+:\s*+on\s++([a-z]++))", i));
 
   if (matches.size() != 2U) {
     return false;
@@ -639,7 +634,7 @@ auto EqualizerUi::parse_apo_filter(const std::string& line, struct ImportedBand&
 
   // get center frequency
 
-  std::regex_search(line, matches, re_freq);
+  std::regex_search(line, matches, std::regex(R"(fc\s++(\d++\.?+\d*+)\s*+hz)", i));
 
   if (matches.size() != 2U) {
     return false;
@@ -650,7 +645,8 @@ auto EqualizerUi::parse_apo_filter(const std::string& line, struct ImportedBand&
   // get slope
 
   if ((filter.type & (LOW_SHELF_xdB | HIGH_SHELF_xdB | LOW_SHELF | HIGH_SHELF)) != 0U) {
-    std::regex_search(line, matches, re_dB_per_octave);
+    std::regex_search(line, matches,
+                      std::regex(R"(filter\s++\d*+:\s*+on\s++[a-z]++\s++([\+-]?+\d++\.?+\d*+)\s*+db)", i));
 
     // _xdB variants require the dB parameter
 
@@ -668,7 +664,7 @@ auto EqualizerUi::parse_apo_filter(const std::string& line, struct ImportedBand&
   // get gain
 
   if ((filter.type & (PEAKING | LOW_SHELF_xdB | HIGH_SHELF_xdB | LOW_SHELF | HIGH_SHELF)) != 0U) {
-    std::regex_search(line, matches, re_gain);
+    std::regex_search(line, matches, std::regex(R"(gain\s++([\+-]?+\d++\.?+\d*+)\s*+db)", i));
 
     // all Shelf types (i.e. all above except for Peaking) require the gain parameter
 
@@ -683,7 +679,7 @@ auto EqualizerUi::parse_apo_filter(const std::string& line, struct ImportedBand&
 
   // get quality factor
   if ((filter.type & (PEAKING | LOW_PASS_Q | HIGH_PASS_Q | LOW_SHELF_xdB | HIGH_SHELF_xdB | NOTCH | ALL_PASS)) != 0U) {
-    std::regex_search(line, matches, re_quality_factor);
+    std::regex_search(line, matches, std::regex(R"(q\s++(\d++\.?+\d*+))", i));
 
     // Peaking and All-Pass filter types require the quality factor parameter
 

--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -792,9 +792,7 @@ void on_registry_global(void* data,
 
         if (name.empty()) {
           return;
-        }
-
-        if (std::ranges::find(pm->blocklist_node_name, name) != pm->blocklist_node_name.end()) {
+        } else if (std::ranges::find(pm->blocklist_node_name, name) != pm->blocklist_node_name.end()) {
           return;
         }
 

--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -1189,6 +1189,24 @@ PipeManager::~PipeManager() {
   pw_thread_loop_destroy(thread_loop);
 }
 
+auto PipeManager::stream_is_connected(const std::string& media_class, const uint& node_id) -> bool {
+  if (media_class == "Stream/Output/Audio") {
+    for (const auto& link : list_links) {
+      if (link.output_node_id == node_id && link.input_node_id == pe_sink_node.id) {
+        return true;
+      }
+    }
+  } else if (media_class == "Stream/Input/Audio") {
+    for (const auto& link : list_links) {
+      if (link.output_node_id == pe_source_node.id && link.input_node_id == node_id) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 void PipeManager::connect_stream_output(const NodeInfo& nd_info) const {
   if (nd_info.media_class == "Stream/Output/Audio") {
     pw_thread_loop_lock(thread_loop);

--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -83,7 +83,7 @@ auto link_info_from_props(const spa_dict* props) -> LinkInfo {
   }
 
   if (const auto* passive = spa_dict_lookup(props, PW_KEY_LINK_PASSIVE)) {
-    if (strcmp(passive, "true") == 0) {
+    if (g_strcmp0(passive, "true") == 0) {
       info.passive = true;
     }
   }
@@ -119,19 +119,19 @@ auto port_info_from_props(const spa_dict* props) -> PortInfo {
   }
 
   if (const auto* port_physical = spa_dict_lookup(props, PW_KEY_PORT_PHYSICAL)) {
-    if (strcmp(port_physical, "true") == 0) {
+    if (g_strcmp0(port_physical, "true") == 0) {
       info.physical = true;
     }
   }
 
   if (const auto* port_terminal = spa_dict_lookup(props, PW_KEY_PORT_TERMINAL)) {
-    if (strcmp(port_terminal, "true") == 0) {
+    if (g_strcmp0(port_terminal, "true") == 0) {
       info.terminal = true;
     }
   }
 
   if (const auto* port_monitor = spa_dict_lookup(props, PW_KEY_PORT_MONITOR)) {
-    if (strcmp(port_monitor, "true") == 0) {
+    if (g_strcmp0(port_monitor, "true") == 0) {
       info.monitor = true;
     }
   }
@@ -748,27 +748,27 @@ void on_registry_global(void* data,
                         const struct spa_dict* props) {
   auto* pm = static_cast<PipeManager*>(data);
 
-  if (strcmp(type, PW_TYPE_INTERFACE_Node) == 0) {
+  if (g_strcmp0(type, PW_TYPE_INTERFACE_Node) == 0) {
     if (const auto* key_media_role = spa_dict_lookup(props, PW_KEY_MEDIA_ROLE)) {
       if (std::ranges::find(pm->blocklist_media_role, std::string(key_media_role)) != pm->blocklist_media_role.end()) {
         return;
       }
 
-      if (strcmp(key_media_role, "DSP") == 0) {
+      if (g_strcmp0(key_media_role, "DSP") == 0) {
         const auto* key_media_category = spa_dict_lookup(props, PW_KEY_MEDIA_CATEGORY);
 
         if (key_media_category == nullptr) {
           return;
         }
 
-        if (strcmp(key_media_category, "Filter") == 0) {
+        if (g_strcmp0(key_media_category, "Filter") == 0) {
           const auto* key_node_description = spa_dict_lookup(props, PW_KEY_NODE_DESCRIPTION);
 
           if (key_node_description == nullptr) {
             return;
           }
 
-          if (strcmp(key_node_description, "easyeffects_filter") == 0) {
+          if (g_strcmp0(key_node_description, "easyeffects_filter") == 0) {
             const auto* node_name = spa_dict_lookup(props, PW_KEY_NODE_NAME);
 
             util::debug(pm->log_tag + "Filter " + node_name + ", id = " + std::to_string(id) + ", was added");
@@ -847,7 +847,7 @@ void on_registry_global(void* data,
     return;
   }
 
-  if (strcmp(type, PW_TYPE_INTERFACE_Link) == 0) {
+  if (g_strcmp0(type, PW_TYPE_INTERFACE_Link) == 0) {
     auto* proxy = static_cast<pw_proxy*>(pw_registry_bind(pm->registry, id, type, PW_VERSION_LINK, sizeof(proxy_data)));
 
     auto* pd = static_cast<proxy_data*>(pw_proxy_get_user_data(proxy));
@@ -890,7 +890,7 @@ void on_registry_global(void* data,
     return;
   }
 
-  if (strcmp(type, PW_TYPE_INTERFACE_Port) == 0) {
+  if (g_strcmp0(type, PW_TYPE_INTERFACE_Port) == 0) {
     auto* proxy = static_cast<pw_proxy*>(pw_registry_bind(pm->registry, id, type, PW_VERSION_PORT, sizeof(proxy_data)));
 
     auto* pd = static_cast<proxy_data*>(pw_proxy_get_user_data(proxy));
@@ -913,7 +913,7 @@ void on_registry_global(void* data,
     return;
   }
 
-  if (strcmp(type, PW_TYPE_INTERFACE_Module) == 0) {
+  if (g_strcmp0(type, PW_TYPE_INTERFACE_Module) == 0) {
     auto* proxy =
         static_cast<pw_proxy*>(pw_registry_bind(pm->registry, id, type, PW_VERSION_MODULE, sizeof(proxy_data)));
 
@@ -937,7 +937,7 @@ void on_registry_global(void* data,
     return;
   }
 
-  if (strcmp(type, PW_TYPE_INTERFACE_Client) == 0) {
+  if (g_strcmp0(type, PW_TYPE_INTERFACE_Client) == 0) {
     auto* proxy =
         static_cast<pw_proxy*>(pw_registry_bind(pm->registry, id, type, PW_VERSION_CLIENT, sizeof(proxy_data)));
 
@@ -957,7 +957,7 @@ void on_registry_global(void* data,
     return;
   }
 
-  if (strcmp(type, PW_TYPE_INTERFACE_Metadata) == 0) {
+  if (g_strcmp0(type, PW_TYPE_INTERFACE_Metadata) == 0) {
     if (const auto* name = spa_dict_lookup(props, PW_KEY_METADATA_NAME)) {
       util::debug(pm->log_tag + "found metadata: " + name);
 
@@ -975,7 +975,7 @@ void on_registry_global(void* data,
     return;
   }
 
-  if (strcmp(type, PW_TYPE_INTERFACE_Device) == 0) {
+  if (g_strcmp0(type, PW_TYPE_INTERFACE_Device) == 0) {
     if (const auto* key_media_class = spa_dict_lookup(props, PW_KEY_MEDIA_CLASS)) {
       const std::string media_class = key_media_class;
 
@@ -1436,7 +1436,7 @@ auto PipeManager::json_object_find(const char* obj, const char* key, char* value
   }
 
   while (spa_json_get_string(sjson.data() + 1, res.data(), res.size() * sizeof(char) - 1) > 0) {
-    if (strcmp(res.data(), key) == 0) {
+    if (g_strcmp0(res.data(), key) == 0) {
       if (spa_json_get_string(sjson.data() + 1, value, len) <= 0) {
         continue;
       }

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -85,6 +85,12 @@ StreamInputEffects::StreamInputEffects(PipeManager* pipe_manager)
   });
 
   settings->signal_changed("plugins").connect([&, this](const auto& key) {
+    if (global_settings->get_boolean("bypass")) {
+      global_settings->set_boolean("bypass", false);
+
+      return; // filter connected through update_bypass_state
+    }
+
     disconnect_filters();
 
     connect_filters();

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -98,28 +98,14 @@ StreamInputEffects::~StreamInputEffects() {
 }
 
 void StreamInputEffects::on_app_added(NodeInfo node_info) {
-  auto forbidden_app = false;
-  auto connected = false;
   const auto& blocklist = settings->get_string_array("blocklist");
 
-  forbidden_app = std::ranges::find(blocklist, node_info.name.c_str()) != blocklist.end();
+  const auto& is_blocklisted = std::ranges::find(blocklist, node_info.name.c_str()) != blocklist.end();;
 
-  for (const auto& link : pm->list_links) {
-    if (link.input_node_id == node_info.id && link.output_node_id == pm->pe_source_node.id) {
-      connected = true;
-
-      break;
-    }
-  }
-
-  if (connected) {
-    if (forbidden_app) {
-      pm->disconnect_stream_input(node_info);
-    }
-  } else {
-    if (!forbidden_app && global_settings->get_boolean("process-all-inputs")) {
-      pm->connect_stream_input(node_info);
-    }
+  if (is_blocklisted) {
+    pm->disconnect_stream_input(node_info);
+  } else if (global_settings->get_boolean("process-all-inputs")) {
+    pm->connect_stream_input(node_info);
   }
 }
 

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -98,28 +98,14 @@ StreamOutputEffects::~StreamOutputEffects() {
 }
 
 void StreamOutputEffects::on_app_added(NodeInfo node_info) {
-  auto forbidden_app = false;
-  auto connected = false;
   const auto& blocklist = settings->get_string_array("blocklist");
 
-  forbidden_app = std::ranges::find(blocklist, node_info.name.c_str()) != blocklist.end();
+  const auto& is_blocklisted = std::ranges::find(blocklist, node_info.name.c_str()) != blocklist.end();
 
-  for (const auto& link : pm->list_links) {
-    if (link.output_node_id == node_info.id && link.input_node_id == pm->pe_sink_node.id) {
-      connected = true;
-
-      break;
-    }
-  }
-
-  if (connected) {
-    if (forbidden_app) {
-      pm->disconnect_stream_output(node_info);
-    }
-  } else {
-    if (!forbidden_app && global_settings->get_boolean("process-all-outputs")) {
-      pm->connect_stream_output(node_info);
-    }
+  if (is_blocklisted) {
+    pm->disconnect_stream_output(node_info);
+  } else if (global_settings->get_boolean("process-all-outputs")) {
+    pm->connect_stream_output(node_info);
   }
 }
 

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -85,6 +85,12 @@ StreamOutputEffects::StreamOutputEffects(PipeManager* pipe_manager)
   });
 
   settings->signal_changed("plugins").connect([&, this](const auto& key) {
+    if (global_settings->get_boolean("bypass")) {
+      global_settings->set_boolean("bypass", false);
+
+      return; // filter connected through update_bypass_state
+    }
+
     disconnect_filters();
 
     connect_filters();


### PR DESCRIPTION
* Since the check of app enabled state is not working in `on_app_added` of `StreamOutputEffects` and `StreamInputEffects`, the blocklist management has been reworked: now the stream is properly enabled/disabled in its startup stage both on window and service mode (other work on blocklist and app info ui will be done in the next days)
* The check of app enabled has been moved in `pipe_manager` passing only needed data and not the whole `NodeInfo` struct
* Removed the unneeded signal emit in its own callback
* Fix sliders shift in Equalizer UI (fixes #1114)
* Adjusted some `page-increment` properties in plugin UI
* Global bypass button is now properly updated on plugin array changes
* Use [g_strcmp0](https://docs.gtk.org/glib/func.strcmp0.html) rather than strcmp because the first is more robust and handles null pointers while [std::strcmp](https://en.cppreference.com/w/cpp/string/byte/strcmp) behaviour is undefined passing nullprt   