### PR TITLE
Nodes tracked in map rather than vector

### DIFF
--- a/data/schemas/com.github.wwmm.easyeffects.autogain.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.autogain.gschema.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
     <schema id="com.github.wwmm.easyeffects.autogain">
+        <key name="input-gain" type="d">
+            <range min="-36" max="36" />
+            <default>0</default>
+        </key>
+        <key name="output-gain" type="d">
+            <range min="-36" max="36" />
+            <default>0</default>
+        </key>
         <key name="target" type="d">
-            <range min="-100.0" max="0.0" />
-            <default>-23.0</default>
+            <range min="-100" max="0" />
+            <default>-23</default>
         </key>
         <key name="reset-history" type="b">
             <default>false</default>

--- a/data/schemas/com.github.wwmm.easyeffects.bassenhancer.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.bassenhancer.gschema.xml
@@ -2,15 +2,15 @@
 <schemalist>
     <schema id="com.github.wwmm.easyeffects.bassenhancer">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="amount" type="d">
-            <range min="-100" max="36.1" />
+            <range min="-100" max="36" />
             <default>0</default>
         </key>
         <key name="harmonics" type="d">

--- a/data/schemas/com.github.wwmm.easyeffects.bassloudness.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.bassloudness.gschema.xml
@@ -2,12 +2,12 @@
 <schemalist>
     <schema id="com.github.wwmm.easyeffects.bassloudness">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="loudness" type="d">
             <range min="-100" max="0" />
@@ -15,7 +15,7 @@
         </key>
         <key name="output" type="d">
             <range min="-100" max="0" />
-            <default>-6.0</default>
+            <default>-6</default>
         </key>
         <key name="link" type="d">
             <range min="-100" max="0" />

--- a/data/schemas/com.github.wwmm.easyeffects.compressor.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.compressor.gschema.xml
@@ -30,51 +30,51 @@
     </enum>
     <schema id="com.github.wwmm.easyeffects.compressor">
         <key name="input-gain" type="d">
-            <range min="-60.0" max="60.0" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-60.0" max="60.0" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="mode" enum="com.github.wwmm.easyeffects.compressor.mode.enum">
             <default>"Downward"</default>
         </key>
         <key name="attack" type="d">
-            <range min="0.0" max="2000.0" />
-            <default>20.0</default>
+            <range min="0" max="2000" />
+            <default>20</default>
         </key>
         <key name="release" type="d">
-            <range min="0.0" max="5000.0" />
-            <default>100.0</default>
+            <range min="0" max="5000" />
+            <default>100</default>
         </key>
         <key name="release-threshold" type="d">
-            <range min="-120.0" max="0.0" />
-            <default>-120.0</default>
+            <range min="-120" max="0" />
+            <default>-120</default>
         </key>
         <key name="threshold" type="d">
-            <range min="-60.0" max="0.0" />
-            <default>-12.0</default>
+            <range min="-60" max="0" />
+            <default>-12</default>
         </key>
         <key name="ratio" type="d">
-            <range min="1.0" max="100.0" />
-            <default>4.0</default>
+            <range min="1" max="100" />
+            <default>4</default>
         </key>
         <key name="knee" type="d">
-            <range min="-23.99" max="0.0" />
-            <default>-6.0</default>
+            <range min="-23.99" max="0" />
+            <default>-6</default>
         </key>
         <key name="makeup" type="d">
-            <range min="-60.0" max="60.0" />
-            <default>0.0</default>
+            <range min="-60" max="60" />
+            <default>0</default>
         </key>
         <key name="boost-amount" type="d">
-            <range min="0.0" max="72.0" />
-            <default>6.0</default>
+            <range min="0" max="72" />
+            <default>6</default>
         </key>
         <key name="boost-threshold" type="d">
-            <range min="-120.0" max="-60.0" />
-            <default>-72.0</default>
+            <range min="-120" max="-60" />
+            <default>-72</default>
         </key>
         <key name="sidechain-listen" type="b">
             <default>false</default>
@@ -89,30 +89,30 @@
             <default>"Middle"</default>
         </key>
         <key name="sidechain-preamp" type="d">
-            <range min="-120.0" max="40.0" />
-            <default>0.0</default>
+            <range min="-120" max="40" />
+            <default>0</default>
         </key>
         <key name="sidechain-reactivity" type="d">
-            <range min="0.0" max="250.0" />
-            <default>10.0</default>
+            <range min="0" max="250" />
+            <default>10</default>
         </key>
         <key name="sidechain-lookahead" type="d">
-            <range min="0.0" max="20.0" />
-            <default>0.0</default>
+            <range min="0" max="20" />
+            <default>0</default>
         </key>
         <key name="hpf-mode" enum="com.github.wwmm.easyeffects.compressor.filter.mode.enum">
             <default>"off"</default>
         </key>
         <key name="hpf-frequency" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>10.0</default>
+            <range min="10" max="20000" />
+            <default>10</default>
         </key>
         <key name="lpf-mode" enum="com.github.wwmm.easyeffects.compressor.filter.mode.enum">
             <default>"off"</default>
         </key>
         <key name="lpf-frequency" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>20000.0</default>
+            <range min="10" max="20000" />
+            <default>20000</default>
         </key>
         <key name="sidechain-input-device" type="s">
             <default>""</default>

--- a/data/schemas/com.github.wwmm.easyeffects.convolver.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.convolver.gschema.xml
@@ -2,12 +2,12 @@
 <schemalist>
     <schema id="com.github.wwmm.easyeffects.convolver">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="kernel-path" type="s">
             <default>""</default>

--- a/data/schemas/com.github.wwmm.easyeffects.crossfeed.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.crossfeed.gschema.xml
@@ -2,12 +2,12 @@
 <schemalist>
     <schema id="com.github.wwmm.easyeffects.crossfeed">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="fcut" type="i">
             <range min="300" max="2000" />

--- a/data/schemas/com.github.wwmm.easyeffects.crystalizer.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.crystalizer.gschema.xml
@@ -2,65 +2,65 @@
 <schemalist>
     <schema id="com.github.wwmm.easyeffects.crystalizer">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
 
         <key name="intensity-band0" type="d">
             <range min="-40" max="32" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
         <key name="intensity-band1" type="d">
             <range min="-40" max="32" />
-            <default>-1.0</default>
+            <default>-1</default>
         </key>
         <key name="intensity-band2" type="d">
             <range min="-40" max="32" />
-            <default>-2.0</default>
+            <default>-2</default>
         </key>
         <key name="intensity-band3" type="d">
             <range min="-40" max="32" />
-            <default>-3.0</default>
+            <default>-3</default>
         </key>
         <key name="intensity-band4" type="d">
             <range min="-40" max="32" />
-            <default>-4.0</default>
+            <default>-4</default>
         </key>
         <key name="intensity-band5" type="d">
             <range min="-40" max="32" />
-            <default>-5.0</default>
+            <default>-5</default>
         </key>
         <key name="intensity-band6" type="d">
             <range min="-40" max="32" />
-            <default>-6.0</default>
+            <default>-6</default>
         </key>
         <key name="intensity-band7" type="d">
             <range min="-40" max="32" />
-            <default>-7.0</default>
+            <default>-7</default>
         </key>
         <key name="intensity-band8" type="d">
             <range min="-40" max="32" />
-            <default>-8.0</default>
+            <default>-8</default>
         </key>
         <key name="intensity-band9" type="d">
             <range min="-40" max="32" />
-            <default>-9.0</default>
+            <default>-9</default>
         </key>
         <key name="intensity-band10" type="d">
             <range min="-40" max="32" />
-            <default>-10.0</default>
+            <default>-10</default>
         </key>
         <key name="intensity-band11" type="d">
             <range min="-40" max="32" />
-            <default>-11.0</default>
+            <default>-11</default>
         </key>
         <key name="intensity-band12" type="d">
             <range min="-40" max="32" />
-            <default>-12.0</default>
+            <default>-12</default>
         </key>
 
         <key name="mute-band0" type="b">

--- a/data/schemas/com.github.wwmm.easyeffects.deesser.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.deesser.gschema.xml
@@ -10,12 +10,12 @@
     </enum>
     <schema id="com.github.wwmm.easyeffects.deesser">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="detection" enum="com.github.wwmm.easyeffects.deesser.detection.enum">
             <default>"RMS"</default>
@@ -24,7 +24,7 @@
             <default>"Wide"</default>
         </key>
         <key name="threshold" type="d">
-            <range min="-60.0" max="0" />
+            <range min="-60" max="0" />
             <default>-18</default>
         </key>
         <key name="ratio" type="d">
@@ -37,7 +37,7 @@
         </key>
         <key name="makeup" type="d">
             <range min="0" max="36" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
         <key name="f1-freq" type="d">
             <range min="10" max="18000" />
@@ -49,7 +49,7 @@
         </key>
         <key name="f1-level" type="d">
             <range min="-24" max="24" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
         <key name="f2-level" type="d">
             <range min="-24" max="24" />

--- a/data/schemas/com.github.wwmm.easyeffects.delay.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.delay.gschema.xml
@@ -2,20 +2,20 @@
 <schemalist>
     <schema id="com.github.wwmm.easyeffects.delay">
         <key name="input-gain" type="d">
-            <range min="-20.0" max="20.0" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-20.0" max="20.0" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="time-l" type="d">
             <range min="0" max="1000" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
         <key name="time-r" type="d">
             <range min="0" max="1000" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
     </schema>
 </schemalist>

--- a/data/schemas/com.github.wwmm.easyeffects.echo_canceller.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.echo_canceller.gschema.xml
@@ -2,12 +2,12 @@
 <schemalist>
     <schema id="com.github.wwmm.easyeffects.echocanceller">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="frame-size" type="i">
             <range min="1" max="100" />

--- a/data/schemas/com.github.wwmm.easyeffects.equalizer.channel.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.equalizer.channel.gschema.xml
@@ -190,7 +190,7 @@
         </key>
         <key name="band8-frequency" type="d">
             <range min="10" max="24000" />
-            <default>126.0</default>
+            <default>126</default>
         </key>
         <key name="band9-frequency" type="d">
             <range min="10" max="24000" />

--- a/data/schemas/com.github.wwmm.easyeffects.equalizer.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.equalizer.gschema.xml
@@ -12,12 +12,12 @@
             <default>32</default>
         </key>
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="split-channels" type="b">
             <default>false</default>

--- a/data/schemas/com.github.wwmm.easyeffects.exciter.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.exciter.gschema.xml
@@ -2,15 +2,15 @@
 <schemalist>
     <schema id="com.github.wwmm.easyeffects.exciter">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="amount" type="d">
-            <range min="-100" max="36.1" />
+            <range min="-100" max="36" />
             <default>0</default>
         </key>
         <key name="harmonics" type="d">

--- a/data/schemas/com.github.wwmm.easyeffects.filter.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.filter.gschema.xml
@@ -16,27 +16,27 @@
     </enum>
     <schema id="com.github.wwmm.easyeffects.filter">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="frequency" type="d">
             <range min="10" max="20000" />
             <default>2000</default>
         </key>
         <key name="resonance" type="d">
-            <range min="-3.0" max="30.1" />
-            <default>-3.0</default>
+            <range min="-3" max="30.1" />
+            <default>-3</default>
         </key>
         <key name="mode" enum="com.github.wwmm.easyeffects.filter.enum">
             <default>"12dB/oct Lowpass"</default>
         </key>
         <key name="inertia" type="d">
             <range min="5" max="100" />
-            <default>20.0</default>
+            <default>20</default>
         </key>
     </schema>
 </schemalist>

--- a/data/schemas/com.github.wwmm.easyeffects.gate.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.gate.gschema.xml
@@ -10,12 +10,12 @@
     </enum>
     <schema id="com.github.wwmm.easyeffects.gate">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="detection" enum="com.github.wwmm.easyeffects.gate.detection.enum">
             <default>"RMS"</default>
@@ -24,19 +24,19 @@
             <default>"Average"</default>
         </key>
         <key name="range" type="d">
-            <range min="-95.0" max="0" />
+            <range min="-95" max="0" />
             <default>-24</default>
         </key>
         <key name="attack" type="d">
             <range min="0.01" max="2000" />
-            <default>20.0</default>
+            <default>20</default>
         </key>
         <key name="release" type="d">
             <range min="0.01" max="2000" />
-            <default>250.0</default>
+            <default>250</default>
         </key>
         <key name="threshold" type="d">
-            <range min="-60.0" max="0" />
+            <range min="-60" max="0" />
             <default>-18</default>
         </key>
         <key name="ratio" type="d">
@@ -49,7 +49,7 @@
         </key>
         <key name="makeup" type="d">
             <range min="0" max="36" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
     </schema>
 </schemalist>

--- a/data/schemas/com.github.wwmm.easyeffects.limiter.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.limiter.gschema.xml
@@ -50,12 +50,12 @@
     </enum>
     <schema id="com.github.wwmm.easyeffects.limiter">
         <key name="input-gain" type="d">
-            <range min="-36.0" max="36.0" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.0" max="36.0" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="mode" enum="com.github.wwmm.easyeffects.limiter.mode.enum">
             <default>"Herm Thin"</default>
@@ -67,46 +67,46 @@
             <default>"None"</default>
         </key>
         <key name="lookahead" type="d">
-            <range min="0.1" max="20.0" />
-            <default>5.0</default>
+            <range min="0.1" max="20" />
+            <default>5</default>
         </key>
         <key name="attack" type="d">
-            <range min="0.25" max="20.0" />
-            <default>5.0</default>
+            <range min="0.25" max="20" />
+            <default>5</default>
         </key>
         <key name="release" type="d">
-            <range min="0.25" max="20.0" />
-            <default>5.0</default>
+            <range min="0.25" max="20" />
+            <default>5</default>
         </key>
         <key name="threshold" type="d">
-            <range min="-48.0" max="0.0" />
-            <default>0.0</default>
+            <range min="-48" max="0" />
+            <default>0</default>
         </key>
         <key name="gain-boost" type="b">
             <default>true</default>
         </key>
         <key name="sidechain-preamp" type="d">
-            <range min="-120" max="40.0" />
-            <default>0.0</default>
+            <range min="-120" max="40" />
+            <default>0</default>
         </key>
         <key name="stereo-link" type="d">
-            <range min="0.0" max="100.0" />
-            <default>100.0</default>
+            <range min="0" max="100" />
+            <default>100</default>
         </key>
         <key name="alr" type="b">
             <default>false</default>
         </key>
         <key name="alr-attack" type="d">
-            <range min="0.10" max="200.0" />
-            <default>5.0</default>
+            <range min="0.10" max="200" />
+            <default>5</default>
         </key>
         <key name="alr-release" type="d">
-            <range min="10.0" max="1000.0" />
-            <default>50.0</default>
+            <range min="10" max="1000" />
+            <default>50</default>
         </key>
         <key name="alr-knee" type="d">
-            <range min="-12.0" max="12.0" />
-            <default>0.0</default>
+            <range min="-12" max="12" />
+            <default>0</default>
         </key>
     </schema>
 </schemalist>

--- a/data/schemas/com.github.wwmm.easyeffects.loudness.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.loudness.gschema.xml
@@ -17,12 +17,12 @@
     </enum>
     <schema id="com.github.wwmm.easyeffects.loudness">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="fft" enum="com.github.wwmm.easyeffects.loudness.fft.enum">
             <default>"4096"</default>
@@ -31,12 +31,12 @@
             <default>"ISO226-2003"</default>
         </key>
         <key name="input" type="d">
-            <range min="-60.0" max="72.0" />
-            <default>0.0</default>
+            <range min="-60" max="72" />
+            <default>0</default>
         </key>
         <key name="volume" type="d">
-            <range min="-83.0" max="7.0" />
-            <default>0.0</default>
+            <range min="-83" max="7" />
+            <default>0</default>
         </key>
     </schema>
 </schemalist>

--- a/data/schemas/com.github.wwmm.easyeffects.maximizer.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.maximizer.gschema.xml
@@ -1,17 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
     <schema id="com.github.wwmm.easyeffects.maximizer">
+        <key name="input-gain" type="d">
+            <range min="-36" max="36" />
+            <default>0</default>
+        </key>
+        <key name="output-gain" type="d">
+            <range min="-36" max="36" />
+            <default>0</default>
+        </key>
         <key name="release" type="d">
             <range min="1" max="100" />
             <default>25</default>
         </key>
         <key name="ceiling" type="d">
             <range min="-30" max="0" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
         <key name="threshold" type="d">
             <range min="-30" max="0" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
     </schema>
 </schemalist>

--- a/data/schemas/com.github.wwmm.easyeffects.multibandcompressor.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.multibandcompressor.gschema.xml
@@ -30,12 +30,12 @@
     </enum>
     <schema id="com.github.wwmm.easyeffects.multibandcompressor">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
 
         <key name="compressor-mode" enum="com.github.wwmm.easyeffects.multibandcompressor.compressormode.enum">
@@ -68,32 +68,32 @@
         </key>
 
         <key name="split-frequency1" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>500.0</default>
+            <range min="10" max="20000" />
+            <default>500</default>
         </key>
         <key name="split-frequency2" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>1000.0</default>
+            <range min="10" max="20000" />
+            <default>1000</default>
         </key>
         <key name="split-frequency3" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>2000.0</default>
+            <range min="10" max="20000" />
+            <default>2000</default>
         </key>
         <key name="split-frequency4" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>4000.0</default>
+            <range min="10" max="20000" />
+            <default>4000</default>
         </key>
         <key name="split-frequency5" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>8000.0</default>
+            <range min="10" max="20000" />
+            <default>8000</default>
         </key>
         <key name="split-frequency6" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>12000.0</default>
+            <range min="10" max="20000" />
+            <default>12000</default>
         </key>
         <key name="split-frequency7" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>16000.0</default>
+            <range min="10" max="20000" />
+            <default>16000</default>
         </key>
 
         <key name="sidechain-mode0" enum="com.github.wwmm.easyeffects.multibandcompressor.sidechainmode.enum">
@@ -147,102 +147,102 @@
         </key>
 
         <key name="sidechain-lookahead0" type="d">
-            <range min="0.0" max="20.0" />
-            <default>0.0</default>
+            <range min="0" max="20" />
+            <default>0</default>
         </key>
         <key name="sidechain-lookahead1" type="d">
-            <range min="0.0" max="20.0" />
-            <default>0.0</default>
+            <range min="0" max="20" />
+            <default>0</default>
         </key>
         <key name="sidechain-lookahead2" type="d">
-            <range min="0.0" max="20.0" />
-            <default>0.0</default>
+            <range min="0" max="20" />
+            <default>0</default>
         </key>
         <key name="sidechain-lookahead3" type="d">
-            <range min="0.0" max="20.0" />
-            <default>0.0</default>
+            <range min="0" max="20" />
+            <default>0</default>
         </key>
         <key name="sidechain-lookahead4" type="d">
-            <range min="0.0" max="20.0" />
-            <default>0.0</default>
+            <range min="0" max="20" />
+            <default>0</default>
         </key>
         <key name="sidechain-lookahead5" type="d">
-            <range min="0.0" max="20.0" />
-            <default>0.0</default>
+            <range min="0" max="20" />
+            <default>0</default>
         </key>
         <key name="sidechain-lookahead6" type="d">
-            <range min="0.0" max="20.0" />
-            <default>0.0</default>
+            <range min="0" max="20" />
+            <default>0</default>
         </key>
         <key name="sidechain-lookahead7" type="d">
-            <range min="0.0" max="20.0" />
-            <default>0.0</default>
+            <range min="0" max="20" />
+            <default>0</default>
         </key>
 
         <key name="sidechain-reactivity0" type="d">
-            <range min="0.0" max="250.0" />
-            <default>10.0</default>
+            <range min="0" max="250" />
+            <default>10</default>
         </key>
         <key name="sidechain-reactivity1" type="d">
-            <range min="0.0" max="250.0" />
-            <default>10.0</default>
+            <range min="0" max="250" />
+            <default>10</default>
         </key>
         <key name="sidechain-reactivity2" type="d">
-            <range min="0.0" max="250.0" />
-            <default>10.0</default>
+            <range min="0" max="250" />
+            <default>10</default>
         </key>
         <key name="sidechain-reactivity3" type="d">
-            <range min="0.0" max="250.0" />
-            <default>10.0</default>
+            <range min="0" max="250" />
+            <default>10</default>
         </key>
         <key name="sidechain-reactivity4" type="d">
-            <range min="0.0" max="250.0" />
-            <default>10.0</default>
+            <range min="0" max="250" />
+            <default>10</default>
         </key>
         <key name="sidechain-reactivity5" type="d">
-            <range min="0.0" max="250.0" />
-            <default>10.0</default>
+            <range min="0" max="250" />
+            <default>10</default>
         </key>
         <key name="sidechain-reactivity6" type="d">
-            <range min="0.0" max="250.0" />
-            <default>10.0</default>
+            <range min="0" max="250" />
+            <default>10</default>
         </key>
         <key name="sidechain-reactivity7" type="d">
-            <range min="0.0" max="250.0" />
-            <default>10.0</default>
+            <range min="0" max="250" />
+            <default>10</default>
         </key>
 
         <key name="sidechain-preamp0" type="d">
-            <range min="-120.0" max="40.0" />
-            <default>0.0</default>
+            <range min="-120" max="40" />
+            <default>0</default>
         </key>
         <key name="sidechain-preamp1" type="d">
-            <range min="-120.0" max="40.0" />
-            <default>0.0</default>
+            <range min="-120" max="40" />
+            <default>0</default>
         </key>
         <key name="sidechain-preamp2" type="d">
-            <range min="-120.0" max="40.0" />
-            <default>0.0</default>
+            <range min="-120" max="40" />
+            <default>0</default>
         </key>
         <key name="sidechain-preamp3" type="d">
-            <range min="-120.0" max="40.0" />
-            <default>0.0</default>
+            <range min="-120" max="40" />
+            <default>0</default>
         </key>
         <key name="sidechain-preamp4" type="d">
-            <range min="-120.0" max="40.0" />
-            <default>0.0</default>
+            <range min="-120" max="40" />
+            <default>0</default>
         </key>
         <key name="sidechain-preamp5" type="d">
-            <range min="-120.0" max="40.0" />
-            <default>0.0</default>
+            <range min="-120" max="40" />
+            <default>0</default>
         </key>
         <key name="sidechain-preamp6" type="d">
-            <range min="-120.0" max="40.0" />
-            <default>0.0</default>
+            <range min="-120" max="40" />
+            <default>0</default>
         </key>
         <key name="sidechain-preamp7" type="d">
-            <range min="-120.0" max="40.0" />
-            <default>0.0</default>
+            <range min="-120" max="40" />
+            <default>0</default>
         </key>
 
         <key name="sidechain-custom-lowcut-filter0" type="b">
@@ -296,69 +296,69 @@
         </key>
 
         <key name="sidechain-lowcut-frequency0" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>10.0</default>
+            <range min="10" max="20000" />
+            <default>10</default>
         </key>
         <key name="sidechain-lowcut-frequency1" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>500.0</default>
+            <range min="10" max="20000" />
+            <default>500</default>
         </key>
         <key name="sidechain-lowcut-frequency2" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>1000.0</default>
+            <range min="10" max="20000" />
+            <default>1000</default>
         </key>
         <key name="sidechain-lowcut-frequency3" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>2000.0</default>
+            <range min="10" max="20000" />
+            <default>2000</default>
         </key>
         <key name="sidechain-lowcut-frequency4" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>4000.0</default>
+            <range min="10" max="20000" />
+            <default>4000</default>
         </key>
         <key name="sidechain-lowcut-frequency5" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>8000.0</default>
+            <range min="10" max="20000" />
+            <default>8000</default>
         </key>
         <key name="sidechain-lowcut-frequency6" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>12000.0</default>
+            <range min="10" max="20000" />
+            <default>12000</default>
         </key>
         <key name="sidechain-lowcut-frequency7" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>16000.0</default>
+            <range min="10" max="20000" />
+            <default>16000</default>
         </key>
 
         <key name="sidechain-highcut-frequency0" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>500.0</default>
+            <range min="10" max="20000" />
+            <default>500</default>
         </key>
         <key name="sidechain-highcut-frequency1" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>1000.0</default>
+            <range min="10" max="20000" />
+            <default>1000</default>
         </key>
         <key name="sidechain-highcut-frequency2" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>2000.0</default>
+            <range min="10" max="20000" />
+            <default>2000</default>
         </key>
         <key name="sidechain-highcut-frequency3" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>4000.0</default>
+            <range min="10" max="20000" />
+            <default>4000</default>
         </key>
         <key name="sidechain-highcut-frequency4" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>8000.0</default>
+            <range min="10" max="20000" />
+            <default>8000</default>
         </key>
         <key name="sidechain-highcut-frequency5" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>12000.0</default>
+            <range min="10" max="20000" />
+            <default>12000</default>
         </key>
         <key name="sidechain-highcut-frequency6" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>16000.0</default>
+            <range min="10" max="20000" />
+            <default>16000</default>
         </key>
         <key name="sidechain-highcut-frequency7" type="d">
-            <range min="10.0" max="20000.0" />
-            <default>20000.0</default>
+            <range min="10" max="20000" />
+            <default>20000</default>
         </key>
 
         <key name="compression-mode0" enum="com.github.wwmm.easyeffects.multibandcompressor.compressionmode.enum">
@@ -462,301 +462,301 @@
         </key>
 
         <key name="attack-threshold0" type="d">
-            <range min="-60.0" max="0.0" />
-            <default>-12.0</default>
+            <range min="-60" max="0" />
+            <default>-12</default>
         </key>
         <key name="attack-threshold1" type="d">
-            <range min="-60.0" max="0.0" />
-            <default>-12.0</default>
+            <range min="-60" max="0" />
+            <default>-12</default>
         </key>
         <key name="attack-threshold2" type="d">
-            <range min="-60.0" max="0.0" />
-            <default>-12.0</default>
+            <range min="-60" max="0" />
+            <default>-12</default>
         </key>
         <key name="attack-threshold3" type="d">
-            <range min="-60.0" max="0.0" />
-            <default>-12.0</default>
+            <range min="-60" max="0" />
+            <default>-12</default>
         </key>
         <key name="attack-threshold4" type="d">
-            <range min="-60.0" max="0.0" />
-            <default>-12.0</default>
+            <range min="-60" max="0" />
+            <default>-12</default>
         </key>
         <key name="attack-threshold5" type="d">
-            <range min="-60.0" max="0.0" />
-            <default>-12.0</default>
+            <range min="-60" max="0" />
+            <default>-12</default>
         </key>
         <key name="attack-threshold6" type="d">
-            <range min="-60.0" max="0.0" />
-            <default>-12.0</default>
+            <range min="-60" max="0" />
+            <default>-12</default>
         </key>
         <key name="attack-threshold7" type="d">
-            <range min="-60.0" max="0.0" />
-            <default>-12.0</default>
+            <range min="-60" max="0" />
+            <default>-12</default>
         </key>
 
         <key name="attack-time0" type="d">
-            <range min="0.0" max="2000.0" />
-            <default>20.0</default>
+            <range min="0" max="2000" />
+            <default>20</default>
         </key>
         <key name="attack-time1" type="d">
-            <range min="0.0" max="2000.0" />
-            <default>20.0</default>
+            <range min="0" max="2000" />
+            <default>20</default>
         </key>
         <key name="attack-time2" type="d">
-            <range min="0.0" max="2000.0" />
-            <default>20.0</default>
+            <range min="0" max="2000" />
+            <default>20</default>
         </key>
         <key name="attack-time3" type="d">
-            <range min="0.0" max="2000.0" />
-            <default>20.0</default>
+            <range min="0" max="2000" />
+            <default>20</default>
         </key>
         <key name="attack-time4" type="d">
-            <range min="0.0" max="2000.0" />
-            <default>20.0</default>
+            <range min="0" max="2000" />
+            <default>20</default>
         </key>
         <key name="attack-time5" type="d">
-            <range min="0.0" max="2000.0" />
-            <default>20.0</default>
+            <range min="0" max="2000" />
+            <default>20</default>
         </key>
         <key name="attack-time6" type="d">
-            <range min="0.0" max="2000.0" />
-            <default>20.0</default>
+            <range min="0" max="2000" />
+            <default>20</default>
         </key>
         <key name="attack-time7" type="d">
-            <range min="0.0" max="2000.0" />
-            <default>20.0</default>
+            <range min="0" max="2000" />
+            <default>20</default>
         </key>
 
         <key name="release-threshold0" type="d">
-            <range min="-120.0" max="36.0" />
-            <default>-120.0</default>
+            <range min="-120" max="36" />
+            <default>-120</default>
         </key>
         <key name="release-threshold1" type="d">
-            <range min="-120.0" max="36.0" />
-            <default>-120.0</default>
+            <range min="-120" max="36" />
+            <default>-120</default>
         </key>
         <key name="release-threshold2" type="d">
-            <range min="-120.0" max="36.0" />
-            <default>-120.0</default>
+            <range min="-120" max="36" />
+            <default>-120</default>
         </key>
         <key name="release-threshold3" type="d">
-            <range min="-120.0" max="36.0" />
-            <default>-120.0</default>
+            <range min="-120" max="36" />
+            <default>-120</default>
         </key>
         <key name="release-threshold4" type="d">
-            <range min="-120.0" max="36.0" />
-            <default>-120.0</default>
+            <range min="-120" max="36" />
+            <default>-120</default>
         </key>
         <key name="release-threshold5" type="d">
-            <range min="-120.0" max="36.0" />
-            <default>-120.0</default>
+            <range min="-120" max="36" />
+            <default>-120</default>
         </key>
         <key name="release-threshold6" type="d">
-            <range min="-120.0" max="36.0" />
-            <default>-120.0</default>
+            <range min="-120" max="36" />
+            <default>-120</default>
         </key>
         <key name="release-threshold7" type="d">
-            <range min="-120.0" max="36.0" />
-            <default>-120.0</default>
+            <range min="-120" max="36" />
+            <default>-120</default>
         </key>
 
         <key name="release-time0" type="d">
-            <range min="0.00" max="5000.0" />
-            <default>100.0</default>
+            <range min="0" max="5000" />
+            <default>100</default>
         </key>
         <key name="release-time1" type="d">
-            <range min="0.00" max="5000.0" />
-            <default>100.0</default>
+            <range min="0" max="5000" />
+            <default>100</default>
         </key>
         <key name="release-time2" type="d">
-            <range min="0.00" max="5000.0" />
-            <default>100.0</default>
+            <range min="0" max="5000" />
+            <default>100</default>
         </key>
         <key name="release-time3" type="d">
-            <range min="0.00" max="5000.0" />
-            <default>100.0</default>
+            <range min="0" max="5000" />
+            <default>100</default>
         </key>
         <key name="release-time4" type="d">
-            <range min="0.00" max="5000.0" />
-            <default>100.0</default>
+            <range min="0" max="5000" />
+            <default>100</default>
         </key>
         <key name="release-time5" type="d">
-            <range min="0.00" max="5000.0" />
-            <default>100.0</default>
+            <range min="0" max="5000" />
+            <default>100</default>
         </key>
         <key name="release-time6" type="d">
-            <range min="0.00" max="5000.0" />
-            <default>100.0</default>
+            <range min="0" max="5000" />
+            <default>100</default>
         </key>
         <key name="release-time7" type="d">
-            <range min="0.00" max="5000.0" />
-            <default>100.0</default>
+            <range min="0" max="5000" />
+            <default>100</default>
         </key>
 
         <key name="ratio0" type="d">
-            <range min="1.0" max="100.0" />
-            <default>1.0</default>
+            <range min="1" max="100" />
+            <default>1</default>
         </key>
         <key name="ratio1" type="d">
-            <range min="1.0" max="100.0" />
-            <default>1.0</default>
+            <range min="1" max="100" />
+            <default>1</default>
         </key>
         <key name="ratio2" type="d">
-            <range min="1.0" max="100.0" />
-            <default>1.0</default>
+            <range min="1" max="100" />
+            <default>1</default>
         </key>
         <key name="ratio3" type="d">
-            <range min="1.0" max="100.0" />
-            <default>1.0</default>
+            <range min="1" max="100" />
+            <default>1</default>
         </key>
         <key name="ratio4" type="d">
-            <range min="1.0" max="100.0" />
-            <default>1.0</default>
+            <range min="1" max="100" />
+            <default>1</default>
         </key>
         <key name="ratio5" type="d">
-            <range min="1.0" max="100.0" />
-            <default>1.0</default>
+            <range min="1" max="100" />
+            <default>1</default>
         </key>
         <key name="ratio6" type="d">
-            <range min="1.0" max="100.0" />
-            <default>1.0</default>
+            <range min="1" max="100" />
+            <default>1</default>
         </key>
         <key name="ratio7" type="d">
-            <range min="1.0" max="100.0" />
-            <default>1.0</default>
+            <range min="1" max="100" />
+            <default>1</default>
         </key>
 
         <key name="knee0" type="d">
-            <range min="-24.0" max="0.0" />
-            <default>-6.0</default>
+            <range min="-24" max="0" />
+            <default>-6</default>
         </key>
         <key name="knee1" type="d">
-            <range min="-24.0" max="0.0" />
-            <default>-6.0</default>
+            <range min="-24" max="0" />
+            <default>-6</default>
         </key>
         <key name="knee2" type="d">
-            <range min="-24.0" max="0.0" />
-            <default>-6.0</default>
+            <range min="-24" max="0" />
+            <default>-6</default>
         </key>
         <key name="knee3" type="d">
-            <range min="-24.0" max="0.0" />
-            <default>-6.0</default>
+            <range min="-24" max="0" />
+            <default>-6</default>
         </key>
         <key name="knee4" type="d">
-            <range min="-24.0" max="0.0" />
-            <default>-6.0</default>
+            <range min="-24" max="0" />
+            <default>-6</default>
         </key>
         <key name="knee5" type="d">
-            <range min="-24.0" max="0.0" />
-            <default>-6.0</default>
+            <range min="-24" max="0" />
+            <default>-6</default>
         </key>
         <key name="knee6" type="d">
-            <range min="-24.0" max="0.0" />
-            <default>-6.0</default>
+            <range min="-24" max="0" />
+            <default>-6</default>
         </key>
         <key name="knee7" type="d">
-            <range min="-24.0" max="0.0" />
-            <default>-6.0</default>
+            <range min="-24" max="0" />
+            <default>-6</default>
         </key>
 
         <key name="boost-threshold0" type="d">
-            <range min="-120.0" max="-60.0" />
-            <default>-72.0</default>
+            <range min="-120" max="-60" />
+            <default>-72</default>
         </key>
         <key name="boost-threshold1" type="d">
-            <range min="-120.0" max="-60.0" />
-            <default>-72.0</default>
+            <range min="-120" max="-60" />
+            <default>-72</default>
         </key>
         <key name="boost-threshold2" type="d">
-            <range min="-120.0" max="-60.0" />
-            <default>-72.0</default>
+            <range min="-120" max="-60" />
+            <default>-72</default>
         </key>
         <key name="boost-threshold3" type="d">
-            <range min="-120.0" max="-60.0" />
-            <default>-72.0</default>
+            <range min="-120" max="-60" />
+            <default>-72</default>
         </key>
         <key name="boost-threshold4" type="d">
-            <range min="-120.0" max="-60.0" />
-            <default>-72.0</default>
+            <range min="-120" max="-60" />
+            <default>-72</default>
         </key>
         <key name="boost-threshold5" type="d">
-            <range min="-120.0" max="-60.0" />
-            <default>-72.0</default>
+            <range min="-120" max="-60" />
+            <default>-72</default>
         </key>
         <key name="boost-threshold6" type="d">
-            <range min="-120.0" max="-60.0" />
-            <default>-72.0</default>
+            <range min="-120" max="-60" />
+            <default>-72</default>
         </key>
         <key name="boost-threshold7" type="d">
-            <range min="-120.0" max="-60.0" />
-            <default>-72.0</default>
+            <range min="-120" max="-60" />
+            <default>-72</default>
         </key>
 
         <key name="boost-amount0" type="d">
-            <range min="0.0" max="72.0" />
-            <default>6.0</default>
+            <range min="0" max="72" />
+            <default>6</default>
         </key>
         <key name="boost-amount1" type="d">
-            <range min="0.0" max="72.0" />
-            <default>6.0</default>
+            <range min="0" max="72" />
+            <default>6</default>
         </key>
         <key name="boost-amount2" type="d">
-            <range min="0.0" max="72.0" />
-            <default>6.0</default>
+            <range min="0" max="72" />
+            <default>6</default>
         </key>
         <key name="boost-amount3" type="d">
-            <range min="0.0" max="72.0" />
-            <default>6.0</default>
+            <range min="0" max="72" />
+            <default>6</default>
         </key>
         <key name="boost-amount4" type="d">
-            <range min="0.0" max="72.0" />
-            <default>6.0</default>
+            <range min="0" max="72" />
+            <default>6</default>
         </key>
         <key name="boost-amount5" type="d">
-            <range min="0.0" max="72.0" />
-            <default>6.0</default>
+            <range min="0" max="72" />
+            <default>6</default>
         </key>
         <key name="boost-amount6" type="d">
-            <range min="0.0" max="72.0" />
-            <default>6.0</default>
+            <range min="0" max="72" />
+            <default>6</default>
         </key>
         <key name="boost-amount7" type="d">
-            <range min="0.0" max="72.0" />
-            <default>6.0</default>
+            <range min="0" max="72" />
+            <default>6</default>
         </key>
 
 
         <key name="makeup0" type="d">
-            <range min="-60.0" max="60.0" />
-            <default>0.0</default>
+            <range min="-60" max="60" />
+            <default>0</default>
         </key>
         <key name="makeup1" type="d">
-            <range min="-60.0" max="60.0" />
-            <default>0.0</default>
+            <range min="-60" max="60" />
+            <default>0</default>
         </key>
         <key name="makeup2" type="d">
-            <range min="-60.0" max="60.0" />
-            <default>0.0</default>
+            <range min="-60" max="60" />
+            <default>0</default>
         </key>
         <key name="makeup3" type="d">
-            <range min="-60.0" max="60.0" />
-            <default>0.0</default>
+            <range min="-60" max="60" />
+            <default>0</default>
         </key>
         <key name="makeup4" type="d">
-            <range min="-60.0" max="60.0" />
-            <default>0.0</default>
+            <range min="-60" max="60" />
+            <default>0</default>
         </key>
         <key name="makeup5" type="d">
-            <range min="-60.0" max="60.0" />
-            <default>0.0</default>
+            <range min="-60" max="60" />
+            <default>0</default>
         </key>
         <key name="makeup6" type="d">
-            <range min="-60.0" max="60.0" />
-            <default>0.0</default>
+            <range min="-60" max="60" />
+            <default>0</default>
         </key>
         <key name="makeup7" type="d">
-            <range min="-60.0" max="60.0" />
-            <default>0.0</default>
+            <range min="-60" max="60" />
+            <default>0</default>
         </key>
 
     </schema>

--- a/data/schemas/com.github.wwmm.easyeffects.multibandgate.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.multibandgate.gschema.xml
@@ -10,12 +10,12 @@
     </enum>
     <schema id="com.github.wwmm.easyeffects.multibandgate">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="freq0" type="d">
             <range min="10" max="20000" />
@@ -33,11 +33,11 @@
             <default>"LR8"</default>
         </key>
         <key name="range0" type="d">
-            <range min="-95.0" max="0" />
+            <range min="-95" max="0" />
             <default>-24</default>
         </key>
         <key name="threshold0" type="d">
-            <range min="-60.0" max="0" />
+            <range min="-60" max="0" />
             <default>-12</default>
         </key>
         <key name="ratio0" type="d">
@@ -46,15 +46,15 @@
         </key>
         <key name="attack0" type="d">
             <range min="0.01" max="2000" />
-            <default>150.0</default>
+            <default>150</default>
         </key>
         <key name="release0" type="d">
             <range min="0.01" max="2000" />
-            <default>300.0</default>
+            <default>300</default>
         </key>
         <key name="makeup0" type="d">
             <range min="0" max="36" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
         <key name="knee0" type="d">
             <range min="0" max="18" />
@@ -70,11 +70,11 @@
             <default>false</default>
         </key>
         <key name="range1" type="d">
-            <range min="-95.0" max="0" />
+            <range min="-95" max="0" />
             <default>-24</default>
         </key>
         <key name="threshold1" type="d">
-            <range min="-60.0" max="0" />
+            <range min="-60" max="0" />
             <default>-12</default>
         </key>
         <key name="ratio1" type="d">
@@ -83,15 +83,15 @@
         </key>
         <key name="attack1" type="d">
             <range min="0.01" max="2000" />
-            <default>150.0</default>
+            <default>150</default>
         </key>
         <key name="release1" type="d">
             <range min="0.01" max="2000" />
-            <default>300.0</default>
+            <default>300</default>
         </key>
         <key name="makeup1" type="d">
             <range min="0" max="36" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
         <key name="knee1" type="d">
             <range min="0" max="18" />
@@ -107,11 +107,11 @@
             <default>false</default>
         </key>
         <key name="range2" type="d">
-            <range min="-95.0" max="0" />
+            <range min="-95" max="0" />
             <default>-24</default>
         </key>
         <key name="threshold2" type="d">
-            <range min="-60.0" max="0" />
+            <range min="-60" max="0" />
             <default>-12</default>
         </key>
         <key name="ratio2" type="d">
@@ -120,15 +120,15 @@
         </key>
         <key name="attack2" type="d">
             <range min="0.01" max="2000" />
-            <default>150.0</default>
+            <default>150</default>
         </key>
         <key name="release2" type="d">
             <range min="0.01" max="2000" />
-            <default>300.0</default>
+            <default>300</default>
         </key>
         <key name="makeup2" type="d">
             <range min="0" max="36" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
         <key name="knee2" type="d">
             <range min="0" max="18" />
@@ -144,11 +144,11 @@
             <default>false</default>
         </key>
         <key name="range3" type="d">
-            <range min="-95.0" max="0" />
+            <range min="-95" max="0" />
             <default>-24</default>
         </key>
         <key name="threshold3" type="d">
-            <range min="-60.0" max="0" />
+            <range min="-60" max="0" />
             <default>-12</default>
         </key>
         <key name="ratio3" type="d">
@@ -157,15 +157,15 @@
         </key>
         <key name="attack3" type="d">
             <range min="0.01" max="2000" />
-            <default>150.0</default>
+            <default>150</default>
         </key>
         <key name="release3" type="d">
             <range min="0.01" max="2000" />
-            <default>300.0</default>
+            <default>300</default>
         </key>
         <key name="makeup3" type="d">
             <range min="0" max="36" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
         <key name="knee3" type="d">
             <range min="0" max="18" />

--- a/data/schemas/com.github.wwmm.easyeffects.pitch.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.pitch.gschema.xml
@@ -2,12 +2,12 @@
 <schemalist>
     <schema id="com.github.wwmm.easyeffects.pitch">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="cents" type="i">
             <range min="-100" max="100" />

--- a/data/schemas/com.github.wwmm.easyeffects.reverb.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.reverb.gschema.xml
@@ -10,12 +10,12 @@
     </enum>
     <schema id="com.github.wwmm.easyeffects.reverb">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="room-size" enum="com.github.wwmm.easyeffects.reverb.roomsize.enum">
             <default>"Large"</default>

--- a/data/schemas/com.github.wwmm.easyeffects.rnnoise.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.rnnoise.gschema.xml
@@ -2,12 +2,12 @@
 <schemalist>
     <schema id="com.github.wwmm.easyeffects.rnnoise">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="model-path" type="s">
             <default>""</default>

--- a/data/schemas/com.github.wwmm.easyeffects.spectrum.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.spectrum.gschema.xml
@@ -19,8 +19,8 @@
             <default>100</default>
         </key>
         <key name="line-width" type="d">
-            <range min="0.1" max="100.0" />
-            <default>2.0</default>
+            <range min="0.1" max="100" />
+            <default>2</default>
         </key>
         <key name="color" type="ad">
             <default>[1.0,1.0,1.0,1.0]</default>

--- a/data/schemas/com.github.wwmm.easyeffects.stereotools.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.stereotools.gschema.xml
@@ -11,20 +11,20 @@
     </enum>
     <schema id="com.github.wwmm.easyeffects.stereotools">
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="balance-in" type="d">
             <range min="-1" max="1" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
         <key name="balance-out" type="d">
             <range min="-1" max="1" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
         <key name="softclip" type="b">
             <default>false</default>
@@ -45,28 +45,28 @@
             <default>"LR > LR (Stereo Default)"</default>
         </key>
         <key name="slev" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="sbal" type="d">
             <range min="-1" max="1" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
         <key name="mlev" type="d">
-            <range min="-36.1" max="36.1" />
-            <default>0.0</default>
+            <range min="-36" max="36" />
+            <default>0</default>
         </key>
         <key name="mpan" type="d">
             <range min="-1" max="1" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
         <key name="stereo-base" type="d">
             <range min="-1" max="1" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
         <key name="delay" type="d">
             <range min="-20" max="20" />
-            <default>0.0</default>
+            <default>0</default>
         </key>
         <key name="sc-level" type="d">
             <range min="1" max="100" />

--- a/data/ui/app_info.ui
+++ b/data/ui/app_info.ui
@@ -223,7 +223,6 @@
 
                 <child>
                     <object class="GtkScale" id="scale_volume">
-                        <property name="visible">False</property>
                         <property name="hexpand">1</property>
                         <property name="valign">center</property>
                         <property name="adjustment">volume</property>

--- a/include/autogain.hpp
+++ b/include/autogain.hpp
@@ -56,7 +56,7 @@ class AutoGain : public PluginBase {
   uint old_rate = 0U;
 
   double target = -23.0;  // target loudness level
-  double output_gain = 1.0;
+  double internal_output_gain = 1.0;
 
   std::vector<float> data;
 

--- a/include/bass_enhancer_ui.hpp
+++ b/include/bass_enhancer_ui.hpp
@@ -47,7 +47,7 @@ class BassEnhancerUi : public Gtk::Box, public PluginUiBase {
 
   Gtk::SpinButton *floor = nullptr, *amount = nullptr, *harmonics = nullptr, *scope = nullptr;
 
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr, *blend = nullptr;
+  Gtk::Scale* blend = nullptr;
 
   Gtk::ToggleButton *floor_active = nullptr, *listen = nullptr;
 };

--- a/include/bass_loudness_ui.hpp
+++ b/include/bass_loudness_ui.hpp
@@ -40,8 +40,6 @@ class BassLoudnessUi : public Gtk::Box, public PluginUiBase {
 
  private:
   Gtk::SpinButton *loudness = nullptr, *output = nullptr, *link = nullptr;
-
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
 };
 
 #endif

--- a/include/compressor_ui.hpp
+++ b/include/compressor_ui.hpp
@@ -55,8 +55,6 @@ class CompressorUi : public Gtk::Box, public PluginUiBase {
                   *boost_amount = nullptr, *preamp = nullptr, *reactivity = nullptr, *lookahead = nullptr,
                   *hpf_freq = nullptr, *lpf_freq = nullptr;
 
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
-
   Gtk::Label *reduction_label = nullptr, *sidechain_label = nullptr, *curve_label = nullptr, *envelope_label = nullptr;
 
   Gtk::ComboBoxText *compression_mode = nullptr, *sidechain_type = nullptr, *sidechain_mode = nullptr,

--- a/include/convolver_ui.hpp
+++ b/include/convolver_ui.hpp
@@ -55,8 +55,6 @@ class ConvolverUi : public Gtk::Box, public PluginUiBase {
 
   Gtk::SpinButton* ir_width = nullptr;
 
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
-
   Gtk::ListView* listview = nullptr;
 
   Gtk::ScrolledWindow* scrolled_window = nullptr;

--- a/include/crossfeed_ui.hpp
+++ b/include/crossfeed_ui.hpp
@@ -41,8 +41,6 @@ class CrossfeedUi : public Gtk::Box, public PluginUiBase {
  private:
   Gtk::SpinButton *fcut = nullptr, *feed = nullptr;
 
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
-
   Gtk::Button *preset_cmoy = nullptr, *preset_default = nullptr, *preset_jmeier = nullptr;
 
   void init_presets_buttons();

--- a/include/crystalizer_ui.hpp
+++ b/include/crystalizer_ui.hpp
@@ -41,8 +41,6 @@ class CrystalizerUi : public Gtk::Box, public PluginUiBase {
  private:
   Gtk::Box* bands_box = nullptr;
 
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
-
   void build_bands(const int& nbands);
 };
 

--- a/include/deesser_ui.hpp
+++ b/include/deesser_ui.hpp
@@ -45,8 +45,6 @@ class DeesserUi : public Gtk::Box, public PluginUiBase {
   Gtk::SpinButton *f1_freq = nullptr, *f2_freq = nullptr, *f1_level = nullptr, *f2_level = nullptr, *f2_q = nullptr,
                   *threshold = nullptr, *ratio = nullptr, *laxity = nullptr, *makeup = nullptr;
 
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
-
   Gtk::LevelBar *compression = nullptr, *detected = nullptr;
 
   Gtk::Label *compression_label = nullptr, *detected_label = nullptr;

--- a/include/delay_ui.hpp
+++ b/include/delay_ui.hpp
@@ -40,8 +40,6 @@ class DelayUi : public Gtk::Box, public PluginUiBase {
 
  private:
   Gtk::SpinButton *time_l = nullptr, *time_r = nullptr;
-
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
 };
 
 #endif

--- a/include/echo_canceller_ui.hpp
+++ b/include/echo_canceller_ui.hpp
@@ -40,8 +40,6 @@ class EchoCancellerUi : public Gtk::Box, public PluginUiBase {
 
  private:
   Gtk::SpinButton *frame_size = nullptr, *filter_length = nullptr;
-
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
 };
 
 #endif

--- a/include/effects_base_ui.hpp
+++ b/include/effects_base_ui.hpp
@@ -93,7 +93,7 @@ class EffectsBaseUi {
 
   std::vector<sigc::connection> connections;
 
-  void on_app_added(uint id, std::string name, std::string media_class);
+  void on_app_added(const uint id, const std::string name, const std::string media_class);
   void on_app_changed(NodeInfo node_info);
   void on_app_removed(NodeInfo node_info);
 

--- a/include/effects_base_ui.hpp
+++ b/include/effects_base_ui.hpp
@@ -95,7 +95,7 @@ class EffectsBaseUi {
 
   void on_app_added(const uint id, const std::string name, const std::string media_class);
   void on_app_changed(const uint id);
-  void on_app_removed(NodeInfo node_info);
+  void on_app_removed(const uint id);
 
   void on_new_output_level_db(const float& left, const float& right);
 

--- a/include/effects_base_ui.hpp
+++ b/include/effects_base_ui.hpp
@@ -93,11 +93,7 @@ class EffectsBaseUi {
 
   std::vector<sigc::connection> connections;
 
-  /*
-    Do not pass node_info by reference. Sometimes it dies before we use it and a segmentation fault happens.
-  */
-
-  void on_app_added(NodeInfo node_info);
+  void on_app_added(uint id, std::string name, std::string media_class);
   void on_app_changed(NodeInfo node_info);
   void on_app_removed(NodeInfo node_info);
 
@@ -174,9 +170,9 @@ class EffectsBaseUi {
 
   void remove_blocklist_entry(const Glib::ustring& name);
 
-  void connect_stream(const NodeInfo& node_info);
+  void connect_stream(const uint& id, const std::string& media_class);
 
-  void disconnect_stream(const NodeInfo& node_info);
+  void disconnect_stream(const uint& id, const std::string& media_class);
 };
 
 #endif

--- a/include/effects_base_ui.hpp
+++ b/include/effects_base_ui.hpp
@@ -94,7 +94,7 @@ class EffectsBaseUi {
   std::vector<sigc::connection> connections;
 
   void on_app_added(const uint id, const std::string name, const std::string media_class);
-  void on_app_changed(NodeInfo node_info);
+  void on_app_changed(const uint id);
   void on_app_removed(NodeInfo node_info);
 
   void on_new_output_level_db(const float& left, const float& right);

--- a/include/equalizer_ui.hpp
+++ b/include/equalizer_ui.hpp
@@ -74,8 +74,6 @@ class EqualizerUi : public Gtk::Box, public PluginUiBase {
 
   Glib::RefPtr<Gio::Settings> settings_left, settings_right;
 
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
-
   Gtk::SpinButton *nbands = nullptr, *resonance = nullptr, *inertia = nullptr;
 
   Gtk::Box *bands_box_left = nullptr, *bands_box_right = nullptr;

--- a/include/exciter_ui.hpp
+++ b/include/exciter_ui.hpp
@@ -47,7 +47,7 @@ class ExciterUi : public Gtk::Box, public PluginUiBase {
 
   Gtk::SpinButton *ceil = nullptr, *amount = nullptr, *harmonics = nullptr, *scope = nullptr;
 
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr, *blend = nullptr;
+  Gtk::Scale* blend = nullptr;
 
   Gtk::ToggleButton *ceil_active = nullptr, *listen = nullptr;
 };

--- a/include/filter_ui.hpp
+++ b/include/filter_ui.hpp
@@ -42,8 +42,6 @@ class FilterUi : public Gtk::Box, public PluginUiBase {
   Gtk::ComboBoxText* mode = nullptr;
 
   Gtk::SpinButton *frequency = nullptr, *resonance = nullptr, *inertia = nullptr;
-
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
 };
 
 #endif

--- a/include/gate_ui.hpp
+++ b/include/gate_ui.hpp
@@ -49,8 +49,6 @@ class GateUi : public Gtk::Box, public PluginUiBase {
   Gtk::Label* gating_label = nullptr;
 
   Gtk::ComboBoxText *detection = nullptr, *stereo_link = nullptr;
-
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
 };
 
 #endif

--- a/include/info_holders.hpp
+++ b/include/info_holders.hpp
@@ -29,7 +29,7 @@ class NodeInfoHolder : public Glib::Object {
 
   static auto create(const NodeInfo& info) -> Glib::RefPtr<NodeInfoHolder>;
 
-  sigc::signal<void(NodeInfo)> info_updated;
+  sigc::signal<void()> info_updated;
 
  protected:
   NodeInfoHolder(NodeInfo info);

--- a/include/limiter_ui.hpp
+++ b/include/limiter_ui.hpp
@@ -55,8 +55,6 @@ class LimiterUi : public Gtk::Box, public PluginUiBase {
   Gtk::ToggleButton* alr = nullptr;
 
   Gtk::Label *gain_left = nullptr, *gain_right = nullptr, *sidechain_left = nullptr, *sidechain_right = nullptr;
-
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
 };
 
 #endif

--- a/include/loudness_ui.hpp
+++ b/include/loudness_ui.hpp
@@ -42,8 +42,6 @@ class LoudnessUi : public Gtk::Box, public PluginUiBase {
   Gtk::ComboBoxText *fft_size = nullptr, *standard = nullptr;
 
   Gtk::SpinButton* volume = nullptr;
-
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
 };
 
 #endif

--- a/include/multiband_compressor_ui.hpp
+++ b/include/multiband_compressor_ui.hpp
@@ -55,8 +55,6 @@ class MultibandCompressorUi : public Gtk::Box, public PluginUiBase {
 
   Gtk::ListBox* listbox = nullptr;
 
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
-
   std::array<Gtk::Label*, n_bands> bands_end, bands_gain_label, bands_envelope_label, bands_curve_label;
 
   void prepare_bands();

--- a/include/multiband_gate_ui.hpp
+++ b/include/multiband_gate_ui.hpp
@@ -63,8 +63,6 @@ class MultibandGateUi : public Gtk::Box, public PluginUiBase {
   Gtk::SpinButton *range3 = nullptr, *attack3 = nullptr, *release3 = nullptr, *threshold3 = nullptr, *knee3 = nullptr,
                   *ratio3 = nullptr, *makeup3 = nullptr;
 
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
-
   Gtk::LevelBar *output0 = nullptr, *output1 = nullptr, *output2 = nullptr, *output3 = nullptr;
 
   Gtk::Label *output0_label = nullptr, *output1_label = nullptr, *output2_label = nullptr, *output3_label = nullptr;

--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -249,8 +249,8 @@ class PipeManager {
 
   static auto json_object_find(const char* obj, const char* key, char* value, const size_t& len) -> int;
 
-  sigc::signal<void(uint, std::string, std::string)> stream_output_added;
-  sigc::signal<void(uint, std::string, std::string)> stream_input_added;
+  sigc::signal<void(const uint, const std::string, const std::string)> stream_output_added;
+  sigc::signal<void(const uint, const std::string, const std::string)> stream_input_added;
 
   /*
     Do not pass NodeInfo by reference. Sometimes it dies before we use it and a segmentation fault happens.

--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -172,6 +172,8 @@ class PipeManager {
 
   spa_hook metadata_listener{};
 
+  std::map<uint, NodeInfo> node_map;
+
   std::vector<NodeInfo> list_nodes;
 
   std::vector<LinkInfo> list_links;

--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -251,6 +251,8 @@ class PipeManager {
 
   sigc::signal<void(const uint, const std::string, const std::string)> stream_output_added;
   sigc::signal<void(const uint, const std::string, const std::string)> stream_input_added;
+  sigc::signal<void(const uint)> stream_output_changed;
+  sigc::signal<void(const uint)> stream_input_changed;
 
   /*
     Do not pass NodeInfo by reference. Sometimes it dies before we use it and a segmentation fault happens.
@@ -264,9 +266,7 @@ class PipeManager {
   sigc::signal<void(NodeInfo)> sink_removed;
   sigc::signal<void(NodeInfo)> new_default_sink;
   sigc::signal<void(NodeInfo)> new_default_source;
-  sigc::signal<void(NodeInfo)> stream_output_changed;
   sigc::signal<void(NodeInfo)> stream_output_removed;
-  sigc::signal<void(NodeInfo)> stream_input_changed;
   sigc::signal<void(NodeInfo)> stream_input_removed;
   sigc::signal<void(DeviceInfo)> device_changed;
 

--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -253,6 +253,8 @@ class PipeManager {
   sigc::signal<void(const uint, const std::string, const std::string)> stream_input_added;
   sigc::signal<void(const uint)> stream_output_changed;
   sigc::signal<void(const uint)> stream_input_changed;
+  sigc::signal<void(const uint)> stream_output_removed;
+  sigc::signal<void(const uint)> stream_input_removed;
 
   /*
     Do not pass NodeInfo by reference. Sometimes it dies before we use it and a segmentation fault happens.
@@ -266,8 +268,6 @@ class PipeManager {
   sigc::signal<void(NodeInfo)> sink_removed;
   sigc::signal<void(NodeInfo)> new_default_sink;
   sigc::signal<void(NodeInfo)> new_default_source;
-  sigc::signal<void(NodeInfo)> stream_output_removed;
-  sigc::signal<void(NodeInfo)> stream_input_removed;
   sigc::signal<void(DeviceInfo)> device_changed;
 
   sigc::signal<void(LinkInfo)> link_changed;

--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -220,9 +220,9 @@ class PipeManager {
 
   void disconnect_stream_input(const uint& id, const std::string& media_class) const;
 
-  static void set_node_volume(const NodeInfo& nd_info, const float& value);
+  static void set_node_volume(pw_proxy* proxy, const int& n_vol_ch, const float& value);
 
-  static void set_node_mute(const NodeInfo& nd_info, const bool& state);
+  static void set_node_mute(pw_proxy* proxy, const bool& state);
 
   /*
     Links the output ports of the node output_node_id to the input ports of the node input_node_id

--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -212,15 +212,15 @@ class PipeManager {
   std::string header_version, library_version, core_name, default_clock_rate, default_min_quantum, default_max_quantum,
       default_quantum;
 
-  auto stream_is_connected(const std::string& media_class, const uint& node_id) -> bool;
+  auto stream_is_connected(const uint& id, const std::string& media_class) -> bool;
 
-  void connect_stream_output(const NodeInfo& nd_info) const;
+  void connect_stream_output(const uint& id, const std::string& media_class) const;
 
-  void connect_stream_input(const NodeInfo& nd_info) const;
+  void connect_stream_input(const uint& id, const std::string& media_class) const;
 
-  void disconnect_stream_output(const NodeInfo& nd_info) const;
+  void disconnect_stream_output(const uint& id, const std::string& media_class) const;
 
-  void disconnect_stream_input(const NodeInfo& nd_info) const;
+  void disconnect_stream_input(const uint& id, const std::string& media_class) const;
 
   static void set_node_volume(const NodeInfo& nd_info, const float& value);
 
@@ -249,6 +249,9 @@ class PipeManager {
 
   static auto json_object_find(const char* obj, const char* key, char* value, const size_t& len) -> int;
 
+  sigc::signal<void(uint, std::string, std::string)> stream_output_added;
+  sigc::signal<void(uint, std::string, std::string)> stream_input_added;
+
   /*
     Do not pass NodeInfo by reference. Sometimes it dies before we use it and a segmentation fault happens.
   */
@@ -261,10 +264,8 @@ class PipeManager {
   sigc::signal<void(NodeInfo)> sink_removed;
   sigc::signal<void(NodeInfo)> new_default_sink;
   sigc::signal<void(NodeInfo)> new_default_source;
-  sigc::signal<void(NodeInfo)> stream_output_added;
   sigc::signal<void(NodeInfo)> stream_output_changed;
   sigc::signal<void(NodeInfo)> stream_output_removed;
-  sigc::signal<void(NodeInfo)> stream_input_added;
   sigc::signal<void(NodeInfo)> stream_input_changed;
   sigc::signal<void(NodeInfo)> stream_input_removed;
   sigc::signal<void(DeviceInfo)> device_changed;

--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -174,8 +174,6 @@ class PipeManager {
 
   std::map<uint, NodeInfo> node_map;
 
-  std::vector<NodeInfo> list_nodes;
-
   std::vector<LinkInfo> list_links;
 
   std::vector<PortInfo> list_ports;

--- a/include/pitch_ui.hpp
+++ b/include/pitch_ui.hpp
@@ -39,8 +39,6 @@ class PitchUi : public Gtk::Box, public PluginUiBase {
   void reset() override;
 
  private:
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
-
   Gtk::ToggleButton *faster = nullptr, *formant_preserving = nullptr;
 
   Gtk::SpinButton *cents = nullptr, *crispness = nullptr, *semitones = nullptr, *octaves = nullptr;

--- a/include/plugin_base.hpp
+++ b/include/plugin_base.hpp
@@ -124,6 +124,8 @@ class PluginBase {
   float notification_time_window = 1.0F / 20.0F;  // seconds
   float notification_dt = 0.0F;
 
+  void setup_input_output_gain();
+
   void initialize_listener();
 
   void notify();

--- a/include/plugin_ui_base.hpp
+++ b/include/plugin_ui_base.hpp
@@ -51,6 +51,8 @@ class PluginUiBase {
 
   Gtk::Button* reset_button = nullptr;
 
+  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
+
   Gtk::LevelBar *input_level_left = nullptr, *input_level_right = nullptr;
   Gtk::LevelBar *output_level_left = nullptr, *output_level_right = nullptr;
   Gtk::Label *input_level_left_label = nullptr, *input_level_right_label = nullptr;
@@ -59,6 +61,8 @@ class PluginUiBase {
   Gtk::Window* transient_window = nullptr;
 
   std::vector<sigc::connection> connections;
+
+  void setup_input_output_gain(const Glib::RefPtr<Gtk::Builder>& builder);
 
   // reset plugin method
   virtual void reset() = 0;

--- a/include/plugin_ui_base.hpp
+++ b/include/plugin_ui_base.hpp
@@ -70,8 +70,6 @@ class PluginUiBase {
 
   static void prepare_spinbutton(Gtk::SpinButton* button, const Glib::ustring& unit);
 
-  static auto string_to_float(const std::string& value) -> float;
-
  private:
   template <typename T1, typename T2, typename T3, typename T4>
   void update_level(const T1& w_left,

--- a/include/reverb_ui.hpp
+++ b/include/reverb_ui.hpp
@@ -47,8 +47,6 @@ class ReverbUi : public Gtk::Box, public PluginUiBase {
   Gtk::Button *preset_room = nullptr, *preset_empty_walls = nullptr, *preset_ambience = nullptr,
               *preset_large_empty_hall = nullptr, *preset_disco = nullptr, *preset_large_occupied_hall = nullptr;
 
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
-
   void init_presets_buttons();
 };
 

--- a/include/rnnoise_ui.hpp
+++ b/include/rnnoise_ui.hpp
@@ -47,8 +47,6 @@ class RNNoiseUi : public Gtk::Box, public PluginUiBase {
 
   Glib::ustring default_model_name;
 
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
-
   Gtk::Button* import_model = nullptr;
 
   Gtk::Frame* model_list_frame = nullptr;

--- a/include/stereo_tools_ui.hpp
+++ b/include/stereo_tools_ui.hpp
@@ -49,8 +49,6 @@ class StereoToolsUi : public Gtk::Box, public PluginUiBase {
 
   Gtk::ToggleButton *softclip = nullptr, *mutel = nullptr, *muter = nullptr, *phasel = nullptr, *phaser = nullptr;
 
-  Gtk::Scale *input_gain = nullptr, *output_gain = nullptr;
-
   Gtk::LevelBar* meter_phase_levelbar = nullptr;
 
   Gtk::Label* meter_phase_label = nullptr;

--- a/include/stream_input_effects.hpp
+++ b/include/stream_input_effects.hpp
@@ -42,7 +42,7 @@ class StreamInputEffects : public EffectsBase {
 
   void disconnect_filters();
 
-  void on_app_added(uint id, std::string name, std::string media_class);
+  void on_app_added(const uint id, const std::string name, const std::string media_class);
 
   void on_link_changed(LinkInfo link_info);
 };

--- a/include/stream_input_effects.hpp
+++ b/include/stream_input_effects.hpp
@@ -42,11 +42,7 @@ class StreamInputEffects : public EffectsBase {
 
   void disconnect_filters();
 
-  /*
-    Do not pass node_info by reference. Sometimes it dies before we use it and a segmentation fault happens.
-  */
-
-  void on_app_added(NodeInfo node_info);
+  void on_app_added(uint id, std::string name, std::string media_class);
 
   void on_link_changed(LinkInfo link_info);
 };

--- a/include/stream_output_effects.hpp
+++ b/include/stream_output_effects.hpp
@@ -40,7 +40,7 @@ class StreamOutputEffects : public EffectsBase {
 
   void disconnect_filters();
 
-  void on_app_added(uint id, std::string name, std::string media_class);
+  void on_app_added(const uint id, const std::string name, const std::string media_class);
 
   void on_link_changed(LinkInfo link_info);
 };

--- a/include/stream_output_effects.hpp
+++ b/include/stream_output_effects.hpp
@@ -40,11 +40,7 @@ class StreamOutputEffects : public EffectsBase {
 
   void disconnect_filters();
 
-  /*
-    Do not pass node_info by reference. Sometimes it dies before we use it and a segmentation fault happens.
-  */
-
-  void on_app_added(NodeInfo node_info);
+  void on_app_added(uint id, std::string name, std::string media_class);
 
   void on_link_changed(LinkInfo link_info);
 };

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -155,7 +155,7 @@ void Application::on_startup() {
 
     NodeInfo target_node;
 
-    for (const auto& node : pm->list_nodes) {
+    for (const auto& [id, node] : pm->node_map) {
       if (node.device_id == device.id) {
         target_node = node;
 
@@ -186,7 +186,7 @@ void Application::on_startup() {
 
     uint device_id = SPA_ID_INVALID;
 
-    for (const auto& node : pm->list_nodes) {
+    for (const auto& [id, node] : pm->node_map) {
       if (node.name == name) {
         device_id = node.device_id;
 
@@ -214,7 +214,7 @@ void Application::on_startup() {
 
     uint device_id = SPA_ID_INVALID;
 
-    for (const auto& node : pm->list_nodes) {
+    for (const auto& [id, node] : pm->node_map) {
       if (node.name == name) {
         device_id = node.device_id;
 

--- a/src/autogain.cpp
+++ b/src/autogain.cpp
@@ -98,7 +98,9 @@ void AutoGain::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   for (uint n = 0U; n < n_samples; n++) {
     data[2U * n] = left_in[n];
@@ -170,8 +172,13 @@ void AutoGain::process(std::span<float>& left_in,
   std::copy(left_in.begin(), left_in.end(), left_out.begin());
   std::copy(right_in.begin(), right_in.end(), right_out.begin());
 
-  apply_gain(left_out, right_out, static_cast<float>(internal_output_gain));
-  apply_gain(left_out, right_out, output_gain);
+  if (internal_output_gain != 1.0F) {
+    apply_gain(left_out, right_out, static_cast<float>(internal_output_gain));
+  }
+
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   if (post_messages) {
     get_peaks(left_in, right_in, left_out, right_out);

--- a/src/autogain.cpp
+++ b/src/autogain.cpp
@@ -33,6 +33,8 @@ AutoGain::AutoGain(const std::string& tag,
 
     init_ebur128();
   });
+
+  setup_input_output_gain();
 }
 
 AutoGain::~AutoGain() {
@@ -96,6 +98,8 @@ void AutoGain::process(std::span<float>& left_in,
     return;
   }
 
+  apply_gain(left_in, right_in, input_gain);
+
   for (uint n = 0U; n < n_samples; n++) {
     data[2U * n] = left_in[n];
     data[2U * n + 1U] = right_in[n];
@@ -157,7 +161,7 @@ void AutoGain::process(std::span<float>& left_in,
 
       if (db_peak > util::minimum_db_level) {
         if (gain * peak < 1.0) {
-          output_gain = gain;
+          internal_output_gain = gain;
         }
       }
     }
@@ -166,7 +170,8 @@ void AutoGain::process(std::span<float>& left_in,
   std::copy(left_in.begin(), left_in.end(), left_out.begin());
   std::copy(right_in.begin(), right_in.end(), right_out.begin());
 
-  apply_gain(left_out, right_out, static_cast<float>(output_gain));
+  apply_gain(left_out, right_out, static_cast<float>(internal_output_gain));
+  apply_gain(left_out, right_out, output_gain);
 
   if (post_messages) {
     get_peaks(left_in, right_in, left_out, right_out);
@@ -175,7 +180,7 @@ void AutoGain::process(std::span<float>& left_in,
 
     if (notification_dt >= notification_time_window) {
       Glib::signal_idle().connect_once(
-          [=, this] { results.emit(loudness, output_gain, momentary, shortterm, global, relative, range); });
+          [=, this] { results.emit(loudness, internal_output_gain, momentary, shortterm, global, relative, range); });
 
       notify();
 

--- a/src/autogain_preset.cpp
+++ b/src/autogain_preset.cpp
@@ -30,11 +30,19 @@ AutoGainPreset::AutoGainPreset() {
 void AutoGainPreset::save(nlohmann::json& json,
                           const std::string& section,
                           const Glib::RefPtr<Gio::Settings>& settings) {
+  json[section]["autogain"]["input-gain"] = settings->get_double("input-gain");
+
+  json[section]["autogain"]["output-gain"] = settings->get_double("output-gain");
+
   json[section]["autogain"]["target"] = settings->get_double("target");
 }
 
 void AutoGainPreset::load(const nlohmann::json& json,
                           const std::string& section,
                           const Glib::RefPtr<Gio::Settings>& settings) {
+  update_key<double>(json.at(section).at("autogain"), settings, "input-gain", "input-gain");
+
+  update_key<double>(json.at(section).at("autogain"), settings, "output-gain", "output-gain");
+
   update_key<double>(json.at(section).at("autogain"), settings, "target", "target");
 }

--- a/src/autogain_ui.cpp
+++ b/src/autogain_ui.cpp
@@ -58,6 +58,8 @@ AutoGainUi::AutoGainUi(BaseObjectType* cobject,
       [=, this]() { settings->set_boolean("reset-history", !settings->get_boolean("reset-history")); });
 
   prepare_spinbutton(target, "dB");
+
+  setup_input_output_gain(builder);
 }
 
 AutoGainUi::~AutoGainUi() {

--- a/src/bass_enhancer.cpp
+++ b/src/bass_enhancer.cpp
@@ -29,17 +29,6 @@ BassEnhancer::BassEnhancer(const std::string& tag,
     util::debug(log_tag + "http://calf.sourceforge.net/plugins/BassEnhancer is not installed");
   }
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   lv2_wrapper->bind_key_double_db(settings, "amount", "amount");
 
   lv2_wrapper->bind_key_double(settings, "harmonics", "drive");
@@ -53,6 +42,8 @@ BassEnhancer::BassEnhancer(const std::string& tag,
   lv2_wrapper->bind_key_bool(settings, "floor-active", "floor_active");
 
   lv2_wrapper->bind_key_bool(settings, "listen", "listen");
+
+  setup_input_output_gain();
 }
 
 BassEnhancer::~BassEnhancer() {
@@ -96,7 +87,7 @@ void BassEnhancer::process(std::span<float>& left_in,
     notification_dt += sample_duration;
 
     if (notification_dt >= notification_time_window) {
-      // harmonics needed as double for levelbar widget ui, so we convert it here 
+      // harmonics needed as double for levelbar widget ui, so we convert it here
 
       const double& harmonics_value = static_cast<double>(lv2_wrapper->get_control_port_value("meter_drive"));
 

--- a/src/bass_enhancer.cpp
+++ b/src/bass_enhancer.cpp
@@ -74,12 +74,16 @@ void BassEnhancer::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
   lv2_wrapper->run();
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   if (post_messages) {
     get_peaks(left_in, right_in, left_out, right_out);

--- a/src/bass_enhancer_ui.cpp
+++ b/src/bass_enhancer_ui.cpp
@@ -37,8 +37,6 @@ BassEnhancerUi::BassEnhancerUi(BaseObjectType* cobject,
   harmonics = builder->get_widget<Gtk::SpinButton>("harmonics");
   scope = builder->get_widget<Gtk::SpinButton>("scope");
   blend = builder->get_widget<Gtk::Scale>("blend");
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
 
   // gsettings bindings
 
@@ -47,14 +45,10 @@ BassEnhancerUi::BassEnhancerUi(BaseObjectType* cobject,
   settings->bind("scope", scope->get_adjustment().get(), "value");
   settings->bind("floor", floor->get_adjustment().get(), "value");
   settings->bind("blend", blend->get_adjustment().get(), "value");
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("listen", listen, "active");
   settings->bind("floor-active", floor_active, "active");
   settings->bind("floor-active", floor, "sensitive", Gio::Settings::BindFlags::GET);
 
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
   prepare_scale(blend, "");
 
   prepare_spinbutton(amount, "dB");
@@ -63,6 +57,8 @@ BassEnhancerUi::BassEnhancerUi(BaseObjectType* cobject,
   prepare_spinbutton(floor, "Hz");
 
   prepare_spinbutton(harmonics, "");
+
+  setup_input_output_gain(builder);
 }
 
 BassEnhancerUi::~BassEnhancerUi() {

--- a/src/bass_loudness.cpp
+++ b/src/bass_loudness.cpp
@@ -29,22 +29,13 @@ BassLoudness::BassLoudness(const std::string& tag,
     util::debug(log_tag + "http://drobilla.net/plugins/mda/Loudness is not installed");
   }
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   lv2_wrapper->bind_key_double_db(settings, "loudness", "loudness");
 
   lv2_wrapper->bind_key_double_db(settings, "output", "output");
 
   lv2_wrapper->bind_key_double_db(settings, "link", "link");
+
+  setup_input_output_gain();
 }
 
 BassLoudness::~BassLoudness() {

--- a/src/bass_loudness.cpp
+++ b/src/bass_loudness.cpp
@@ -66,12 +66,16 @@ void BassLoudness::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
   lv2_wrapper->run();
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   if (post_messages) {
     get_peaks(left_in, right_in, left_out, right_out);

--- a/src/bass_loudness_ui.cpp
+++ b/src/bass_loudness_ui.cpp
@@ -31,20 +31,18 @@ BassLoudnessUi::BassLoudnessUi(BaseObjectType* cobject,
   loudness = builder->get_widget<Gtk::SpinButton>("loudness");
   output = builder->get_widget<Gtk::SpinButton>("output");
   link = builder->get_widget<Gtk::SpinButton>("link");
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
 
   // gsettings bindings
 
   settings->bind("loudness", loudness->get_adjustment().get(), "value");
   settings->bind("output", output->get_adjustment().get(), "value");
   settings->bind("link", link->get_adjustment().get(), "value");
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
 
   prepare_spinbutton(loudness, "dB");
   prepare_spinbutton(output, "dB");
   prepare_spinbutton(link, "dB");
+
+  setup_input_output_gain(builder);
 }
 
 BassLoudnessUi::~BassLoudnessUi() {

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -29,17 +29,6 @@ Compressor::Compressor(const std::string& tag,
     util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/sc_compressor_stereo is not installed");
   }
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   settings->signal_changed("sidechain-type").connect([=, this](const auto& key) {
     if (settings->get_string(key) == "External") {
       const auto* device_name = settings->get_string("sidechain-input-device").c_str();
@@ -129,6 +118,8 @@ Compressor::Compressor(const std::string& tag,
   lv2_wrapper->bind_key_double_db(settings, "makeup", "mk");
 
   lv2_wrapper->bind_key_double_db(settings, "sidechain-preamp", "scp");
+
+  setup_input_output_gain();
 }
 
 Compressor::~Compressor() {

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -152,12 +152,16 @@ void Compressor::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out, probe_left, probe_right);
   lv2_wrapper->run();
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   /*
    This plugin gives the latency in number of samples

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -46,7 +46,7 @@ Compressor::Compressor(const std::string& tag,
 
       NodeInfo input_device = pm->pe_source_node;
 
-      for (const auto& node : pm->list_nodes) {
+      for (const auto& [id, node] : pm->node_map) {
         if (node.name == device_name) {
           input_device = node;
 
@@ -70,7 +70,7 @@ Compressor::Compressor(const std::string& tag,
 
       NodeInfo input_device = pm->pe_source_node;
 
-      for (const auto& node : pm->list_nodes) {
+      for (const auto& [id, node] : pm->node_map) {
         if (node.name == device_name) {
           input_device = node;
 

--- a/src/compressor_ui.cpp
+++ b/src/compressor_ui.cpp
@@ -479,7 +479,7 @@ void CompressorUi::set_pipe_manager_ptr(PipeManager* pipe_manager) {
 
   input_devices_model->append(NodeInfoHolder::create(pm->pe_source_node));
 
-  for (const auto& node : pm->list_nodes) {
+  for (const auto& [id, node] : pm->node_map) {
     if (node.media_class == "Audio/Source") {
       input_devices_model->append(NodeInfoHolder::create(node));
     }

--- a/src/compressor_ui.cpp
+++ b/src/compressor_ui.cpp
@@ -202,9 +202,6 @@ CompressorUi::CompressorUi(BaseObjectType* cobject,
 
   // loading builder widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
-
   attack = builder->get_widget<Gtk::SpinButton>("attack");
   knee = builder->get_widget<Gtk::SpinButton>("knee");
   makeup = builder->get_widget<Gtk::SpinButton>("makeup");
@@ -260,8 +257,6 @@ CompressorUi::CompressorUi(BaseObjectType* cobject,
   settings->bind("sidechain-preamp", preamp->get_adjustment().get(), "value");
   settings->bind("sidechain-reactivity", reactivity->get_adjustment().get(), "value");
   settings->bind("sidechain-lookahead", lookahead->get_adjustment().get(), "value");
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("release-threshold", release_threshold->get_adjustment().get(), "value");
   settings->bind("boost-threshold", boost_threshold->get_adjustment().get(), "value");
   settings->bind("boost-amount", boost_amount->get_adjustment().get(), "value");
@@ -296,9 +291,6 @@ CompressorUi::CompressorUi(BaseObjectType* cobject,
       dropdown_input_devices->set_sensitive(true);
     }
   }));
-
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
 
   prepare_spinbutton(threshold, "dB");
   prepare_spinbutton(attack, "ms");
@@ -349,6 +341,8 @@ CompressorUi::CompressorUi(BaseObjectType* cobject,
   set_boost_spinbuttons_sensitivity();
 
   compression_mode->signal_changed().connect(set_boost_spinbuttons_sensitivity);
+
+  setup_input_output_gain(builder);
 }
 
 CompressorUi::~CompressorUi() {

--- a/src/convolver.cpp
+++ b/src/convolver.cpp
@@ -160,7 +160,9 @@ void Convolver::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   if (n_samples_is_power_of_2) {
     std::copy(left_in.begin(), left_in.end(), left_out.begin());
@@ -226,7 +228,9 @@ void Convolver::process(std::span<float>& left_in,
     }
   }
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   if (notify_latency) {
     const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);

--- a/src/convolver.cpp
+++ b/src/convolver.cpp
@@ -32,17 +32,6 @@ Convolver::Convolver(const std::string& tag,
                      const std::string& schema_path,
                      PipeManager* pipe_manager)
     : PluginBase(tag, plugin_name::convolver, schema, schema_path, pipe_manager) {
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   settings->signal_changed("ir-width").connect([=, this](const auto& key) {
     ir_width = settings->get_int(key);
 
@@ -86,6 +75,8 @@ Convolver::Convolver(const std::string& tag,
       data_mutex.unlock();
     }
   });
+
+  setup_input_output_gain();
 }
 
 Convolver::~Convolver() {

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -44,9 +44,6 @@ ConvolverUi::ConvolverUi(BaseObjectType* cobject,
 
   // loading builder widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
-
   ir_width = builder->get_widget<Gtk::SpinButton>("ir_width");
 
   listview = builder->get_widget<Gtk::ListView>("listview");
@@ -69,9 +66,6 @@ ConvolverUi::ConvolverUi(BaseObjectType* cobject,
   drawing_area = builder->get_widget<Gtk::DrawingArea>("drawing_area");
 
   entry_search = builder->get_widget<Gtk::SearchEntry>("entry_search");
-
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
 
   setup_listview();
 
@@ -105,9 +99,9 @@ ConvolverUi::ConvolverUi(BaseObjectType* cobject,
 
   // gsettings bindings
 
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("ir-width", ir_width->get_adjustment().get(), "value");
+
+  setup_input_output_gain(builder);
 
   // reading the current configured irs file
 

--- a/src/crossfeed.cpp
+++ b/src/crossfeed.cpp
@@ -72,7 +72,9 @@ void Crossfeed::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   for (size_t n = 0U, li_size = left_in.size(); n < li_size; n++) {
     data[n * 2U] = left_in[n];
@@ -86,7 +88,9 @@ void Crossfeed::process(std::span<float>& left_in,
     right_out[n] = data[n * 2U + 1U];
   }
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   if (post_messages) {
     get_peaks(left_in, right_in, left_out, right_out);

--- a/src/crossfeed.cpp
+++ b/src/crossfeed.cpp
@@ -24,20 +24,9 @@ Crossfeed::Crossfeed(const std::string& tag,
                      const std::string& schema_path,
                      PipeManager* pipe_manager)
     : PluginBase(tag, plugin_name::crossfeed, schema, schema_path, pipe_manager) {
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
   bs2b.set_level_fcut(settings->get_int("fcut"));
 
   bs2b.set_level_feed(10 * static_cast<int>(settings->get_double("feed")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
 
   settings->signal_changed("fcut").connect([=, this](const auto& key) {
     std::scoped_lock<std::mutex> lock(data_mutex);
@@ -50,6 +39,8 @@ Crossfeed::Crossfeed(const std::string& tag,
 
     bs2b.set_level_feed(10 * settings->get_double(key));
   });
+
+  setup_input_output_gain();
 }
 
 Crossfeed::~Crossfeed() {

--- a/src/crossfeed_ui.cpp
+++ b/src/crossfeed_ui.cpp
@@ -28,9 +28,6 @@ CrossfeedUi::CrossfeedUi(BaseObjectType* cobject,
 
   // loading builder widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
-
   fcut = builder->get_widget<Gtk::SpinButton>("fcut");
   feed = builder->get_widget<Gtk::SpinButton>("feed");
 
@@ -40,18 +37,15 @@ CrossfeedUi::CrossfeedUi(BaseObjectType* cobject,
 
   // gsettings bindings
 
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("fcut", fcut->get_adjustment().get(), "value");
   settings->bind("feed", feed->get_adjustment().get(), "value");
-
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
 
   prepare_spinbutton(fcut, "Hz");
   prepare_spinbutton(feed, "dB");
 
   init_presets_buttons();
+
+  setup_input_output_gain(builder);
 }
 
 CrossfeedUi::~CrossfeedUi() {

--- a/src/crystalizer.cpp
+++ b/src/crystalizer.cpp
@@ -49,20 +49,11 @@ Crystalizer::Crystalizer(const std::string& tag,
   frequencies[12] = 15020.0F;
   frequencies[13] = 20020.0F;
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   for (uint n = 0U; n < nbands; n++) {
     bind_band(static_cast<int>(n));
   }
+
+  setup_input_output_gain();
 }
 
 Crystalizer::~Crystalizer() {

--- a/src/crystalizer.cpp
+++ b/src/crystalizer.cpp
@@ -140,7 +140,9 @@ void Crystalizer::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   if (n_samples_is_power_of_2) {
     std::copy(left_in.begin(), left_in.end(), left_out.begin());
@@ -206,7 +208,9 @@ void Crystalizer::process(std::span<float>& left_in,
     }
   }
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   if (notify_latency) {
     const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);

--- a/src/crystalizer_ui.cpp
+++ b/src/crystalizer_ui.cpp
@@ -28,20 +28,13 @@ CrystalizerUi::CrystalizerUi(BaseObjectType* cobject,
 
   // loading builder widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
-
   bands_box = builder->get_widget<Gtk::Box>("bands_box");
 
   // gsettings bindings
 
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
-
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
-
   build_bands(13);
+
+  setup_input_output_gain(builder);
 }
 
 CrystalizerUi::~CrystalizerUi() {

--- a/src/deesser.cpp
+++ b/src/deesser.cpp
@@ -29,17 +29,6 @@ Deesser::Deesser(const std::string& tag,
     util::debug(log_tag + "http://calf.sourceforge.net/plugins/Deesser is not installed");
   }
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   lv2_wrapper->bind_key_enum(settings, "mode", "mode");
 
   lv2_wrapper->bind_key_enum(settings, "detection", "detection");
@@ -63,6 +52,8 @@ Deesser::Deesser(const std::string& tag,
   lv2_wrapper->bind_key_int(settings, "laxity", "laxity");
 
   lv2_wrapper->bind_key_bool(settings, "sc-listen", "sc_listen");
+
+  setup_input_output_gain();
 }
 
 Deesser::~Deesser() {

--- a/src/deesser.cpp
+++ b/src/deesser.cpp
@@ -84,12 +84,16 @@ void Deesser::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
   lv2_wrapper->run();
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   if (post_messages) {
     get_peaks(left_in, right_in, left_out, right_out);

--- a/src/deesser_ui.cpp
+++ b/src/deesser_ui.cpp
@@ -82,9 +82,6 @@ DeesserUi::DeesserUi(BaseObjectType* cobject,
 
   // loading builder widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
-
   makeup = builder->get_widget<Gtk::SpinButton>("makeup");
   ratio = builder->get_widget<Gtk::SpinButton>("ratio");
   threshold = builder->get_widget<Gtk::SpinButton>("threshold");
@@ -109,8 +106,6 @@ DeesserUi::DeesserUi(BaseObjectType* cobject,
 
   // gsettings bindings
 
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("sc-listen", sc_listen, "active");
   settings->bind("makeup", makeup->get_adjustment().get(), "value");
   settings->bind("ratio", ratio->get_adjustment().get(), "value");
@@ -128,9 +123,6 @@ DeesserUi::DeesserUi(BaseObjectType* cobject,
   g_settings_bind_with_mapping(settings->gobj(), "mode", mode->gobj(), "active", G_SETTINGS_BIND_DEFAULT,
                                mode_enum_to_int, int_to_mode_enum, nullptr, nullptr);
 
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
-
   prepare_spinbutton(makeup, "dB");
   prepare_spinbutton(threshold, "dB");
   prepare_spinbutton(f1_level, "dB");
@@ -140,6 +132,8 @@ DeesserUi::DeesserUi(BaseObjectType* cobject,
   prepare_spinbutton(f2_freq, "Hz");
 
   prepare_spinbutton(f2_q, "");
+
+  setup_input_output_gain(builder);
 }
 
 DeesserUi::~DeesserUi() {

--- a/src/delay.cpp
+++ b/src/delay.cpp
@@ -32,19 +32,10 @@ Delay::Delay(const std::string& tag,
   lv2_wrapper->set_control_port_value("mode_l", 2);
   lv2_wrapper->set_control_port_value("mode_r", 2);
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   lv2_wrapper->bind_key_double(settings, "time-l", "time_l");
   lv2_wrapper->bind_key_double(settings, "time-r", "time_r");
+
+  setup_input_output_gain();
 }
 
 Delay::~Delay() {

--- a/src/delay.cpp
+++ b/src/delay.cpp
@@ -66,12 +66,16 @@ void Delay::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
   lv2_wrapper->run();
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   /*
     This plugin gives the latency in number of samples

--- a/src/delay_ui.cpp
+++ b/src/delay_ui.cpp
@@ -28,23 +28,18 @@ DelayUi::DelayUi(BaseObjectType* cobject,
 
   // loading glade widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
   time_l = builder->get_widget<Gtk::SpinButton>("time_l");
   time_r = builder->get_widget<Gtk::SpinButton>("time_r");
 
   // gsettings bindings
 
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("time-l", time_l->get_adjustment().get(), "value");
   settings->bind("time-r", time_r->get_adjustment().get(), "value");
 
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
-
   prepare_spinbutton(time_l, "ms");
   prepare_spinbutton(time_r, "ms");
+
+  setup_input_output_gain(builder);
 }
 
 DelayUi::~DelayUi() {

--- a/src/echo_canceller.cpp
+++ b/src/echo_canceller.cpp
@@ -24,17 +24,6 @@ EchoCanceller::EchoCanceller(const std::string& tag,
                              const std::string& schema_path,
                              PipeManager* pipe_manager)
     : PluginBase(tag, plugin_name::echo_canceller, schema, schema_path, pipe_manager, true) {
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   settings->signal_changed("frame-size").connect([=, this](const auto& key) {
     std::scoped_lock<std::mutex> lock(data_mutex);
 
@@ -50,6 +39,8 @@ EchoCanceller::EchoCanceller(const std::string& tag,
 
     init_speex();
   });
+
+  setup_input_output_gain();
 }
 
 EchoCanceller::~EchoCanceller() {

--- a/src/echo_canceller.cpp
+++ b/src/echo_canceller.cpp
@@ -95,7 +95,9 @@ void EchoCanceller::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   for (size_t j = 0U, li_size = left_in.size(); j < li_size; j++) {
     data_L.emplace_back(left_in[j] * (SHRT_MAX + 1));
@@ -160,7 +162,9 @@ void EchoCanceller::process(std::span<float>& left_in,
     }
   }
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   if (notify_latency) {
     const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);

--- a/src/echo_canceller_ui.cpp
+++ b/src/echo_canceller_ui.cpp
@@ -28,24 +28,18 @@ EchoCancellerUi::EchoCancellerUi(BaseObjectType* cobject,
 
   // loading builder widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
-
   frame_size = builder->get_widget<Gtk::SpinButton>("frame_size");
   filter_length = builder->get_widget<Gtk::SpinButton>("filter_length");
 
   // gsettings bindings
 
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("frame-size", frame_size->get_adjustment().get(), "value");
   settings->bind("filter-length", filter_length->get_adjustment().get(), "value");
 
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
-
   prepare_spinbutton(frame_size, "ms");
   prepare_spinbutton(filter_length, "ms");
+
+  setup_input_output_gain(builder);
 }
 
 EchoCancellerUi::~EchoCancellerUi() {

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -1309,7 +1309,7 @@ void EffectsBaseUi::setup_listview_selected_plugins() {
   });
 }
 
-void EffectsBaseUi::on_app_added(uint id, std::string name, std::string media_class) {
+void EffectsBaseUi::on_app_added(const uint id, const std::string name, const std::string media_class) {
   // do not add the same stream twice
 
   for (guint n = 0U; n < all_players_model->get_n_items(); n++) {

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -1340,9 +1340,9 @@ void EffectsBaseUi::on_app_changed(const uint id) {
   }
 }
 
-void EffectsBaseUi::on_app_removed(NodeInfo node_info) {
+void EffectsBaseUi::on_app_removed(const uint id) {
   for (guint n = 0U; n < players_model->get_n_items(); n++) {
-    if (players_model->get_item(n)->info.id == node_info.id) {
+    if (players_model->get_item(n)->info.id == id) {
       players_model->remove(n);
 
       break;
@@ -1350,7 +1350,7 @@ void EffectsBaseUi::on_app_removed(NodeInfo node_info) {
   }
 
   for (guint n = 0U; n < all_players_model->get_n_items(); n++) {
-    if (all_players_model->get_item(n)->info.id == node_info.id) {
+    if (all_players_model->get_item(n)->info.id == id) {
       all_players_model->remove(n);
 
       break;

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -667,8 +667,10 @@ void EffectsBaseUi::setup_listview_players() {
         },
         false);
 
-    auto connection_volume = volume->signal_value_changed().connect(
-        [=]() { PipeManager::set_node_volume(holder->info, static_cast<float>(volume->get_value()) / 100.0F); });
+    auto connection_volume = volume->signal_value_changed().connect([=]() {
+      PipeManager::set_node_volume(holder->info.proxy, holder->info.n_volume_channels,
+                                   static_cast<float>(volume->get_value()) / 100.0F); }
+    );
 
     auto connection_mute = mute->signal_toggled().connect([=]() {
       const auto& state = mute->get_active();
@@ -683,7 +685,7 @@ void EffectsBaseUi::setup_listview_players() {
         scale_volume->set_sensitive(true);
       }
 
-      PipeManager::set_node_mute(holder->info, state);
+      PipeManager::set_node_mute(holder->info.proxy, state);
     });
 
     auto connection_blocklist_checkbutton = blocklist->signal_toggled().connect([=, this]() {

--- a/src/equalizer.cpp
+++ b/src/equalizer.cpp
@@ -34,17 +34,6 @@ Equalizer::Equalizer(const std::string& tag,
     util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/para_equalizer_x32_lr is not installed");
   }
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   lv2_wrapper->bind_key_enum(settings, "mode", "mode");
 
   for (uint n = 0U; n < max_bands; n++) {
@@ -93,6 +82,8 @@ Equalizer::Equalizer(const std::string& tag,
       settings_right->set_double(bandn + "-q", settings_left->get_double(bandn + "-q"));
     }
   });
+
+  setup_input_output_gain();
 }
 
 Equalizer::~Equalizer() {

--- a/src/equalizer.cpp
+++ b/src/equalizer.cpp
@@ -114,12 +114,16 @@ void Equalizer::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
   lv2_wrapper->run();
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   /*
     This plugin gives the latency in number of samples

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -640,7 +640,7 @@ auto EqualizerUi::parse_apo_filter(const std::string& line, struct ImportedBand&
     return false;
   }
 
-  filter.freq = string_to_float(matches.str(1));
+  filter.freq = std::stof(matches.str(1));
 
   // get slope
 
@@ -657,7 +657,7 @@ auto EqualizerUi::parse_apo_filter(const std::string& line, struct ImportedBand&
     if (matches.size() == 2U) {
       // we satisfied the condition, now assign the paramater if given
 
-      filter.slope_dB = string_to_float(matches.str(1));
+      filter.slope_dB = std::stof(matches.str(1));
     }
   }
 
@@ -673,7 +673,7 @@ auto EqualizerUi::parse_apo_filter(const std::string& line, struct ImportedBand&
     }
 
     if (matches.size() == 2U) {
-      filter.gain = string_to_float(matches.str(1));
+      filter.gain = std::stof(matches.str(1));
     }
   }
 
@@ -688,7 +688,7 @@ auto EqualizerUi::parse_apo_filter(const std::string& line, struct ImportedBand&
     }
 
     if (matches.size() == 2U) {
-      filter.quality_factor = string_to_float(matches.str(1));
+      filter.quality_factor = std::stof(matches.str(1));
     }
   }
 

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -218,9 +218,6 @@ EqualizerUi::EqualizerUi(BaseObjectType* cobject,
 
   // loading builder widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
-
   bands_box_left = builder->get_widget<Gtk::Box>("bands_box_left");
   bands_box_right = builder->get_widget<Gtk::Box>("bands_box_right");
 
@@ -259,16 +256,13 @@ EqualizerUi::EqualizerUi(BaseObjectType* cobject,
   // gsettings bindings
 
   settings->bind("num-bands", nbands->get_adjustment().get(), "value");
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("split-channels", split_channels, "active");
   settings->bind("split-channels", stack_switcher, "visible", Gio::Settings::BindFlags::GET);
 
   g_settings_bind_with_mapping(settings->gobj(), "mode", mode->gobj(), "active", G_SETTINGS_BIND_DEFAULT,
                                mode_enum_to_int, int_to_mode_enum, nullptr, nullptr);
 
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
+  setup_input_output_gain(builder);
 
   // explicitly invoke the method to build equalizer bands (fixes #843)
   // if the preset num-bands value is equal to the default schema value

--- a/src/exciter.cpp
+++ b/src/exciter.cpp
@@ -29,17 +29,6 @@ Exciter::Exciter(const std::string& tag,
     util::debug(log_tag + "http://calf.sourceforge.net/plugins/Exciter is not installed");
   }
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   lv2_wrapper->bind_key_double_db(settings, "amount", "amount");
 
   lv2_wrapper->bind_key_double(settings, "harmonics", "drive");
@@ -53,6 +42,8 @@ Exciter::Exciter(const std::string& tag,
   lv2_wrapper->bind_key_bool(settings, "ceil-active", "ceil_active");
 
   lv2_wrapper->bind_key_bool(settings, "listen", "listen");
+
+  setup_input_output_gain();
 }
 
 Exciter::~Exciter() {

--- a/src/exciter.cpp
+++ b/src/exciter.cpp
@@ -74,12 +74,16 @@ void Exciter::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
   lv2_wrapper->run();
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   if (post_messages) {
     get_peaks(left_in, right_in, left_out, right_out);

--- a/src/exciter_ui.cpp
+++ b/src/exciter_ui.cpp
@@ -37,8 +37,6 @@ ExciterUi::ExciterUi(BaseObjectType* cobject,
   harmonics = builder->get_widget<Gtk::SpinButton>("harmonics");
   scope = builder->get_widget<Gtk::SpinButton>("scope");
   blend = builder->get_widget<Gtk::Scale>("blend");
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
 
   // gsettings bindings
 
@@ -47,14 +45,10 @@ ExciterUi::ExciterUi(BaseObjectType* cobject,
   settings->bind("scope", scope->get_adjustment().get(), "value");
   settings->bind("ceil", ceil->get_adjustment().get(), "value");
   settings->bind("blend", blend->get_adjustment().get(), "value");
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("listen", listen, "active");
   settings->bind("ceil-active", ceil_active, "active");
   settings->bind("ceil-active", ceil, "sensitive", Gio::Settings::BindFlags::GET);
 
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
   prepare_scale(blend, "");
 
   prepare_spinbutton(amount, "dB");
@@ -63,6 +57,8 @@ ExciterUi::ExciterUi(BaseObjectType* cobject,
   prepare_spinbutton(ceil, "Hz");
 
   prepare_spinbutton(harmonics, "");
+
+  setup_input_output_gain(builder);
 }
 
 ExciterUi::~ExciterUi() {

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -29,22 +29,13 @@ Filter::Filter(const std::string& tag,
     util::debug(log_tag + "http://calf.sourceforge.net/plugins/Filter is not installed");
   }
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   lv2_wrapper->bind_key_double(settings, "frequency", "freq");
 
   lv2_wrapper->bind_key_double_db(settings, "resonance", "res");
 
   lv2_wrapper->bind_key_enum(settings, "mode", "mode");
+
+  setup_input_output_gain();
 }
 
 Filter::~Filter() {

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -66,12 +66,16 @@ void Filter::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
   lv2_wrapper->run();
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   if (post_messages) {
     get_peaks(left_in, right_in, left_out, right_out);

--- a/src/filter_ui.cpp
+++ b/src/filter_ui.cpp
@@ -107,8 +107,6 @@ FilterUi::FilterUi(BaseObjectType* cobject,
 
   // loading builder widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
   frequency = builder->get_widget<Gtk::SpinButton>("frequency");
   resonance = builder->get_widget<Gtk::SpinButton>("resonance");
   inertia = builder->get_widget<Gtk::SpinButton>("inertia");
@@ -116,8 +114,6 @@ FilterUi::FilterUi(BaseObjectType* cobject,
 
   // gsettings bindings
 
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("frequency", frequency->get_adjustment().get(), "value");
   settings->bind("resonance", resonance->get_adjustment().get(), "value");
   settings->bind("inertia", inertia->get_adjustment().get(), "value");
@@ -125,12 +121,11 @@ FilterUi::FilterUi(BaseObjectType* cobject,
   g_settings_bind_with_mapping(settings->gobj(), "mode", mode->gobj(), "active", G_SETTINGS_BIND_DEFAULT,
                                filter_enum_to_int, int_to_filter_enum, nullptr, nullptr);
 
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
-
   prepare_spinbutton(resonance, "dB");
   prepare_spinbutton(frequency, "Hz");
   prepare_spinbutton(inertia, "ms");
+
+  setup_input_output_gain(builder);
 }
 
 FilterUi::~FilterUi() {

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -26,17 +26,6 @@ Gate::Gate(const std::string& tag, const std::string& schema, const std::string&
     util::debug(log_tag + "http://calf.sourceforge.net/plugins/Gate is not installed");
   }
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   lv2_wrapper->bind_key_enum(settings, "detection", "detection");
 
   lv2_wrapper->bind_key_enum(settings, "stereo-link", "stereo_link");
@@ -54,6 +43,8 @@ Gate::Gate(const std::string& tag, const std::string& schema, const std::string&
   lv2_wrapper->bind_key_double_db(settings, "knee", "knee");
 
   lv2_wrapper->bind_key_double_db(settings, "makeup", "makeup");
+
+  setup_input_output_gain();
 }
 
 Gate::~Gate() {

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -75,12 +75,16 @@ void Gate::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
   lv2_wrapper->run();
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   if (post_messages) {
     get_peaks(left_in, right_in, left_out, right_out);

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -82,8 +82,6 @@ GateUi::GateUi(BaseObjectType* cobject,
 
   // loading builder widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
   attack = builder->get_widget<Gtk::SpinButton>("attack");
   knee = builder->get_widget<Gtk::SpinButton>("knee");
   makeup = builder->get_widget<Gtk::SpinButton>("makeup");
@@ -100,8 +98,6 @@ GateUi::GateUi(BaseObjectType* cobject,
 
   // gsettings bindings
 
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("attack", attack->get_adjustment().get(), "value");
   settings->bind("knee", knee->get_adjustment().get(), "value");
   settings->bind("makeup", makeup->get_adjustment().get(), "value");
@@ -116,9 +112,6 @@ GateUi::GateUi(BaseObjectType* cobject,
   g_settings_bind_with_mapping(settings->gobj(), "stereo-link", stereo_link->gobj(), "active", G_SETTINGS_BIND_DEFAULT,
                                stereo_link_enum_to_int, int_to_stereo_link_enum, nullptr, nullptr);
 
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
-
   prepare_spinbutton(attack, "ms");
   prepare_spinbutton(release, "ms");
 
@@ -128,6 +121,8 @@ GateUi::GateUi(BaseObjectType* cobject,
   prepare_spinbutton(makeup, "dB");
 
   prepare_spinbutton(ratio, "");
+
+  setup_input_output_gain(builder);
 }
 
 GateUi::~GateUi() {

--- a/src/limiter.cpp
+++ b/src/limiter.cpp
@@ -88,12 +88,16 @@ void Limiter::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
   lv2_wrapper->run();
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   /*
    This plugin gives the latency in number of samples

--- a/src/limiter.cpp
+++ b/src/limiter.cpp
@@ -29,17 +29,6 @@ Limiter::Limiter(const std::string& tag,
     util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/limiter_stereo is not installed");
   }
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   lv2_wrapper->bind_key_enum(settings, "mode", "mode");
 
   lv2_wrapper->bind_key_enum(settings, "oversampling", "ovs");
@@ -67,6 +56,8 @@ Limiter::Limiter(const std::string& tag,
   lv2_wrapper->bind_key_double(settings, "alr-release", "alr_rt");
 
   lv2_wrapper->bind_key_double_db(settings, "alr-knee", "knee");
+
+  setup_input_output_gain();
 }
 
 Limiter::~Limiter() {

--- a/src/limiter_ui.cpp
+++ b/src/limiter_ui.cpp
@@ -287,9 +287,6 @@ LimiterUi::LimiterUi(BaseObjectType* cobject,
 
   // loading builder widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
-
   mode = builder->get_widget<Gtk::ComboBoxText>("mode");
   oversampling = builder->get_widget<Gtk::ComboBoxText>("oversampling");
   dither = builder->get_widget<Gtk::ComboBoxText>("dither");
@@ -314,8 +311,6 @@ LimiterUi::LimiterUi(BaseObjectType* cobject,
 
   // gsettings bindings
 
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("sidechain-preamp", sc_preamp->get_adjustment().get(), "value");
   settings->bind("lookahead", lookahead->get_adjustment().get(), "value");
   settings->bind("attack", attack->get_adjustment().get(), "value");
@@ -338,9 +333,6 @@ LimiterUi::LimiterUi(BaseObjectType* cobject,
                               G_SETTINGS_BIND_DEFAULT, dither_enum_to_int, int_to_dither_enum, nullptr, nullptr);
 
   // prepare widgets
-
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
 
   prepare_spinbutton(sc_preamp, "db");
   prepare_spinbutton(lookahead, "ms");
@@ -365,6 +357,8 @@ LimiterUi::LimiterUi(BaseObjectType* cobject,
   set_alr_spinbuttons_sensitivity();
 
   alr->signal_toggled().connect(set_alr_spinbuttons_sensitivity);
+
+  setup_input_output_gain(builder);
 }
 
 LimiterUi::~LimiterUi() {

--- a/src/loudness.cpp
+++ b/src/loudness.cpp
@@ -29,21 +29,12 @@ Loudness::Loudness(const std::string& tag,
     util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/loud_comp_stereo is not installed");
   }
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   lv2_wrapper->bind_key_enum(settings, "std", "std");
   lv2_wrapper->bind_key_enum(settings, "fft", "fft");
 
   lv2_wrapper->bind_key_double(settings, "volume", "volume");
+
+  setup_input_output_gain();
 }
 
 Loudness::~Loudness() {

--- a/src/loudness.cpp
+++ b/src/loudness.cpp
@@ -65,12 +65,16 @@ void Loudness::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
   lv2_wrapper->run();
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   /*
    This plugin gives the latency in number of samples

--- a/src/loudness_ui.cpp
+++ b/src/loudness_ui.cpp
@@ -117,9 +117,6 @@ LoudnessUi::LoudnessUi(BaseObjectType* cobject,
 
   // loading builder widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
-
   standard = builder->get_widget<Gtk::ComboBoxText>("standard");
   fft_size = builder->get_widget<Gtk::ComboBoxText>("fft_size");
 
@@ -127,8 +124,6 @@ LoudnessUi::LoudnessUi(BaseObjectType* cobject,
 
   // gsettings bindings
 
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("volume", volume->get_adjustment().get(), "value");
 
   g_settings_bind_with_mapping(settings->gobj(), "fft", fft_size->gobj(), "active", G_SETTINGS_BIND_DEFAULT,
@@ -137,10 +132,9 @@ LoudnessUi::LoudnessUi(BaseObjectType* cobject,
   g_settings_bind_with_mapping(settings->gobj(), "std", standard->gobj(), "active", G_SETTINGS_BIND_DEFAULT,
                                standard_enum_to_int, int_to_standard_enum, nullptr, nullptr);
 
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
-
   prepare_spinbutton(volume, "dB");
+
+  setup_input_output_gain(builder);
 }
 
 LoudnessUi::~LoudnessUi() {

--- a/src/maximizer.cpp
+++ b/src/maximizer.cpp
@@ -34,6 +34,8 @@ Maximizer::Maximizer(const std::string& tag,
   lv2_wrapper->bind_key_double(settings, "ceiling", "ceil");
 
   lv2_wrapper->bind_key_double(settings, "release", "rel");
+
+  setup_input_output_gain();
 }
 
 Maximizer::~Maximizer() {

--- a/src/maximizer.cpp
+++ b/src/maximizer.cpp
@@ -66,13 +66,17 @@ void Maximizer::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
 
   lv2_wrapper->run();
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   /*
     This plugin gives the latency in number of samples

--- a/src/maximizer_preset.cpp
+++ b/src/maximizer_preset.cpp
@@ -30,6 +30,10 @@ MaximizerPreset::MaximizerPreset() {
 void MaximizerPreset::save(nlohmann::json& json,
                            const std::string& section,
                            const Glib::RefPtr<Gio::Settings>& settings) {
+  json[section]["maximizer"]["input-gain"] = settings->get_double("input-gain");
+
+  json[section]["maximizer"]["output-gain"] = settings->get_double("output-gain");
+
   json[section]["maximizer"]["release"] = settings->get_double("release");
 
   json[section]["maximizer"]["ceiling"] = settings->get_double("ceiling");
@@ -40,6 +44,10 @@ void MaximizerPreset::save(nlohmann::json& json,
 void MaximizerPreset::load(const nlohmann::json& json,
                            const std::string& section,
                            const Glib::RefPtr<Gio::Settings>& settings) {
+  update_key<double>(json.at(section).at("maximizer"), settings, "input-gain", "input-gain");
+
+  update_key<double>(json.at(section).at("maximizer"), settings, "output-gain", "output-gain");
+
   update_key<double>(json.at(section).at("maximizer"), settings, "release", "release");
 
   update_key<double>(json.at(section).at("maximizer"), settings, "ceiling", "ceiling");

--- a/src/maximizer_ui.cpp
+++ b/src/maximizer_ui.cpp
@@ -43,6 +43,8 @@ MaximizerUi::MaximizerUi(BaseObjectType* cobject,
   prepare_spinbutton(threshold, "dB");
   prepare_spinbutton(ceiling, "dB");
   prepare_spinbutton(release, "ms");
+
+  setup_input_output_gain(builder);
 }
 
 MaximizerUi::~MaximizerUi() {
@@ -62,6 +64,10 @@ auto MaximizerUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path
 
 void MaximizerUi::reset() {
   bypass->set_active(false);
+
+  settings->reset("input-gain");
+
+  settings->reset("output-gain");
 
   settings->reset("release");
 

--- a/src/multiband_compressor.cpp
+++ b/src/multiband_compressor.cpp
@@ -118,12 +118,16 @@ void MultibandCompressor::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
   lv2_wrapper->run();
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   /*
    This plugin gives the latency in number of samples

--- a/src/multiband_compressor.cpp
+++ b/src/multiband_compressor.cpp
@@ -29,17 +29,6 @@ MultibandCompressor::MultibandCompressor(const std::string& tag,
     util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/mb_compressor_stereo is not installed");
   }
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   lv2_wrapper->bind_key_enum(settings, "compressor-mode", "mode");
 
   lv2_wrapper->bind_key_enum(settings, "envelope-boost", "envb");
@@ -97,6 +86,8 @@ MultibandCompressor::MultibandCompressor(const std::string& tag,
 
     lv2_wrapper->bind_key_double_db(settings, "makeup" + nstr, "mk_" + nstr);
   }
+
+  setup_input_output_gain();
 }
 
 MultibandCompressor::~MultibandCompressor() {

--- a/src/multiband_compressor_ui.cpp
+++ b/src/multiband_compressor_ui.cpp
@@ -202,9 +202,6 @@ MultibandCompressorUi::MultibandCompressorUi(BaseObjectType* cobject,
 
   // loading builder widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
-
   compressor_mode = builder->get_widget<Gtk::ComboBoxText>("compressor_mode");
 
   envelope_boost = builder->get_widget<Gtk::ComboBoxText>("envelope_boost");
@@ -228,9 +225,6 @@ MultibandCompressorUi::MultibandCompressorUi(BaseObjectType* cobject,
 
   // gsettings bindings
 
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
-
   g_settings_bind_with_mapping(settings->gobj(), "compressor-mode", compressor_mode->gobj(), "active",
                                G_SETTINGS_BIND_DEFAULT, compressor_mode_enum_to_int, int_to_compressor_mode_enum,
                                nullptr, nullptr);
@@ -238,9 +232,6 @@ MultibandCompressorUi::MultibandCompressorUi(BaseObjectType* cobject,
   g_settings_bind_with_mapping(settings->gobj(), "envelope-boost", envelope_boost->gobj(), "active",
                                G_SETTINGS_BIND_DEFAULT, envelope_boost_enum_to_int, int_to_envelope_boost_enum, nullptr,
                                nullptr);
-
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
 
   // band checkbuttons
 
@@ -253,6 +244,8 @@ MultibandCompressorUi::MultibandCompressorUi(BaseObjectType* cobject,
   }
 
   prepare_bands();
+
+  setup_input_output_gain(builder);
 }
 
 MultibandCompressorUi::~MultibandCompressorUi() {

--- a/src/multiband_gate.cpp
+++ b/src/multiband_gate.cpp
@@ -156,12 +156,16 @@ void MultibandGate::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
   lv2_wrapper->run();
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   if (post_messages) {
     get_peaks(left_in, right_in, left_out, right_out);

--- a/src/multiband_gate.cpp
+++ b/src/multiband_gate.cpp
@@ -29,17 +29,6 @@ MultibandGate::MultibandGate(const std::string& tag,
     util::debug(log_tag + "http://calf.sourceforge.net/plugins/MultibandGate is not installed");
   }
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   lv2_wrapper->bind_key_enum(settings, "mode", "mode");
 
   lv2_wrapper->bind_key_double(settings, "freq0", "freq0");
@@ -135,6 +124,8 @@ MultibandGate::MultibandGate(const std::string& tag,
   lv2_wrapper->bind_key_bool(settings, "bypass3", "bypass3");
 
   lv2_wrapper->bind_key_bool(settings, "solo3", "solo3");
+
+  setup_input_output_gain();
 }
 
 MultibandGate::~MultibandGate() {

--- a/src/multiband_gate_ui.cpp
+++ b/src/multiband_gate_ui.cpp
@@ -79,9 +79,6 @@ MultibandGateUi::MultibandGateUi(BaseObjectType* cobject,
 
   // loading builder widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
-
   freq0 = builder->get_widget<Gtk::SpinButton>("freq0");
   freq1 = builder->get_widget<Gtk::SpinButton>("freq1");
   freq2 = builder->get_widget<Gtk::SpinButton>("freq2");
@@ -150,8 +147,6 @@ MultibandGateUi::MultibandGateUi(BaseObjectType* cobject,
 
   // gsettings bindings
 
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("freq0", freq0->get_adjustment().get(), "value");
   settings->bind("freq1", freq1->get_adjustment().get(), "value");
   settings->bind("freq2", freq2->get_adjustment().get(), "value");
@@ -208,9 +203,6 @@ MultibandGateUi::MultibandGateUi(BaseObjectType* cobject,
   g_settings_bind_with_mapping(settings->gobj(), "detection3", detection3->gobj(), "active", G_SETTINGS_BIND_DEFAULT,
                                detection_enum_to_int, int_to_detection_enum, nullptr, nullptr);
 
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
-
   prepare_spinbutton(range0, "dB");
   prepare_spinbutton(range1, "dB");
   prepare_spinbutton(range2, "dB");
@@ -249,6 +241,8 @@ MultibandGateUi::MultibandGateUi(BaseObjectType* cobject,
   prepare_spinbutton(ratio1, "");
   prepare_spinbutton(ratio2, "");
   prepare_spinbutton(ratio3, "");
+
+  setup_input_output_gain(builder);
 }
 
 MultibandGateUi::~MultibandGateUi() {

--- a/src/pipe_info_ui.cpp
+++ b/src/pipe_info_ui.cpp
@@ -37,7 +37,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
       autoloading_input_model(Gio::ListStore<PresetsAutoloadingHolder>::create()),
       output_presets_string_list(Gtk::StringList::create({"initial_value"})),
       input_presets_string_list(Gtk::StringList::create({"initial_value"})) {
-  for (const auto& node : pm->list_nodes) {
+  for (const auto& [id, node] : pm->node_map) {
     if (node.name == "easyeffects_sink" || node.name == "easyeffects_source") {
       continue;
     }

--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -819,25 +819,23 @@ void on_registry_global(void* data,
         util::debug(pm->log_tag + media_class + " " + std::to_string(id) + " " + pd->nd_info.name + " was added");
 
         // sometimes PipeWire destroys the pointer before signal_idle is called,
-        // therefore we make a copy
+        // therefore we make a copy of NodeInfo
 
-        NodeInfo nd_info_copy = pd->nd_info;  // TO REMOVE
+        if (media_class == "Audio/Source" && name != "easyeffects_source") {
+          NodeInfo nd_info_copy = pd->nd_info;
 
-        uint nd_id = pd->nd_info.id;
-        std::string nd_name = pd->nd_info.name;
-        std::string nd_media_class = pd->nd_info.media_class;
-
-        if (media_class == "Audio/Source" && nd_info_copy.name != "easyeffects_source") {
           Glib::signal_idle().connect_once([pm, nd_info_copy] { pm->source_added.emit(nd_info_copy); });
-        } else if (media_class == "Audio/Sink" && nd_info_copy.name != "easyeffects_sink") {
+        } else if (media_class == "Audio/Sink" && name != "easyeffects_sink") {
+          NodeInfo nd_info_copy = pd->nd_info;
+
           Glib::signal_idle().connect_once([pm, nd_info_copy] { pm->sink_added.emit(nd_info_copy); });
         } else if (media_class == "Stream/Output/Audio") {
-          Glib::signal_idle().connect_once([pm, nd_id, nd_name, nd_media_class] {
-            pm->stream_output_added.emit(nd_id, nd_name, nd_media_class);
+          Glib::signal_idle().connect_once([pm, id, name, media_class] {
+            pm->stream_output_added.emit(id, name, media_class);
           });
         } else if (media_class == "Stream/Input/Audio") {
-          Glib::signal_idle().connect_once([pm, nd_id, nd_name, nd_media_class] {
-            pm->stream_input_added.emit(nd_id, nd_name, nd_media_class);
+          Glib::signal_idle().connect_once([pm, id, name, media_class] {
+            pm->stream_input_added.emit(id, name, media_class);
           });
         }
       }

--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -149,9 +149,6 @@ void on_removed_node_proxy(void* data) {
 
 void on_destroy_node_proxy(void* data) {
   auto* pd = static_cast<node_data*>(data);
-  auto* pm = pd->pm;
-
-  const auto& nd_info = pd->nd_info;
 
   spa_hook_remove(&pd->proxy_listener);
 
@@ -163,14 +160,24 @@ void on_destroy_node_proxy(void* data) {
 
   util::debug(pd->pm->log_tag + pd->nd_info.media_class + " " + pd->nd_info.name + " was removed");
 
+  auto* pm = pd->pm;
+
   if (pd->nd_info.media_class == "Audio/Source") {
-    Glib::signal_idle().connect_once([pm, nd_info] { pm->source_removed.emit(nd_info); });
+    auto nd_info_copy = pd->nd_info;
+
+    Glib::signal_idle().connect_once([pm, nd_info_copy] { pm->source_removed.emit(nd_info_copy); });
   } else if (pd->nd_info.media_class == "Audio/Sink") {
-    Glib::signal_idle().connect_once([pm, nd_info] { pm->sink_removed.emit(nd_info); });
+    auto nd_info_copy = pd->nd_info;
+
+    Glib::signal_idle().connect_once([pm, nd_info_copy] { pm->sink_removed.emit(nd_info_copy); });
   } else if (pd->nd_info.media_class == "Stream/Output/Audio") {
-    Glib::signal_idle().connect_once([pm, nd_info] { pm->stream_output_removed.emit(nd_info); });
+    auto node_id = pd->nd_info.id;
+
+    Glib::signal_idle().connect_once([pm, node_id] { pm->stream_output_removed.emit(node_id); });
   } else if (pd->nd_info.media_class == "Stream/Input/Audio") {
-    Glib::signal_idle().connect_once([pm, nd_info] { pm->stream_input_removed.emit(nd_info); });
+    auto node_id = pd->nd_info.id;
+
+    Glib::signal_idle().connect_once([pm, node_id] { pm->stream_input_removed.emit(node_id); });
   }
 }
 

--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -242,15 +242,21 @@ void on_node_info(void* object, const struct pw_node_info* info) {
     // sometimes PipeWire destroys the pointer before signal_idle is called,
     // therefore we make a copy
 
-    NodeInfo nd_info_copy = nd->nd_info;
+    if (nd->nd_info.media_class == "Stream/Output/Audio") {
+      auto node_id = nd->nd_info.id;
 
-    if (nd_info_copy.media_class == "Stream/Output/Audio") {
-      Glib::signal_idle().connect_once([pm, nd_info_copy] { pm->stream_output_changed.emit(nd_info_copy); });
-    } else if (nd_info_copy.media_class == "Stream/Input/Audio") {
-      Glib::signal_idle().connect_once([pm, nd_info_copy] { pm->stream_input_changed.emit(nd_info_copy); });
-    } else if (nd_info_copy.media_class == "Audio/Source") {
+      Glib::signal_idle().connect_once([pm, node_id] { pm->stream_output_changed.emit(node_id); });
+    } else if (nd->nd_info.media_class == "Stream/Input/Audio") {
+      auto node_id = nd->nd_info.id;
+
+      Glib::signal_idle().connect_once([pm, node_id] { pm->stream_input_changed.emit(node_id); });
+    } else if (nd->nd_info.media_class == "Audio/Source") {
+      auto nd_info_copy = nd->nd_info;
+
       Glib::signal_idle().connect_once([pm, nd_info_copy] { pm->source_changed.emit(nd_info_copy); });
-    } else if (nd_info_copy.media_class == "Audio/Sink") {
+    } else if (nd->nd_info.media_class == "Audio/Sink") {
+      auto nd_info_copy = nd->nd_info;
+
       Glib::signal_idle().connect_once([pm, nd_info_copy] { pm->sink_changed.emit(nd_info_copy); });
     }
   }
@@ -382,23 +388,30 @@ void on_node_event_param(void* object,
     }
 
     if (notify) {
+      auto* pm = nd->pm;
+
       // sometimes PipeWire destroys the pointer before signal_idle is called,
       // therefore we make a copy
 
-      NodeInfo nd_info_copy = nd->nd_info;
-      auto* pm = nd->pm;
+      if (nd->nd_info.media_class == "Stream/Output/Audio") {
+        auto node_id = nd->nd_info.id;
 
-      if (nd_info_copy.media_class == "Stream/Output/Audio") {
-        Glib::signal_idle().connect_once([pm, nd_info_copy] { pm->stream_output_changed.emit(nd_info_copy); });
-      } else if (nd_info_copy.media_class == "Stream/Input/Audio") {
-        Glib::signal_idle().connect_once([pm, nd_info_copy] { pm->stream_input_changed.emit(nd_info_copy); });
-      } else if (nd_info_copy.media_class == "Audio/Source/Virtual") {
+        Glib::signal_idle().connect_once([pm, node_id] { pm->stream_output_changed.emit(node_id); });
+      } else if (nd->nd_info.media_class == "Stream/Input/Audio") {
+        auto node_id = nd->nd_info.id;
+
+        Glib::signal_idle().connect_once([pm, node_id] { pm->stream_input_changed.emit(node_id); });
+      } else if (nd->nd_info.media_class == "Audio/Source/Virtual") {
+        auto nd_info_copy = nd->nd_info;
+
         if (nd_info_copy.id == pm->pe_source_node.id) {
           pm->pe_source_node = nd_info_copy;
         }
 
         Glib::signal_idle().connect_once([pm, nd_info_copy] { pm->source_changed.emit(nd_info_copy); });
-      } else if (nd_info_copy.media_class == "Audio/Sink") {
+      } else if (nd->nd_info.media_class == "Audio/Sink") {
+        auto nd_info_copy = nd->nd_info;
+
         if (nd_info_copy.id == pm->pe_sink_node.id) {
           pm->pe_sink_node = nd_info_copy;
         }
@@ -822,11 +835,11 @@ void on_registry_global(void* data,
         // therefore we make a copy of NodeInfo
 
         if (media_class == "Audio/Source" && name != "easyeffects_source") {
-          NodeInfo nd_info_copy = pd->nd_info;
+          auto nd_info_copy = pd->nd_info;
 
           Glib::signal_idle().connect_once([pm, nd_info_copy] { pm->source_added.emit(nd_info_copy); });
         } else if (media_class == "Audio/Sink" && name != "easyeffects_sink") {
-          NodeInfo nd_info_copy = pd->nd_info;
+          auto nd_info_copy = pd->nd_info;
 
           Glib::signal_idle().connect_once([pm, nd_info_copy] { pm->sink_added.emit(nd_info_copy); });
         } else if (media_class == "Stream/Output/Audio") {

--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -1259,28 +1259,28 @@ void PipeManager::disconnect_stream_input(const uint& id, const std::string& med
   }
 }
 
-void PipeManager::set_node_volume(const NodeInfo& nd_info, const float& value) {
+void PipeManager::set_node_volume(pw_proxy* proxy, const int& n_vol_ch, const float& value) {
   std::array<float, SPA_AUDIO_MAX_CHANNELS> volumes{};
 
   std::ranges::fill(volumes, 0.0F);
-  std::fill_n(volumes.begin(), nd_info.n_volume_channels, value);
+  std::fill_n(volumes.begin(), n_vol_ch, value);
 
   std::array<char, 1024> buffer{};
 
   auto builder = SPA_POD_BUILDER_INIT(buffer.data(), sizeof(buffer));
 
-  pw_node_set_param((struct pw_node*)nd_info.proxy, SPA_PARAM_Props, 0,
+  pw_node_set_param((struct pw_node*)proxy, SPA_PARAM_Props, 0,
                     (spa_pod*)spa_pod_builder_add_object(
                         &builder, SPA_TYPE_OBJECT_Props, SPA_PARAM_Props, SPA_PROP_channelVolumes,
-                        SPA_POD_Array(sizeof(float), SPA_TYPE_Float, nd_info.n_volume_channels, volumes.data())));
+                        SPA_POD_Array(sizeof(float), SPA_TYPE_Float, n_vol_ch, volumes.data())));
 }
 
-void PipeManager::set_node_mute(const NodeInfo& nd_info, const bool& state) {
+void PipeManager::set_node_mute(pw_proxy* proxy, const bool& state) {
   std::array<char, 1024> buffer{};
 
   auto builder = SPA_POD_BUILDER_INIT(buffer.data(), sizeof(buffer));
 
-  pw_node_set_param((pw_node*)nd_info.proxy, SPA_PARAM_Props, 0,
+  pw_node_set_param((pw_node*)proxy, SPA_PARAM_Props, 0,
                     (spa_pod*)spa_pod_builder_add_object(&builder, SPA_TYPE_OBJECT_Props, SPA_PARAM_Props,
                                                          SPA_PROP_mute, SPA_POD_Bool(state)));
 }

--- a/src/pitch.cpp
+++ b/src/pitch.cpp
@@ -24,9 +24,6 @@ Pitch::Pitch(const std::string& tag,
              const std::string& schema_path,
              PipeManager* pipe_manager)
     : PluginBase(tag, plugin_name::pitch, schema, schema_path, pipe_manager) {
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
   formant_preserving = settings->get_boolean("formant-preserving");
   faster = settings->get_boolean("faster");
 
@@ -34,14 +31,6 @@ Pitch::Pitch(const std::string& tag,
   octaves = settings->get_int("octaves");
   semitones = settings->get_int("semitones");
   cents = settings->get_int("cents");
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
 
   settings->signal_changed("crispness").connect([=, this](const auto& key) {
     crispness = settings->get_int("crispness");
@@ -100,6 +89,8 @@ Pitch::Pitch(const std::string& tag,
 
     update_pitch_scale();
   });
+
+  setup_input_output_gain();
 }
 
 Pitch::~Pitch() {

--- a/src/pitch.cpp
+++ b/src/pitch.cpp
@@ -135,7 +135,9 @@ void Pitch::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   stretcher_in[0] = left_in.data();
   stretcher_in[1] = right_in.data();
@@ -194,7 +196,9 @@ void Pitch::process(std::span<float>& left_in,
     }
   }
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   if (notify_latency) {
     const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);

--- a/src/pitch_ui.cpp
+++ b/src/pitch_ui.cpp
@@ -28,9 +28,6 @@ PitchUi::PitchUi(BaseObjectType* cobject,
 
   // loading builder widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
-
   crispness = builder->get_widget<Gtk::SpinButton>("crispness");
   cents = builder->get_widget<Gtk::SpinButton>("cents");
   semitones = builder->get_widget<Gtk::SpinButton>("semitones");
@@ -41,8 +38,6 @@ PitchUi::PitchUi(BaseObjectType* cobject,
 
   // gsettings bindings
 
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("cents", cents->get_adjustment().get(), "value");
   settings->bind("crispness", crispness->get_adjustment().get(), "value");
   settings->bind("semitones", semitones->get_adjustment().get(), "value");
@@ -50,8 +45,7 @@ PitchUi::PitchUi(BaseObjectType* cobject,
   settings->bind("faster", faster, "active");
   settings->bind("formant-preserving", formant_preserving, "active");
 
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
+  setup_input_output_gain(builder);
 }
 
 PitchUi::~PitchUi() {

--- a/src/plugin_base.cpp
+++ b/src/plugin_base.cpp
@@ -277,6 +277,19 @@ void PluginBase::get_peaks(const std::span<float>& left_in,
   output_peak_right = (peak_r > output_peak_right) ? peak_r : output_peak_right;
 }
 
+void PluginBase::setup_input_output_gain() {
+  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
+  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
+
+  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
+    input_gain = util::db_to_linear(settings->get_double(key));
+  });
+
+  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
+    output_gain = util::db_to_linear(settings->get_double(key));
+  });
+}
+
 void PluginBase::apply_gain(std::span<float>& left, std::span<float>& right, const float& gain) {
   if (left.empty() || right.empty()) {
     return;

--- a/src/plugin_ui_base.cpp
+++ b/src/plugin_ui_base.cpp
@@ -47,6 +47,17 @@ PluginUiBase::~PluginUiBase() {
   }
 }
 
+void PluginUiBase::setup_input_output_gain(const Glib::RefPtr<Gtk::Builder>& builder) {
+  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
+  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
+
+  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
+  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
+
+  prepare_scale(input_gain, "");
+  prepare_scale(output_gain, "");
+}
+
 void PluginUiBase::on_new_input_level(const float& left, const float& right) {
   update_level(input_level_left, input_level_left_label, input_level_right, input_level_right_label, left, right);
 }

--- a/src/plugin_ui_base.cpp
+++ b/src/plugin_ui_base.cpp
@@ -60,12 +60,6 @@ void PluginUiBase::prepare_spinbutton(Gtk::SpinButton* button, const Glib::ustri
   button->signal_input().connect([=](double& new_value) { return parse_spinbutton_input(button, new_value); }, true);
 }
 
-auto PluginUiBase::string_to_float(const std::string& value) -> float {
-  // this conversion must be locale independent
-
-  return std::stof(value);
-}
-
 void PluginUiBase::set_transient_window(Gtk::Window* transient_window) {
   this->transient_window = transient_window;
 }

--- a/src/reverb.cpp
+++ b/src/reverb.cpp
@@ -29,17 +29,6 @@ Reverb::Reverb(const std::string& tag,
     util::debug(log_tag + "http://calf.sourceforge.net/plugins/Reverb is not installed");
   }
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   lv2_wrapper->bind_key_double(settings, "decay-time", "decay_time");
 
   lv2_wrapper->bind_key_double(settings, "hf-damp", "hf_damp");
@@ -57,6 +46,8 @@ Reverb::Reverb(const std::string& tag,
   lv2_wrapper->bind_key_double_db(settings, "dry", "dry");
 
   lv2_wrapper->bind_key_enum(settings, "room-size", "room_size");
+
+  setup_input_output_gain();
 }
 
 Reverb::~Reverb() {

--- a/src/reverb.cpp
+++ b/src/reverb.cpp
@@ -78,12 +78,16 @@ void Reverb::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
   lv2_wrapper->run();
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   if (post_messages) {
     get_peaks(left_in, right_in, left_out, right_out);

--- a/src/reverb_ui.cpp
+++ b/src/reverb_ui.cpp
@@ -77,8 +77,6 @@ ReverbUi::ReverbUi(BaseObjectType* cobject,
 
   // loading builder widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
   predelay = builder->get_widget<Gtk::SpinButton>("predelay");
   decay_time = builder->get_widget<Gtk::SpinButton>("decay_time");
   diffusion = builder->get_widget<Gtk::SpinButton>("diffusion");
@@ -97,8 +95,6 @@ ReverbUi::ReverbUi(BaseObjectType* cobject,
 
   // gsettings bindings
 
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("predelay", predelay->get_adjustment().get(), "value");
   settings->bind("decay-time", decay_time->get_adjustment().get(), "value");
   settings->bind("diffusion", diffusion->get_adjustment().get(), "value");
@@ -110,9 +106,6 @@ ReverbUi::ReverbUi(BaseObjectType* cobject,
 
   g_settings_bind_with_mapping(settings->gobj(), "room-size", room_size->gobj(), "active", G_SETTINGS_BIND_DEFAULT,
                                room_size_enum_to_int, int_to_room_size_enum, nullptr, nullptr);
-
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
 
   prepare_spinbutton(decay_time, "s");
 
@@ -128,6 +121,8 @@ ReverbUi::ReverbUi(BaseObjectType* cobject,
   prepare_spinbutton(diffusion, "");
 
   init_presets_buttons();
+
+  setup_input_output_gain(builder);
 }
 
 ReverbUi::~ReverbUi() {

--- a/src/rnnoise.cpp
+++ b/src/rnnoise.cpp
@@ -27,17 +27,6 @@ RNNoise::RNNoise(const std::string& tag,
   data_L.reserve(blocksize);
   data_R.reserve(blocksize);
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   settings->signal_changed("model-path").connect([=, this](const auto& key) {
     data_mutex.lock();
 
@@ -56,6 +45,8 @@ RNNoise::RNNoise(const std::string& tag,
 
     rnnoise_ready = true;
   });
+
+  setup_input_output_gain();
 
   auto* m = get_model_from_file();
 

--- a/src/rnnoise.cpp
+++ b/src/rnnoise.cpp
@@ -109,7 +109,9 @@ void RNNoise::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   if (resample) {
     if (resampler_ready) {
@@ -179,7 +181,9 @@ void RNNoise::process(std::span<float>& left_in,
     }
   }
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   if (notify_latency) {
     const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);

--- a/src/rnnoise_ui.cpp
+++ b/src/rnnoise_ui.cpp
@@ -32,9 +32,6 @@ RNNoiseUi::RNNoiseUi(BaseObjectType* cobject,
 
   // loading builder widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
-
   model_list_frame = builder->get_widget<Gtk::Frame>("model_list_frame");
 
   listview = builder->get_widget<Gtk::ListView>("listview");
@@ -49,14 +46,8 @@ RNNoiseUi::RNNoiseUi(BaseObjectType* cobject,
 
   // gsettings bindings
 
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
-
   connections.emplace_back(
       settings->signal_changed("model-path").connect([=, this](const auto& key) { set_active_model_label(); }));
-
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
 
   // model dir
 
@@ -69,6 +60,8 @@ RNNoiseUi::RNNoiseUi(BaseObjectType* cobject,
   } else {
     util::debug(log_tag + "model directory already exists: " + model_dir.string());
   }
+
+  setup_input_output_gain(builder);
 
   setup_listview();
 

--- a/src/stereo_tools.cpp
+++ b/src/stereo_tools.cpp
@@ -92,12 +92,16 @@ void StereoTools::process(std::span<float>& left_in,
     return;
   }
 
-  apply_gain(left_in, right_in, input_gain);
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
 
   lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
   lv2_wrapper->run();
 
-  apply_gain(left_out, right_out, output_gain);
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
 
   if (post_messages) {
     get_peaks(left_in, right_in, left_out, right_out);

--- a/src/stereo_tools.cpp
+++ b/src/stereo_tools.cpp
@@ -29,17 +29,6 @@ StereoTools::StereoTools(const std::string& tag,
     util::debug(log_tag + "http://calf.sourceforge.net/plugins/StereoTools is not installed");
   }
 
-  input_gain = static_cast<float>(util::db_to_linear(settings->get_double("input-gain")));
-  output_gain = static_cast<float>(util::db_to_linear(settings->get_double("output-gain")));
-
-  settings->signal_changed("input-gain").connect([=, this](const auto& key) {
-    input_gain = util::db_to_linear(settings->get_double(key));
-  });
-
-  settings->signal_changed("output-gain").connect([=, this](const auto& key) {
-    output_gain = util::db_to_linear(settings->get_double(key));
-  });
-
   lv2_wrapper->bind_key_double(settings, "balance-in", "balance_in");
 
   lv2_wrapper->bind_key_double(settings, "balance-out", "balance_out");
@@ -71,6 +60,8 @@ StereoTools::StereoTools(const std::string& tag,
   lv2_wrapper->bind_key_bool(settings, "phaser", "phaser");
 
   lv2_wrapper->bind_key_enum(settings, "mode", "mode");
+
+  setup_input_output_gain();
 }
 
 StereoTools::~StereoTools() {

--- a/src/stereo_tools_ui.cpp
+++ b/src/stereo_tools_ui.cpp
@@ -82,8 +82,6 @@ StereoToolsUi::StereoToolsUi(BaseObjectType* cobject,
 
   // loading glade widgets
 
-  input_gain = builder->get_widget<Gtk::Scale>("input_gain");
-  output_gain = builder->get_widget<Gtk::Scale>("output_gain");
   balance_in = builder->get_widget<Gtk::SpinButton>("balance_in");
   balance_out = builder->get_widget<Gtk::SpinButton>("balance_out");
   slev = builder->get_widget<Gtk::SpinButton>("slev");
@@ -110,8 +108,6 @@ StereoToolsUi::StereoToolsUi(BaseObjectType* cobject,
   settings->bind("muter", muter, "active");
   settings->bind("phasel", phasel, "active");
   settings->bind("phaser", phaser, "active");
-  settings->bind("input-gain", input_gain->get_adjustment().get(), "value");
-  settings->bind("output-gain", output_gain->get_adjustment().get(), "value");
   settings->bind("balance-in", balance_in->get_adjustment().get(), "value");
   settings->bind("balance-out", balance_out->get_adjustment().get(), "value");
   settings->bind("slev", slev->get_adjustment().get(), "value");
@@ -126,9 +122,6 @@ StereoToolsUi::StereoToolsUi(BaseObjectType* cobject,
   g_settings_bind_with_mapping(settings->gobj(), "mode", mode->gobj(), "active", G_SETTINGS_BIND_DEFAULT,
                                stereo_tools_enum_to_int, int_to_stereo_tools_enum, nullptr, nullptr);
 
-  prepare_scale(input_gain, "");
-  prepare_scale(output_gain, "");
-
   prepare_spinbutton(slev, "dB");
   prepare_spinbutton(mlev, "dB");
 
@@ -141,6 +134,8 @@ StereoToolsUi::StereoToolsUi(BaseObjectType* cobject,
   prepare_spinbutton(mpan, "");
   prepare_spinbutton(stereo_base, "");
   prepare_spinbutton(stereo_phase, "");
+
+  setup_input_output_gain(builder);
 }
 
 StereoToolsUi::~StereoToolsUi() {

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -30,7 +30,7 @@ StreamInputEffects::StreamInputEffects(PipeManager* pipe_manager)
 
     const auto* input_device = settings->get_string("input-device").c_str();
 
-    for (const auto& node : pm->list_nodes) {
+    for (const auto& [id, node] : pm->node_map) {
       if (node.name == input_device) {
         pm->input_device = node;
 
@@ -48,7 +48,7 @@ StreamInputEffects::StreamInputEffects(PipeManager* pipe_manager)
   auto* PULSE_SOURCE = std::getenv("PULSE_SOURCE");
 
   if (PULSE_SOURCE != nullptr) {
-    for (const auto& node : pm->list_nodes) {
+    for (const auto& [id, node] : pm->node_map) {
       if (node.name == PULSE_SOURCE) {
         pm->input_device = node;
 
@@ -71,7 +71,7 @@ StreamInputEffects::StreamInputEffects(PipeManager* pipe_manager)
       return;
     }
 
-    for (const auto& node : pm->list_nodes) {
+    for (const auto& [id, node] : pm->node_map) {
       if (node.name == name) {
         pm->input_device = node;
 

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -103,15 +103,15 @@ StreamInputEffects::~StreamInputEffects() {
   disconnect_filters();
 }
 
-void StreamInputEffects::on_app_added(NodeInfo node_info) {
+void StreamInputEffects::on_app_added(uint id, std::string name, std::string media_class) {
   const auto& blocklist = settings->get_string_array("blocklist");
 
-  const auto& is_blocklisted = std::ranges::find(blocklist, node_info.name.c_str()) != blocklist.end();;
+  const auto& is_blocklisted = std::ranges::find(blocklist, name.c_str()) != blocklist.end();;
 
   if (is_blocklisted) {
-    pm->disconnect_stream_input(node_info);
+    pm->disconnect_stream_input(id, media_class);
   } else if (global_settings->get_boolean("process-all-inputs")) {
-    pm->connect_stream_input(node_info);
+    pm->connect_stream_input(id, media_class);
   }
 }
 

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -103,7 +103,7 @@ StreamInputEffects::~StreamInputEffects() {
   disconnect_filters();
 }
 
-void StreamInputEffects::on_app_added(uint id, std::string name, std::string media_class) {
+void StreamInputEffects::on_app_added(const uint id, const std::string name, const std::string media_class) {
   const auto& blocklist = settings->get_string_array("blocklist");
 
   const auto& is_blocklisted = std::ranges::find(blocklist, name.c_str()) != blocklist.end();;

--- a/src/stream_input_effects_ui.cpp
+++ b/src/stream_input_effects_ui.cpp
@@ -38,9 +38,9 @@ StreamInputEffectsUi::StreamInputEffectsUi(BaseObjectType* cobject,
 
   toggle_listen_mic->signal_toggled().connect([&, this]() { sie->set_listen_to_mic(toggle_listen_mic->get_active()); });
 
-  for (const auto& node : pm->list_nodes) {
+  for (const auto& [key, node] : pm->node_map) {
     if (node.media_class == "Stream/Input/Audio") {
-      on_app_added(node);
+      on_app_added(node.id, node.name, node.media_class);
     }
   }
 

--- a/src/stream_input_effects_ui.cpp
+++ b/src/stream_input_effects_ui.cpp
@@ -38,7 +38,7 @@ StreamInputEffectsUi::StreamInputEffectsUi(BaseObjectType* cobject,
 
   toggle_listen_mic->signal_toggled().connect([&, this]() { sie->set_listen_to_mic(toggle_listen_mic->get_active()); });
 
-  for (const auto& [key, node] : pm->node_map) {
+  for (const auto& [id, node] : pm->node_map) {
     if (node.media_class == "Stream/Input/Audio") {
       on_app_added(node.id, node.name, node.media_class);
     }

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -103,7 +103,7 @@ StreamOutputEffects::~StreamOutputEffects() {
   util::debug(log_tag + "destroyed");
 }
 
-void StreamOutputEffects::on_app_added(uint id, std::string name, std::string media_class) {
+void StreamOutputEffects::on_app_added(const uint id, const std::string name, const std::string media_class) {
   const auto& blocklist = settings->get_string_array("blocklist");
 
   const auto& is_blocklisted = std::ranges::find(blocklist, name.c_str()) != blocklist.end();

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -30,7 +30,7 @@ StreamOutputEffects::StreamOutputEffects(PipeManager* pipe_manager)
 
     const auto* output_device = settings->get_string("output-device").c_str();
 
-    for (const auto& node : pm->list_nodes) {
+    for (const auto& [id, node] : pm->node_map) {
       if (node.name == output_device) {
         pm->output_device = node;
 
@@ -48,7 +48,7 @@ StreamOutputEffects::StreamOutputEffects(PipeManager* pipe_manager)
   auto* PULSE_SINK = std::getenv("PULSE_SINK");
 
   if (PULSE_SINK != nullptr) {
-    for (const auto& node : pm->list_nodes) {
+    for (const auto& [id, node] : pm->node_map) {
       if (node.name == PULSE_SINK) {
         pm->output_device = node;
 
@@ -71,7 +71,7 @@ StreamOutputEffects::StreamOutputEffects(PipeManager* pipe_manager)
       return;
     }
 
-    for (const auto& node : pm->list_nodes) {
+    for (const auto& [id, node] : pm->node_map) {
       if (node.name == name) {
         pm->output_device = node;
 

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -103,15 +103,15 @@ StreamOutputEffects::~StreamOutputEffects() {
   util::debug(log_tag + "destroyed");
 }
 
-void StreamOutputEffects::on_app_added(NodeInfo node_info) {
+void StreamOutputEffects::on_app_added(uint id, std::string name, std::string media_class) {
   const auto& blocklist = settings->get_string_array("blocklist");
 
-  const auto& is_blocklisted = std::ranges::find(blocklist, node_info.name.c_str()) != blocklist.end();
+  const auto& is_blocklisted = std::ranges::find(blocklist, name.c_str()) != blocklist.end();
 
   if (is_blocklisted) {
-    pm->disconnect_stream_output(node_info);
+    pm->disconnect_stream_output(id, media_class);
   } else if (global_settings->get_boolean("process-all-outputs")) {
-    pm->connect_stream_output(node_info);
+    pm->connect_stream_output(id, media_class);
   }
 }
 

--- a/src/stream_output_effects_ui.cpp
+++ b/src/stream_output_effects_ui.cpp
@@ -24,7 +24,7 @@ StreamOutputEffectsUi::StreamOutputEffectsUi(BaseObjectType* cobject,
                                              StreamOutputEffects* soe_ptr,
                                              const std::string& schema)
     : Gtk::Box(cobject), EffectsBaseUi(refBuilder, soe_ptr, schema), soe(soe_ptr) {
-  for (const auto& [key, node] : pm->node_map) {
+  for (const auto& [id, node] : pm->node_map) {
     if (node.media_class == "Stream/Output/Audio") {
       on_app_added(node.id, node.name, node.media_class);
     }

--- a/src/stream_output_effects_ui.cpp
+++ b/src/stream_output_effects_ui.cpp
@@ -24,9 +24,9 @@ StreamOutputEffectsUi::StreamOutputEffectsUi(BaseObjectType* cobject,
                                              StreamOutputEffects* soe_ptr,
                                              const std::string& schema)
     : Gtk::Box(cobject), EffectsBaseUi(refBuilder, soe_ptr, schema), soe(soe_ptr) {
-  for (const auto& node : pm->list_nodes) {
+  for (const auto& [key, node] : pm->node_map) {
     if (node.media_class == "Stream/Output/Audio") {
-      on_app_added(node);
+      on_app_added(node.id, node.name, node.media_class);
     }
   }
 


### PR DESCRIPTION
* the vector of nodes has been replaced with a map indexed by node id
* resolved the issue related to app info ui: now the correct info are show when the window is opened in service mode
* on_node_info a new state of the NodeInfo is updated inside the node map 
* now on stream added/changed/removed we only pass node id, not the whole NodeInfo struct; with the id we can scan the node map to get the updated NodeInfo data
* some functions have been partially rewritten the pass only the relevant data and not the whole NodeInfo
* string_to_float function removed: it was needed only for eq APO import; it has been replaced with std:stof    

edit: Tested, it's working to me. Please @wwmm, test the input pipeline.

edit2: Fixes #1124