### PR TITLE
Add new plugins before a limiter, if present

### DIFF
--- a/include/effects_base_ui.hpp
+++ b/include/effects_base_ui.hpp
@@ -125,7 +125,7 @@ class EffectsBaseUi {
 
   Glib::RefPtr<Gtk::StringList> blocklist, plugins, selected_plugins;
 
-  std::map<std::string, std::string> plugins_names{{plugin_name::autogain, _("Autogain")},
+  std::map<Glib::ustring, Glib::ustring> plugins_names{{plugin_name::autogain, _("Autogain")},
                                                    {plugin_name::bass_enhancer, _("Bass Enhancer")},
                                                    {plugin_name::bass_loudness, _("Bass Loudness")},
                                                    {plugin_name::compressor, _("Compressor")},

--- a/src/stream_input_effects_ui.cpp
+++ b/src/stream_input_effects_ui.cpp
@@ -33,7 +33,7 @@ StreamInputEffectsUi::StreamInputEffectsUi(BaseObjectType* cobject,
   stack_top->connect_property_changed("visible-child", [=, this]() {
     const auto& child_name = stack_top->get_visible_child_name();
 
-    toggle_listen_mic->set_visible((child_name == "page_players") ? false : true);
+    toggle_listen_mic->set_visible(child_name != "page_players");
   });
 
   toggle_listen_mic->signal_toggled().connect([&, this]() { sie->set_listen_to_mic(toggle_listen_mic->get_active()); });


### PR DESCRIPTION
I added a new security feature which is quite helpful.

Adding a new plugin to the stack we have to be careful because sometimes the output level could be too high and that may damage the audio device.

That's because it's recommended to use a plugin of type limiter at the last position of the filter chain (the limiter itself or the maximizer).

If the user don't use one of these plugins in such place we can't do nothing. But if the user has been already careful to put one of them at the final position, we follow this responsible behaviour adding new plugins at the second to last position, just before the limiter.