### PR TITLE
Fix lv2 port values, icon theme and autoload preset dropdown

### DIFF
--- a/include/application_ui.hpp
+++ b/include/application_ui.hpp
@@ -64,6 +64,8 @@ class ApplicationUi : public Gtk::ApplicationWindow {
   int soe_latency = 0, sie_latency = 0;
 
   static void apply_css_style(const std::string& css_file_name);
+
+  auto setup_icon_theme() -> Glib::RefPtr<Gtk::IconTheme>;
 };
 
 #endif

--- a/include/autogain.hpp
+++ b/include/autogain.hpp
@@ -42,13 +42,14 @@ class AutoGain : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(const double&,              // loudness
-                    const double&,              // gain
-                    const double&,              // momentary
-                    const double&,              // shortterm
-                    const double&,              // integrated
-                    const double&,              // relative
-                    const double&)> results;    // range
+  sigc::signal<void(const double&,  // loudness
+                    const double&,  // gain
+                    const double&,  // momentary
+                    const double&,  // shortterm
+                    const double&,  // integrated
+                    const double&,  // relative
+                    const double&)>
+      results;  // range
 
  private:
   bool ebur128_ready = false;

--- a/include/bass_enhancer.hpp
+++ b/include/bass_enhancer.hpp
@@ -44,6 +44,8 @@ class BassEnhancer : public PluginBase {
 
   sigc::signal<void(const double&)> harmonics;
 
+  double harmonics_port_value = 0.0;
+
  private:
   std::unique_ptr<lv2::Lv2Wrapper> lv2_wrapper;
 };

--- a/include/compressor.hpp
+++ b/include/compressor.hpp
@@ -46,6 +46,12 @@ class Compressor : public PluginBase {
 
   sigc::signal<void(const float&)> reduction, sidechain, curve, envelope, latency;
 
+  float reduction_port_value = 0.0F;
+  float sidechain_port_value = 0.0F;
+  float curve_port_value = 0.0F;
+  float envelope_port_value = 0.0F;
+  float latency_port_value = 0.0F;
+
  private:
   uint latency_n_frames = 0U;
 

--- a/include/deesser.hpp
+++ b/include/deesser.hpp
@@ -41,6 +41,9 @@ class Deesser : public PluginBase {
 
   sigc::signal<void(const double&)> compression, detected;
 
+  double compression_port_value = 0.0;
+  double detected_port_value = 0.0;
+
  private:
   std::unique_ptr<lv2::Lv2Wrapper> lv2_wrapper;
 };

--- a/include/delay.hpp
+++ b/include/delay.hpp
@@ -41,6 +41,8 @@ class Delay : public PluginBase {
 
   sigc::signal<void(const float&)> latency;
 
+  float latency_port_value = 0.0F;
+
  private:
   uint latency_n_frames = 0U;
 

--- a/include/effects_base_ui.hpp
+++ b/include/effects_base_ui.hpp
@@ -57,7 +57,10 @@
 
 class EffectsBaseUi {
  public:
-  EffectsBaseUi(const Glib::RefPtr<Gtk::Builder>& builder, EffectsBase* effects_base, const std::string& schema);
+  EffectsBaseUi(const Glib::RefPtr<Gtk::Builder>& builder,
+                Glib::RefPtr<Gtk::IconTheme> icon_ptr,
+                EffectsBase* effects_base,
+                const std::string& schema);
   EffectsBaseUi(const EffectsBaseUi&) = delete;
   auto operator=(const EffectsBaseUi&) -> EffectsBaseUi& = delete;
   EffectsBaseUi(const EffectsBaseUi&&) = delete;

--- a/include/equalizer.hpp
+++ b/include/equalizer.hpp
@@ -47,6 +47,8 @@ class Equalizer : public PluginBase {
 
   sigc::signal<void(const float&)> latency;
 
+  float latency_port_value = 0.0F;
+
  private:
   Glib::RefPtr<Gio::Settings> settings_left, settings_right;
 

--- a/include/exciter.hpp
+++ b/include/exciter.hpp
@@ -41,6 +41,8 @@ class Exciter : public PluginBase {
 
   sigc::signal<void(const double&)> harmonics;
 
+  double harmonics_port_value = 0.0;
+
  private:
   std::unique_ptr<lv2::Lv2Wrapper> lv2_wrapper;
 };

--- a/include/gate.hpp
+++ b/include/gate.hpp
@@ -41,6 +41,8 @@ class Gate : public PluginBase {
 
   sigc::signal<void(const double&)> gating;
 
+  double gating_port_value = 0.0;
+
  private:
   std::unique_ptr<lv2::Lv2Wrapper> lv2_wrapper;
 };

--- a/include/limiter.hpp
+++ b/include/limiter.hpp
@@ -39,9 +39,13 @@ class Limiter : public PluginBase {
                std::span<float>& left_out,
                std::span<float>& right_out) override;
 
-  sigc::signal<void(const float&)> latency;
+  sigc::signal<void(const float&)> gain_left, gain_right, sidechain_left, sidechain_right, latency;
 
-  sigc::signal<void(const float&)> gain_left, gain_right, sidechain_left, sidechain_right;
+  float gain_l_port_value = 0.0F;
+  float gain_r_port_value = 0.0F;
+  float sidechain_l_port_value = 0.0F;
+  float sidechain_r_port_value = 0.0F;
+  float latency_port_value = 0.0F;
 
  private:
   uint latency_n_frames = 0U;

--- a/include/loudness.hpp
+++ b/include/loudness.hpp
@@ -44,6 +44,8 @@ class Loudness : public PluginBase {
 
   sigc::signal<void(const float&)> latency;
 
+  float latency_port_value = 0.0F;
+
  private:
   uint latency_n_frames = 0U;
 

--- a/include/maximizer.hpp
+++ b/include/maximizer.hpp
@@ -46,6 +46,10 @@ class Maximizer : public PluginBase {
 
   sigc::signal<void(const float&)> latency;
 
+  double reduction_port_value = 0.0;
+
+  float latency_port_value = 0.0F;
+
  private:
   uint latency_n_frames = 0U;
 

--- a/include/multiband_compressor.hpp
+++ b/include/multiband_compressor.hpp
@@ -48,6 +48,13 @@ class MultibandCompressor : public PluginBase {
 
   sigc::signal<void(const std::array<float, n_bands>&)> reduction, envelope, curve, frequency_range;
 
+  float latency_port_value = 0.0F;
+
+  std::array<float, n_bands> frequency_range_end_port_array = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
+  std::array<float, n_bands> envelope_port_array = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
+  std::array<float, n_bands> curve_port_array = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
+  std::array<float, n_bands> reduction_port_array = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
+
  private:
   uint latency_n_frames = 0U;
 

--- a/include/multiband_gate.hpp
+++ b/include/multiband_gate.hpp
@@ -44,6 +44,16 @@ class MultibandGate : public PluginBase {
 
   sigc::signal<void(const double&)> output0, output1, output2, output3, gating0, gating1, gating2, gating3;
 
+  double output0_port_value = 0.0;
+  double output1_port_value = 0.0;
+  double output2_port_value = 0.0;
+  double output3_port_value = 0.0;
+
+  double gating0_port_value = 0.0;
+  double gating1_port_value = 0.0;
+  double gating2_port_value = 0.0;
+  double gating3_port_value = 0.0;
+
  private:
   std::unique_ptr<lv2::Lv2Wrapper> lv2_wrapper;
 };

--- a/include/presets_manager.hpp
+++ b/include/presets_manager.hpp
@@ -75,14 +75,16 @@ class PresetsManager {
 
   void save_preset_file(const PresetType& preset_type, const Glib::ustring& name);
 
-  void write_plugins_preset(const PresetType& preset_type, const std::vector<Glib::ustring>& plugins,
+  void write_plugins_preset(const PresetType& preset_type,
+                            const std::vector<Glib::ustring>& plugins,
                             nlohmann::json& json);
 
   void remove(const PresetType& preset_type, const Glib::ustring& name);
 
   void load_preset_file(const PresetType& preset_type, const Glib::ustring& name);
 
-  void read_plugins_preset(const PresetType& preset_type, const std::vector<Glib::ustring>& plugins,
+  void read_plugins_preset(const PresetType& preset_type,
+                           const std::vector<Glib::ustring>& plugins,
                            const nlohmann::json& json);
 
   void import(const PresetType& preset_type, const std::string& file_path);

--- a/include/scale_helper.hpp
+++ b/include/scale_helper.hpp
@@ -24,8 +24,8 @@
 
 inline auto prepare_scale(Gtk::Scale* scale, const std::string& unit) {
   scale->set_format_value_func([=](const auto& value) {
-    const auto& v_str = Glib::ustring::format(std::setprecision(scale->get_digits()), std::fixed,
-                                              scale->get_adjustment()->get_value());
+    const auto& v_str =
+        Glib::ustring::format(std::setprecision(scale->get_digits()), std::fixed, scale->get_adjustment()->get_value());
 
     return v_str + ((unit.empty()) ? "" : (" " + unit));
   });

--- a/include/spinbutton_helper.hpp
+++ b/include/spinbutton_helper.hpp
@@ -24,8 +24,8 @@
 #include <sstream>
 
 inline auto parse_spinbutton_output(Gtk::SpinButton* button, const Glib::ustring& unit) -> bool {
-  const auto& value = Glib::ustring::format(std::setprecision(button->get_digits()), std::fixed,
-                                            button->get_adjustment()->get_value());
+  const auto& value =
+      Glib::ustring::format(std::setprecision(button->get_digits()), std::fixed, button->get_adjustment()->get_value());
 
   button->set_text(value + ((unit.empty()) ? "" : (" " + unit)));
 

--- a/include/stereo_tools.hpp
+++ b/include/stereo_tools.hpp
@@ -44,6 +44,8 @@ class StereoTools : public PluginBase {
 
   sigc::signal<void(const double&)> new_correlation;
 
+  double correlation_port_value = 0.0;
+
  private:
   std::unique_ptr<lv2::Lv2Wrapper> lv2_wrapper;
 };

--- a/include/stream_input_effects_ui.hpp
+++ b/include/stream_input_effects_ui.hpp
@@ -27,6 +27,7 @@ class StreamInputEffectsUi : public Gtk::Box, public EffectsBaseUi {
  public:
   StreamInputEffectsUi(BaseObjectType* cobject,
                        const Glib::RefPtr<Gtk::Builder>& refBuilder,
+                       Glib::RefPtr<Gtk::IconTheme> icon_ptr,
                        StreamInputEffects* sie_ptr,
                        const std::string& schema);
   StreamInputEffectsUi(const StreamInputEffectsUi&) = delete;
@@ -35,7 +36,8 @@ class StreamInputEffectsUi : public Gtk::Box, public EffectsBaseUi {
   auto operator=(const StreamInputEffectsUi&&) -> StreamInputEffectsUi& = delete;
   ~StreamInputEffectsUi() override;
 
-  static auto add_to_stack(Gtk::Stack* stack, StreamInputEffects* sie_ptr) -> StreamInputEffectsUi*;
+  static auto add_to_stack(Gtk::Stack* stack, StreamInputEffects* sie_ptr, Glib::RefPtr<Gtk::IconTheme> icon_ptr)
+      -> StreamInputEffectsUi*;
 
  protected:
   const std::string log_tag = "sie_ui: ";

--- a/include/stream_output_effects_ui.hpp
+++ b/include/stream_output_effects_ui.hpp
@@ -27,6 +27,7 @@ class StreamOutputEffectsUi : public Gtk::Box, public EffectsBaseUi {
  public:
   StreamOutputEffectsUi(BaseObjectType* cobject,
                         const Glib::RefPtr<Gtk::Builder>& refBuilder,
+                        Glib::RefPtr<Gtk::IconTheme> icon_ptr,
                         StreamOutputEffects* soe_ptr,
                         const std::string& schema);
   StreamOutputEffectsUi(const StreamOutputEffectsUi&) = delete;
@@ -35,7 +36,8 @@ class StreamOutputEffectsUi : public Gtk::Box, public EffectsBaseUi {
   auto operator=(const StreamOutputEffectsUi&&) -> StreamOutputEffectsUi& = delete;
   ~StreamOutputEffectsUi() override;
 
-  static auto add_to_stack(Gtk::Stack* stack, StreamOutputEffects* soe_ptr) -> StreamOutputEffectsUi*;
+  static auto add_to_stack(Gtk::Stack* stack, StreamOutputEffects* soe_ptr, Glib::RefPtr<Gtk::IconTheme> icon_ptr)
+      -> StreamOutputEffectsUi*;
 
  protected:
   const std::string log_tag = "soe_ui: ";

--- a/src/bass_enhancer.cpp
+++ b/src/bass_enhancer.cpp
@@ -93,9 +93,9 @@ void BassEnhancer::process(std::span<float>& left_in,
     if (notification_dt >= notification_time_window) {
       // harmonics needed as double for levelbar widget ui, so we convert it here
 
-      const double& harmonics_value = static_cast<double>(lv2_wrapper->get_control_port_value("meter_drive"));
+      harmonics_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("meter_drive"));
 
-      Glib::signal_idle().connect_once([=, this] { harmonics.emit(harmonics_value); });
+      Glib::signal_idle().connect_once([=, this] { harmonics.emit(harmonics_port_value); });
 
       notify();
 

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -172,15 +172,15 @@ void Compressor::process(std::span<float>& left_in,
   if (latency_n_frames != lv) {
     latency_n_frames = lv;
 
-    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    latency_port_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
-    util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
+    util::debug(log_tag + name + " latency: " + std::to_string(latency_port_value) + " s");
 
-    Glib::signal_idle().connect_once([=, this] { latency.emit(latency_value); });
+    Glib::signal_idle().connect_once([=, this] { latency.emit(latency_port_value); });
 
     spa_process_latency_info latency_info{};
 
-    latency_info.ns = static_cast<uint64_t>(latency_value * 1000000000.0F);
+    latency_info.ns = static_cast<uint64_t>(latency_port_value * 1000000000.0F);
 
     std::array<char, 1024U> buffer{};
 
@@ -199,16 +199,16 @@ void Compressor::process(std::span<float>& left_in,
     notification_dt += sample_duration;
 
     if (notification_dt >= notification_time_window) {
-      const float& reduction_value = lv2_wrapper->get_control_port_value("rlm");
-      const float& sidechain_value = lv2_wrapper->get_control_port_value("slm");
-      const float& curve_value = lv2_wrapper->get_control_port_value("clm");
-      const float& envelope_value = lv2_wrapper->get_control_port_value("elm");
+      reduction_port_value = lv2_wrapper->get_control_port_value("rlm");
+      sidechain_port_value = lv2_wrapper->get_control_port_value("slm");
+      curve_port_value = lv2_wrapper->get_control_port_value("clm");
+      envelope_port_value = lv2_wrapper->get_control_port_value("elm");
 
       Glib::signal_idle().connect_once([=, this] {
-        reduction.emit(reduction_value);
-        sidechain.emit(sidechain_value);
-        curve.emit(curve_value);
-        envelope.emit(envelope_value);
+        reduction.emit(reduction_port_value);
+        sidechain.emit(sidechain_port_value);
+        curve.emit(curve_port_value);
+        envelope.emit(envelope_port_value);
       });
 
       notify();

--- a/src/deesser.cpp
+++ b/src/deesser.cpp
@@ -103,12 +103,12 @@ void Deesser::process(std::span<float>& left_in,
     if (notification_dt >= notification_time_window) {
       // values needed as double for levelbars widget ui, so we convert them here
 
-      const double& detected_value = static_cast<double>(lv2_wrapper->get_control_port_value("detected"));
-      const double& compression_value = static_cast<double>(lv2_wrapper->get_control_port_value("compression"));
+      detected_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("detected"));
+      compression_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("compression"));
 
       Glib::signal_idle().connect_once([=, this] {
-        detected.emit(detected_value);
-        compression.emit(compression_value);
+        detected.emit(detected_port_value);
+        compression.emit(compression_port_value);
       });
 
       notify();

--- a/src/delay.cpp
+++ b/src/delay.cpp
@@ -86,15 +86,15 @@ void Delay::process(std::span<float>& left_in,
   if (latency_n_frames != lv) {
     latency_n_frames = lv;
 
-    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    latency_port_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
-    util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
+    util::debug(log_tag + name + " latency: " + std::to_string(latency_port_value) + " s");
 
-    Glib::signal_idle().connect_once([=, this] { latency.emit(latency_value); });
+    Glib::signal_idle().connect_once([=, this] { latency.emit(latency_port_value); });
 
     spa_process_latency_info latency_info{};
 
-    latency_info.ns = static_cast<uint64_t>(latency_value * 1000000000.0F);
+    latency_info.ns = static_cast<uint64_t>(latency_port_value * 1000000000.0F);
 
     std::array<char, 1024U> buffer{};
 

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -20,35 +20,19 @@
 #include "effects_base_ui.hpp"
 
 EffectsBaseUi::EffectsBaseUi(const Glib::RefPtr<Gtk::Builder>& builder,
+                             Glib::RefPtr<Gtk::IconTheme> icon_ptr,
                              EffectsBase* effects_base,
                              const std::string& schema)
     : effects_base(effects_base),
       schema(schema),
       settings(Gio::Settings::create(schema)),
+      icon_theme(icon_ptr),
       pm(effects_base->pm),
       players_model(Gio::ListStore<NodeInfoHolder>::create()),
       all_players_model(Gio::ListStore<NodeInfoHolder>::create()),
       blocklist(Gtk::StringList::create({"initial_value"})),
       plugins(Gtk::StringList::create({"initial_value"})),
       selected_plugins(Gtk::StringList::create({"initial_value"})) {
-  // Icon Theme object initialization
-
-  try {
-    icon_theme = Gtk::IconTheme::get_for_display(Gdk::Display::get_default());
-
-    const auto& icon_theme_name = icon_theme->get_theme_name();
-
-    if (icon_theme_name.empty()) {
-      util::debug(log_tag + "Icon Theme detected, but the name is empty");
-    } else {
-      util::debug(log_tag + "Icon Theme " + icon_theme_name.raw() + " detected");
-    }
-  } catch (...) {
-    icon_theme = nullptr;
-
-    util::warning(log_tag + "Can't retrieve the icon theme in use on the system. App icons won't be shown.");
-  }
-
   // loading builder widgets
 
   global_output_level_left = builder->get_widget<Gtk::Label>("global_output_level_left");

--- a/src/equalizer.cpp
+++ b/src/equalizer.cpp
@@ -134,15 +134,15 @@ void Equalizer::process(std::span<float>& left_in,
   if (latency_n_frames != lv) {
     latency_n_frames = lv;
 
-    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    latency_port_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
-    util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
+    util::debug(log_tag + name + " latency: " + std::to_string(latency_port_value) + " s");
 
-    Glib::signal_idle().connect_once([=, this] { latency.emit(latency_value); });
+    Glib::signal_idle().connect_once([=, this] { latency.emit(latency_port_value); });
 
     spa_process_latency_info latency_info{};
 
-    latency_info.ns = static_cast<uint64_t>(latency_value * 1000000000.0F);
+    latency_info.ns = static_cast<uint64_t>(latency_port_value * 1000000000.0F);
 
     std::array<char, 1024U> buffer{};
 

--- a/src/exciter.cpp
+++ b/src/exciter.cpp
@@ -93,9 +93,9 @@ void Exciter::process(std::span<float>& left_in,
     if (notification_dt >= notification_time_window) {
       /// harmonics needed as double for levelbar widget ui, so we convert it here
 
-      const double& harmonics_value = static_cast<double>(lv2_wrapper->get_control_port_value("meter_drive"));
+      harmonics_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("meter_drive"));
 
-      Glib::signal_idle().connect_once([=, this] { harmonics.emit(harmonics_value); });
+      Glib::signal_idle().connect_once([=, this] { harmonics.emit(harmonics_port_value); });
 
       notify();
 

--- a/src/fir_filter_base.cpp
+++ b/src/fir_filter_base.cpp
@@ -114,9 +114,9 @@ auto FirFilterBase::create_lowpass_kernel(const float& cutoff, const float& tran
       Blackman window https://www.dspguide.com/ch16/1.htm
     */
 
-    const float w =
-        0.42F - 0.5F * std::cos(2.0F * std::numbers::pi_v<float> * static_cast<float>(n) / static_cast<float>(M)) +
-        0.08F * std::cos(4.0F * std::numbers::pi_v<float> * static_cast<float>(n) / static_cast<float>(M));
+    const float w = 0.42F -
+                    0.5F * std::cos(2.0F * std::numbers::pi_v<float> * static_cast<float>(n) / static_cast<float>(M)) +
+                    0.08F * std::cos(4.0F * std::numbers::pi_v<float> * static_cast<float>(n) / static_cast<float>(M));
 
     output[n] *= w;
 

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -94,9 +94,9 @@ void Gate::process(std::span<float>& left_in,
     if (notification_dt >= notification_time_window) {
       // gating needed as double for levelbar widget ui, so we convert it here
 
-      const double& gating_value = static_cast<double>(lv2_wrapper->get_control_port_value("gating"));
+      gating_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("gating"));
 
-      Glib::signal_idle().connect_once([=, this] { gating.emit(gating_value); });
+      Glib::signal_idle().connect_once([=, this] { gating.emit(gating_port_value); });
 
       notify();
 

--- a/src/limiter.cpp
+++ b/src/limiter.cpp
@@ -108,15 +108,15 @@ void Limiter::process(std::span<float>& left_in,
   if (latency_n_frames != lv) {
     latency_n_frames = lv;
 
-    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    latency_port_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
-    util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
+    util::debug(log_tag + name + " latency: " + std::to_string(latency_port_value) + " s");
 
-    Glib::signal_idle().connect_once([=, this] { latency.emit(latency_value); });
+    Glib::signal_idle().connect_once([=, this] { latency.emit(latency_port_value); });
 
     spa_process_latency_info latency_info{};
 
-    latency_info.ns = static_cast<uint64_t>(latency_value * 1000000000.0F);
+    latency_info.ns = static_cast<uint64_t>(latency_port_value * 1000000000.0F);
 
     std::array<char, 1024U> buffer{};
 
@@ -135,15 +135,15 @@ void Limiter::process(std::span<float>& left_in,
     notification_dt += sample_duration;
 
     if (notification_dt >= notification_time_window) {
-      const float& gain_l = lv2_wrapper->get_control_port_value("grlm_l");
-      const float& gain_r = lv2_wrapper->get_control_port_value("grlm_r");
-      const float& sidechain_l = lv2_wrapper->get_control_port_value("sclm_l");
-      const float& sidechain_r = lv2_wrapper->get_control_port_value("sclm_r");
+      gain_l_port_value = lv2_wrapper->get_control_port_value("grlm_l");
+      gain_r_port_value = lv2_wrapper->get_control_port_value("grlm_r");
+      sidechain_l_port_value = lv2_wrapper->get_control_port_value("sclm_l");
+      sidechain_r_port_value = lv2_wrapper->get_control_port_value("sclm_r");
 
-      Glib::signal_idle().connect_once([=, this] { gain_left.emit(gain_l); });
-      Glib::signal_idle().connect_once([=, this] { gain_right.emit(gain_r); });
-      Glib::signal_idle().connect_once([=, this] { sidechain_left.emit(sidechain_l); });
-      Glib::signal_idle().connect_once([=, this] { sidechain_right.emit(sidechain_r); });
+      Glib::signal_idle().connect_once([=, this] { gain_left.emit(gain_l_port_value); });
+      Glib::signal_idle().connect_once([=, this] { gain_right.emit(gain_r_port_value); });
+      Glib::signal_idle().connect_once([=, this] { sidechain_left.emit(sidechain_l_port_value); });
+      Glib::signal_idle().connect_once([=, this] { sidechain_right.emit(sidechain_r_port_value); });
 
       notify();
 

--- a/src/loudness.cpp
+++ b/src/loudness.cpp
@@ -85,15 +85,15 @@ void Loudness::process(std::span<float>& left_in,
   if (latency_n_frames != lv) {
     latency_n_frames = lv;
 
-    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    const float latency_port_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
-    util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
+    util::debug(log_tag + name + " latency: " + std::to_string(latency_port_value) + " s");
 
-    Glib::signal_idle().connect_once([=, this] { latency.emit(latency_value); });
+    Glib::signal_idle().connect_once([=, this] { latency.emit(latency_port_value); });
 
     spa_process_latency_info latency_info{};
 
-    latency_info.ns = static_cast<uint64_t>(latency_value * 1000000000.0F);
+    latency_info.ns = static_cast<uint64_t>(latency_port_value * 1000000000.0F);
 
     std::array<char, 1024U> buffer{};
 

--- a/src/maximizer.cpp
+++ b/src/maximizer.cpp
@@ -87,15 +87,15 @@ void Maximizer::process(std::span<float>& left_in,
   if (latency_n_frames != lv) {
     latency_n_frames = lv;
 
-    const float latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+    latency_port_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
 
-    util::debug(log_tag + name + " latency: " + std::to_string(latency_value) + " s");
+    util::debug(log_tag + name + " latency: " + std::to_string(latency_port_value) + " s");
 
-    Glib::signal_idle().connect_once([=, this] { latency.emit(latency_value); });
+    Glib::signal_idle().connect_once([=, this] { latency.emit(latency_port_value); });
 
     spa_process_latency_info latency_info{};
 
-    latency_info.ns = static_cast<uint64_t>(latency_value * 1000000000.0F);
+    latency_info.ns = static_cast<uint64_t>(latency_port_value * 1000000000.0F);
 
     std::array<char, 1024U> buffer{};
 
@@ -116,9 +116,9 @@ void Maximizer::process(std::span<float>& left_in,
     if (notification_dt >= notification_time_window) {
       // reduction needed as double for levelbar widget ui, so we convert it here
 
-      const double& reduction_value = static_cast<double>(lv2_wrapper->get_control_port_value("gr"));
+      reduction_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("gr"));
 
-      Glib::signal_idle().connect_once([=, this] { reduction.emit(reduction_value); });
+      Glib::signal_idle().connect_once([=, this] { reduction.emit(reduction_port_value); });
 
       notify();
 

--- a/src/multiband_gate.cpp
+++ b/src/multiband_gate.cpp
@@ -175,26 +175,26 @@ void MultibandGate::process(std::span<float>& left_in,
     if (notification_dt >= notification_time_window) {
       // values needed as double for levelbars widget ui, so we convert them here
 
-      const double& output0_value = static_cast<double>(lv2_wrapper->get_control_port_value("output0"));
-      const double& output1_value = static_cast<double>(lv2_wrapper->get_control_port_value("output1"));
-      const double& output2_value = static_cast<double>(lv2_wrapper->get_control_port_value("output2"));
-      const double& output3_value = static_cast<double>(lv2_wrapper->get_control_port_value("output3"));
+      output0_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("output0"));
+      output1_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("output1"));
+      output2_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("output2"));
+      output3_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("output3"));
 
-      const double& gating0_value = static_cast<double>(lv2_wrapper->get_control_port_value("gating0"));
-      const double& gating1_value = static_cast<double>(lv2_wrapper->get_control_port_value("gating1"));
-      const double& gating2_value = static_cast<double>(lv2_wrapper->get_control_port_value("gating2"));
-      const double& gating3_value = static_cast<double>(lv2_wrapper->get_control_port_value("gating3"));
+      gating0_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("gating0"));
+      gating1_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("gating1"));
+      gating2_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("gating2"));
+      gating3_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("gating3"));
 
       Glib::signal_idle().connect_once([=, this] {
-        output0.emit(output0_value);
-        output1.emit(output1_value);
-        output2.emit(output2_value);
-        output3.emit(output3_value);
+        output0.emit(output0_port_value);
+        output1.emit(output1_port_value);
+        output2.emit(output2_port_value);
+        output3.emit(output3_port_value);
 
-        gating0.emit(gating0_value);
-        gating1.emit(gating1_value);
-        gating2.emit(gating2_value);
-        gating3.emit(gating3_value);
+        gating0.emit(gating0_port_value);
+        gating1.emit(gating1_port_value);
+        gating2.emit(gating2_port_value);
+        gating3.emit(gating3_port_value);
       });
 
       notify();

--- a/src/pipe_info_ui.cpp
+++ b/src/pipe_info_ui.cpp
@@ -229,10 +229,10 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
       }
     }
 
-    const auto& id = dropdown_autoloading_output_presets->get_selected();
+    const auto preset_name =
+        dropdown_autoloading_output_presets->get_selected_item()->get_property<Glib::ustring>("string").raw();
 
-    presets_manager->add_autoload(PresetType::output, output_presets_string_list->get_string(id).raw(),
-                                  holder->info.name, device_profile);
+    presets_manager->add_autoload(PresetType::output, preset_name, holder->info.name, device_profile);
   });
 
   autoloading_add_input_profile->signal_clicked().connect([=, this]() {
@@ -264,10 +264,10 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
       }
     }
 
-    const auto& id = dropdown_autoloading_input_presets->get_selected();
+    const auto preset_name =
+        dropdown_autoloading_input_presets->get_selected_item()->get_property<Glib::ustring>("string").raw();
 
-    presets_manager->add_autoload(PresetType::input, input_presets_string_list->get_string(id).raw(), holder->info.name,
-                                  device_profile);
+    presets_manager->add_autoload(PresetType::input, preset_name, holder->info.name, device_profile);
   });
 
   spinbutton_test_signal_frequency->signal_output().connect(

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -211,9 +211,9 @@ void Plot::on_draw(const Cairo::RefPtr<Cairo::Context>& ctx, const int& width, c
     }
 
     if (controller_motion->contains_pointer()) {
-      const auto& msg = "x = " + Glib::ustring::format(std::setprecision(n_x_decimals), std::fixed, mouse_x) +
-                        " " + x_unit + "  y = " +
-                        Glib::ustring::format(std::setprecision(n_y_decimals), std::fixed, mouse_y) + " " + y_unit;
+      const auto& msg =
+          "x = " + Glib::ustring::format(std::setprecision(n_x_decimals), std::fixed, mouse_x) + " " + x_unit +
+          "  y = " + Glib::ustring::format(std::setprecision(n_y_decimals), std::fixed, mouse_y) + " " + y_unit;
 
       Pango::FontDescription font;
       font.set_family("Monospace");

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -371,7 +371,8 @@ void PresetsManager::save_preset_file(const PresetType& preset_type, const Glib:
   util::debug(log_tag + "saved preset: " + output_file.string());
 }
 
-void PresetsManager::write_plugins_preset(const PresetType& preset_type, const std::vector<Glib::ustring>& plugins,
+void PresetsManager::write_plugins_preset(const PresetType& preset_type,
+                                          const std::vector<Glib::ustring>& plugins,
                                           nlohmann::json& json) {
   for (const auto& name : plugins) {
     if (name == plugin_name::autogain) {
@@ -547,8 +548,9 @@ void PresetsManager::load_preset_file(const PresetType& preset_type, const Glib:
   util::debug(log_tag + "loaded preset: " + input_file.string());
 }
 
-void PresetsManager::read_plugins_preset(const PresetType& preset_type, const std::vector<Glib::ustring>& plugins,
-                         const nlohmann::json& json) {
+void PresetsManager::read_plugins_preset(const PresetType& preset_type,
+                                         const std::vector<Glib::ustring>& plugins,
+                                         const nlohmann::json& json) {
   for (const auto& name : plugins) {
     if (name == plugin_name::autogain) {
       autogain->read(preset_type, json);

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -73,9 +73,8 @@ void Spectrum::process(std::span<float>& left_in,
     if (const uint& k = total_count + n; k < real_input.size()) {
       // https://en.wikipedia.org/wiki/Hann_function
 
-      const float w =
-          0.5F * (1.0F - std::cos(2.0F * std::numbers::pi_v<float> * static_cast<float>(k) /
-          static_cast<float>(real_input.size() - 1U)));
+      const float w = 0.5F * (1.0F - std::cos(2.0F * std::numbers::pi_v<float> * static_cast<float>(k) /
+                                              static_cast<float>(real_input.size() - 1U)));
 
       real_input[k] = 0.5F * (left_in[n] + right_in[n]) * w;
     } else {

--- a/src/spectrum_ui.cpp
+++ b/src/spectrum_ui.cpp
@@ -30,10 +30,11 @@ SpectrumUi::SpectrumUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>
   connections.emplace_back(
       settings->signal_changed("color-axis-labels").connect([&](const auto& key) { init_frequency_labels_color(); }));
 
-  connections.emplace_back(
-      settings->signal_changed("height").connect([&](const auto& key) { set_content_height(settings->get_int("height")); }));
+  connections.emplace_back(settings->signal_changed("height").connect(
+      [&](const auto& key) { set_content_height(settings->get_int("height")); }));
 
-  connections.emplace_back(settings->signal_changed("n-points").connect([&](const auto& key) { init_frequency_axis(); }));
+  connections.emplace_back(
+      settings->signal_changed("n-points").connect([&](const auto& key) { init_frequency_axis(); }));
 
   connections.emplace_back(
       settings->signal_changed("minimum-frequency").connect([&](const auto& key) { init_frequency_axis(); }));
@@ -43,8 +44,8 @@ SpectrumUi::SpectrumUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>
 
   connections.emplace_back(settings->signal_changed("type").connect([&](const auto& key) { init_type(); }));
 
-  connections.emplace_back(
-      settings->signal_changed("fill").connect([&](const auto& key) { plot->set_fill_bars(settings->get_boolean(key)); }));
+  connections.emplace_back(settings->signal_changed("fill").connect(
+      [&](const auto& key) { plot->set_fill_bars(settings->get_boolean(key)); }));
 
   connections.emplace_back(settings->signal_changed("show-bar-border").connect([&](const auto& key) {
     plot->set_draw_bar_border(settings->get_boolean(key));

--- a/src/stereo_tools.cpp
+++ b/src/stereo_tools.cpp
@@ -111,9 +111,9 @@ void StereoTools::process(std::span<float>& left_in,
     if (notification_dt >= notification_time_window) {
       // correlation needed as double for levelbar widget ui, so we convert it here
 
-      const double& correlation = static_cast<double>(lv2_wrapper->get_control_port_value("meter_phase"));
+      correlation_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("meter_phase"));
 
-      Glib::signal_idle().connect_once([=, this] { new_correlation.emit(correlation); });
+      Glib::signal_idle().connect_once([=, this] { new_correlation.emit(correlation_port_value); });
 
       notify();
 

--- a/src/stream_input_effects_ui.cpp
+++ b/src/stream_input_effects_ui.cpp
@@ -21,9 +21,10 @@
 
 StreamInputEffectsUi::StreamInputEffectsUi(BaseObjectType* cobject,
                                            const Glib::RefPtr<Gtk::Builder>& refBuilder,
+                                           Glib::RefPtr<Gtk::IconTheme> icon_ptr,
                                            StreamInputEffects* sie_ptr,
                                            const std::string& schema)
-    : Gtk::Box(cobject), EffectsBaseUi(refBuilder, sie_ptr, schema), sie(sie_ptr) {
+    : Gtk::Box(cobject), EffectsBaseUi(refBuilder, icon_ptr, sie_ptr, schema), sie(sie_ptr) {
   auto* toggle_players_icon = dynamic_cast<Gtk::Image*>(toggle_players->get_child()->get_first_child());
   auto* toggle_players_label = dynamic_cast<Gtk::Label*>(toggle_players_icon->get_next_sibling());
 
@@ -77,11 +78,13 @@ StreamInputEffectsUi::~StreamInputEffectsUi() {
   util::debug(log_tag + "destroyed");
 }
 
-auto StreamInputEffectsUi::add_to_stack(Gtk::Stack* stack, StreamInputEffects* sie_ptr) -> StreamInputEffectsUi* {
+auto StreamInputEffectsUi::add_to_stack(Gtk::Stack* stack,
+                                        StreamInputEffects* sie_ptr,
+                                        Glib::RefPtr<Gtk::IconTheme> icon_ptr) -> StreamInputEffectsUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/effects_base.ui");
 
-  auto* const ui = Gtk::Builder::get_widget_derived<StreamInputEffectsUi>(builder, "top_box", sie_ptr,
-                                                                    "com.github.wwmm.easyeffects.streaminputs");
+  auto* const ui = Gtk::Builder::get_widget_derived<StreamInputEffectsUi>(builder, "top_box", icon_ptr, sie_ptr,
+                                                                          "com.github.wwmm.easyeffects.streaminputs");
 
   auto stack_page = stack->add(*ui, "stream_input");
 

--- a/src/stream_output_effects_ui.cpp
+++ b/src/stream_output_effects_ui.cpp
@@ -21,9 +21,10 @@
 
 StreamOutputEffectsUi::StreamOutputEffectsUi(BaseObjectType* cobject,
                                              const Glib::RefPtr<Gtk::Builder>& refBuilder,
+                                             Glib::RefPtr<Gtk::IconTheme> icon_ptr,
                                              StreamOutputEffects* soe_ptr,
                                              const std::string& schema)
-    : Gtk::Box(cobject), EffectsBaseUi(refBuilder, soe_ptr, schema), soe(soe_ptr) {
+    : Gtk::Box(cobject), EffectsBaseUi(refBuilder, icon_ptr, soe_ptr, schema), soe(soe_ptr) {
   for (const auto& [id, node] : pm->node_map) {
     if (node.media_class == "Stream/Output/Audio") {
       on_app_added(node.id, node.name, node.media_class);
@@ -51,8 +52,8 @@ StreamOutputEffectsUi::StreamOutputEffectsUi(BaseObjectType* cobject,
     }
   }));
 
-  const auto& v = Glib::ustring::format(std::setprecision(1), std::fixed,
-                                        static_cast<float>(soe->pm->pe_sink_node.rate) * 0.001F);
+  const auto& v =
+      Glib::ustring::format(std::setprecision(1), std::fixed, static_cast<float>(soe->pm->pe_sink_node.rate) * 0.001F);
 
   device_state->set_text(v + " kHz" + Glib::ustring(5, ' '));
 }
@@ -61,11 +62,13 @@ StreamOutputEffectsUi::~StreamOutputEffectsUi() {
   util::debug(log_tag + "destroyed");
 }
 
-auto StreamOutputEffectsUi::add_to_stack(Gtk::Stack* stack, StreamOutputEffects* soe_ptr) -> StreamOutputEffectsUi* {
+auto StreamOutputEffectsUi::add_to_stack(Gtk::Stack* stack,
+                                         StreamOutputEffects* soe_ptr,
+                                         Glib::RefPtr<Gtk::IconTheme> icon_ptr) -> StreamOutputEffectsUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/effects_base.ui");
 
-  auto* const ui = Gtk::Builder::get_widget_derived<StreamOutputEffectsUi>(builder, "top_box", soe_ptr,
-                                                                     "com.github.wwmm.easyeffects.streamoutputs");
+  auto* const ui = Gtk::Builder::get_widget_derived<StreamOutputEffectsUi>(builder, "top_box", icon_ptr, soe_ptr,
+                                                                           "com.github.wwmm.easyeffects.streamoutputs");
 
   auto stack_page = stack->add(*ui, "stream_output");
 


### PR DESCRIPTION
This should resolve [this](https://github.com/wwmm/easyeffects/pull/1127#issuecomment-911951540).

We make a single copy and, since a static member is used, the lambda will not capture it avoiding another copy. @wwmm correct my if I'm wrong.

They're storage duration is tied to the application, so it should be extremely safe.