### PR TITLE
Fix app icons lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 - When editing presets files in an external editor, duplicated entries won't be shown in our presets menu.
 - Now the blocklist is correctly set when switching presets.
 - Now the status of the global bypass button is correctly updated when changing plugin stack.
-- Missing icons on the system should not be shown inside the application info UI.
+- Missing icons on the system should not be shown inside the application info UI (if an application icon could not be
+  shown even if you're sure it's correctly installed, please open an issue).
 - Some icons not showing in Plasma DE with Breeze icon theme should appear now.
 
 ## [6.1.0]

--- a/include/application_ui.hpp
+++ b/include/application_ui.hpp
@@ -42,6 +42,10 @@ class ApplicationUi : public Gtk::ApplicationWindow {
 
   static auto create(Application* app) -> ApplicationUi*;
 
+  static auto setup_icon_theme() -> Glib::RefPtr<Gtk::IconTheme>;
+
+  inline static Glib::RefPtr<Gtk::IconTheme> icon_theme = nullptr;
+
  private:
   const std::string log_tag = "application_ui: ";
 
@@ -64,8 +68,6 @@ class ApplicationUi : public Gtk::ApplicationWindow {
   int soe_latency = 0, sie_latency = 0;
 
   static void apply_css_style(const std::string& css_file_name);
-
-  auto setup_icon_theme() -> Glib::RefPtr<Gtk::IconTheme>;
 };
 
 #endif

--- a/include/effects_base_ui.hpp
+++ b/include/effects_base_ui.hpp
@@ -106,6 +106,8 @@ class EffectsBaseUi {
   void on_app_changed(const uint id);
   void on_app_removed(const uint id);
 
+  auto icon_available(const Glib::ustring& icon_name) -> bool;
+
   void on_new_output_level_db(const float& left, const float& right);
 
   static auto node_state_to_ustring(const pw_node_state& state) -> Glib::ustring;

--- a/src/application_ui.cpp
+++ b/src/application_ui.cpp
@@ -39,7 +39,10 @@ ApplicationUi::ApplicationUi(BaseObjectType* cobject,
   GeneralSettingsUi::add_to_stack(stack_menu_settings, app);
   SpectrumSettingsUi::add_to_stack(stack_menu_settings, app);
 
-  auto icon_theme = setup_icon_theme();
+  if (icon_theme == nullptr) {
+    icon_theme = setup_icon_theme();
+  }
+
   soe_ui = StreamOutputEffectsUi::add_to_stack(stack, app->soe.get(), icon_theme);
   sie_ui = StreamInputEffectsUi::add_to_stack(stack, app->sie.get(), icon_theme);
   pipe_info_ui = PipeInfoUi::add_to_stack(stack, app->pm.get(), app->presets_manager.get());
@@ -111,21 +114,19 @@ void ApplicationUi::apply_css_style(const std::string& css_file_name) {
 
 auto ApplicationUi::setup_icon_theme() -> Glib::RefPtr<Gtk::IconTheme> {
   try {
-    Glib::RefPtr<Gtk::IconTheme> icon_theme = Gtk::IconTheme::get_for_display(Gdk::Display::get_default());
+    Glib::RefPtr<Gtk::IconTheme> ic_theme = Gtk::IconTheme::get_for_display(Gdk::Display::get_default());
 
-    const auto& icon_theme_name = icon_theme->get_theme_name();
+    const auto& icon_theme_name = ic_theme->get_theme_name();
 
     if (icon_theme_name.empty()) {
-      util::debug(log_tag + "Icon Theme detected, but the name is empty");
+      util::debug("application_ui: Icon Theme detected, but the name is empty");
     } else {
-      util::debug(log_tag + "Icon Theme " + icon_theme_name.raw() + " detected");
+      util::debug("application_ui: Icon Theme " + icon_theme_name.raw() + " detected");
     }
 
-    icon_theme->add_resource_path("/com/github/wwmm/easyeffects/icons");
-
-    return icon_theme;
+    return ic_theme;
   } catch (...) {
-    util::warning(log_tag + "Can't retrieve the icon theme in use on the system. App icons won't be shown.");
+    util::warning("application_ui: Can't retrieve the icon theme in use on the system. App icons won't be shown.");
 
     return nullptr;
   }


### PR DESCRIPTION
Fixes #1143

More robust way to lookup icons. Pixmaps directories are checked if the icon is not present in the icon theme - tested with Adwaita and Brave (the original one, not brave-bin) which install the icon in pixmaps.

Cases where Pipewire sets an incorrect icon name are now handled with a map.