### PR TITLE
Loopback test for output stream down/upmixing

### DIFF
--- a/data/schemas/com.github.wwmm.easyeffects.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.gschema.xml
@@ -7,6 +7,9 @@
         <key name="process-all-inputs" type="b">
             <default>false</default>
         </key>
+        <key name="loopback-mode" type="b">
+            <default>false</default>
+        </key>
         <key name="use-dark-theme" type="b">
             <default>false</default>
         </key>

--- a/include/application.hpp
+++ b/include/application.hpp
@@ -39,6 +39,8 @@ class Application : public Gtk::Application {
   auto operator=(const Application&&) -> Application& = delete;
   ~Application() override;
 
+  inline static bool loopback_mode = false;
+
   static auto create() -> Glib::RefPtr<Application>;
   Glib::RefPtr<Gio::Settings> settings;
   Glib::RefPtr<Gio::Settings> soe_settings;

--- a/include/effects_base_ui.hpp
+++ b/include/effects_base_ui.hpp
@@ -102,7 +102,7 @@ class EffectsBaseUi {
 
   std::vector<sigc::connection> connections;
 
-  void on_app_added(const uint id, const std::string name, const std::string media_class);
+  void on_app_added(const uint id, const std::string name);
   void on_app_changed(const uint id);
   void on_app_removed(const uint id);
 

--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -195,12 +195,12 @@ class PipeManager {
 
   std::vector<DeviceInfo> list_devices;
 
-  NodeInfo ee_sink_node, ee_source_node, ee_loopback_sink, ee_loopback_output;
+  NodeInfo ee_sink_node, ee_source_node, ee_loopback_sink, ee_loopback_playback;
 
   const std::string ee_source_name = "easyeffects_source";
   const std::string ee_sink_name = "easyeffects_sink";
 
-  const std::string loopback_output_name = "easyeffects_loopback_playback";
+  const std::string loopback_playback_name = "easyeffects_loopback_playback";
   const std::string loopback_sink_name = "easyeffects_loopback_sink";
 
   NodeInfo default_output_device, default_input_device;
@@ -236,6 +236,8 @@ class PipeManager {
   void disconnect_stream_output(const uint& id) const;
 
   void disconnect_stream_input(const uint& id) const;
+
+  void set_loopback_target_node(const uint& id);
 
   static void set_node_volume(pw_proxy* proxy, const int& n_vol_ch, const float& value);
 
@@ -301,6 +303,9 @@ class PipeManager {
   spa_hook core_listener{}, registry_listener{};
 
   void set_metadata_target_node(const uint& origin_id, const uint& target_id) const;
+
+  auto get_loopback_capture_property() -> std::string;
+  auto get_loopback_playback_property(const char* target_id = nullptr) -> std::string;
 };
 
 #endif

--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -200,7 +200,7 @@ class PipeManager {
   const std::string ee_source_name = "easyeffects_source";
   const std::string ee_sink_name = "easyeffects_sink";
 
-  const std::string loopback_output_name = "easyeffects_loopback_output";
+  const std::string loopback_output_name = "easyeffects_loopback_playback";
   const std::string loopback_sink_name = "easyeffects_loopback_sink";
 
   NodeInfo default_output_device, default_input_device;

--- a/include/stream_input_effects.hpp
+++ b/include/stream_input_effects.hpp
@@ -42,7 +42,7 @@ class StreamInputEffects : public EffectsBase {
 
   void disconnect_filters();
 
-  void on_app_added(const uint id, const std::string name, const std::string media_class);
+  void on_app_added(const uint id, const std::string name);
 
   void on_link_changed(LinkInfo link_info);
 };

--- a/include/stream_output_effects.hpp
+++ b/include/stream_output_effects.hpp
@@ -40,9 +40,11 @@ class StreamOutputEffects : public EffectsBase {
 
   void disconnect_filters();
 
-  void on_app_added(const uint id, const std::string name, const std::string media_class);
+  void on_app_added(const uint id, const std::string name);
 
   void on_link_changed(LinkInfo link_info);
+
+  void on_loopback_mode_disabled();
 };
 
 #endif

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -114,7 +114,9 @@ void Application::on_startup() {
 
   create_actions();
 
-  pm = std::make_unique<PipeManager>();
+  loopback_mode = settings->get_boolean("loopback-mode");
+
+  pm = std::make_unique<PipeManager>(loopback_mode);
   soe = std::make_unique<StreamOutputEffects>(pm.get());
   sie = std::make_unique<StreamInputEffects>(pm.get());
 
@@ -127,7 +129,7 @@ void Application::on_startup() {
 
     if (soe_settings->get_boolean("use-default-output-device")) {
       /*
-        Depending on the hardware headphones can cause a node recreation hwere the id and the name are kept.
+        Depending on the hardware headphones can cause a node recreation here the id and the name are kept.
         So we clear the key to force the callbacks to be called
       */
 

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -33,7 +33,7 @@ Compressor::Compressor(const std::string& tag,
     if (settings->get_string(key) == "External") {
       const auto* device_name = settings->get_string("sidechain-input-device").c_str();
 
-      NodeInfo input_device = pm->pe_source_node;
+      NodeInfo input_device = pm->ee_source_node;
 
       for (const auto& [id, node] : pm->node_map) {
         if (node.name == device_name) {
@@ -57,7 +57,7 @@ Compressor::Compressor(const std::string& tag,
     if (settings->get_string("sidechain-type") == "External") {
       const auto* device_name = settings->get_string(key).c_str();
 
-      NodeInfo input_device = pm->pe_source_node;
+      NodeInfo input_device = pm->ee_source_node;
 
       for (const auto& [id, node] : pm->node_map) {
         if (node.name == device_name) {

--- a/src/compressor_ui.cpp
+++ b/src/compressor_ui.cpp
@@ -471,7 +471,7 @@ void CompressorUi::setup_dropdown_input_devices() {
 void CompressorUi::set_pipe_manager_ptr(PipeManager* pipe_manager) {
   pm = pipe_manager;
 
-  input_devices_model->append(NodeInfoHolder::create(pm->pe_source_node));
+  input_devices_model->append(NodeInfoHolder::create(pm->ee_source_node));
 
   for (const auto& [id, node] : pm->node_map) {
     if (node.media_class == "Audio/Source") {

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -842,17 +842,17 @@ void EffectsBaseUi::setup_listview_players() {
 
 void EffectsBaseUi::connect_stream(const uint& id, const std::string& media_class) {
   if (media_class == "Stream/Output/Audio") {
-    pm->connect_stream_output(id, media_class);
+    pm->connect_stream_output(id);
   } else if (media_class == "Stream/Input/Audio") {
-    pm->connect_stream_input(id, media_class);
+    pm->connect_stream_input(id);
   }
 }
 
 void EffectsBaseUi::disconnect_stream(const uint& id, const std::string& media_class) {
   if (media_class == "Stream/Output/Audio") {
-    pm->disconnect_stream_output(id, media_class);
+    pm->disconnect_stream_output(id);
   } else if (media_class == "Stream/Input/Audio") {
-    pm->disconnect_stream_input(id, media_class);
+    pm->disconnect_stream_input(id);
   }
 }
 
@@ -1334,7 +1334,7 @@ void EffectsBaseUi::setup_listview_selected_plugins() {
   });
 }
 
-void EffectsBaseUi::on_app_added(const uint id, const std::string name, const std::string media_class) {
+void EffectsBaseUi::on_app_added(const uint id, const std::string name) {
   // do not add the same stream twice
 
   for (guint n = 0U; n < all_players_model->get_n_items(); n++) {

--- a/src/pipe_info_ui.cpp
+++ b/src/pipe_info_ui.cpp
@@ -37,8 +37,10 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
       autoloading_input_model(Gio::ListStore<PresetsAutoloadingHolder>::create()),
       output_presets_string_list(Gtk::StringList::create({"initial_value"})),
       input_presets_string_list(Gtk::StringList::create({"initial_value"})) {
+  static const auto ee_nodes = {pm->ee_sink_name, pm->ee_source_name, pm->loopback_sink_name, pm->loopback_output_name};
+
   for (const auto& [id, node] : pm->node_map) {
-    if (node.name == "easyeffects_sink" || node.name == "easyeffects_source") {
+    if (std::any_of(ee_nodes.begin(), ee_nodes.end(), [&](const auto& str) { return str == node.name; })) {
       continue;
     }
 

--- a/src/pipe_info_ui.cpp
+++ b/src/pipe_info_ui.cpp
@@ -37,7 +37,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
       autoloading_input_model(Gio::ListStore<PresetsAutoloadingHolder>::create()),
       output_presets_string_list(Gtk::StringList::create({"initial_value"})),
       input_presets_string_list(Gtk::StringList::create({"initial_value"})) {
-  static const auto ee_nodes = {pm->ee_sink_name, pm->ee_source_name, pm->loopback_sink_name, pm->loopback_output_name};
+  static const auto ee_nodes = {pm->ee_sink_name, pm->ee_source_name, pm->loopback_sink_name, pm->loopback_playback_name};
 
   for (const auto& [id, node] : pm->node_map) {
     if (std::any_of(ee_nodes.begin(), ee_nodes.end(), [&](const auto& str) { return str == node.name; })) {

--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -1199,23 +1199,34 @@ PipeManager::PipeManager(const bool& lb_mode) : loopback_mode(lb_mode) {
 
   if (loopback_mode) {
     auto props_lb_capture = std::string();
+    auto props_lb_playback = std::string();
     auto props_loopback = std::string();
 
     props_lb_capture += "{ ";
+    props_lb_capture += "audio.position = \"FL,FR\" ";
     props_lb_capture += std::string(PW_KEY_NODE_NAME) + " = " + loopback_sink_name + " ";
     props_lb_capture += std::string(PW_KEY_MEDIA_NAME) + " = \"EasyEffects Loopback Sink\" ";
     props_lb_capture += std::string(PW_KEY_NODE_DESCRIPTION) + " = \"EasyEffects Loopback Sink\" ";
     props_lb_capture += std::string(PW_KEY_MEDIA_CLASS) + " = Audio/Sink ";
     props_lb_capture += std::string(PW_KEY_NODE_AUTOCONNECT) + " = false ";
+    props_lb_capture += std::string(PW_KEY_NODE_PASSIVE) + " = true ";
+    props_lb_capture += std::string(PW_KEY_STREAM_DONT_REMIX) + " = false ";
     props_lb_capture += "}";
 
+    props_lb_playback += "{ ";
+    props_lb_playback += "audio.position = \"FL,FR\" ";
+    props_lb_playback += std::string(PW_KEY_NODE_NAME) + " = " + loopback_output_name + " ";
+    props_lb_playback += std::string(PW_KEY_MEDIA_NAME) + " = \"EasyEffects Channel Remapping Loopback\" ";
+    props_lb_playback += std::string(PW_KEY_NODE_DESCRIPTION) + " = \"EasyEffects Channel Remapping Loopback\" ";
+    props_lb_playback += std::string(PW_KEY_NODE_PASSIVE) + " = true ";
+    props_lb_playback += "}";
+
     props_loopback += "{ ";
-    props_loopback += "audio.position = \"FL,FR\" ";
-    props_loopback += std::string(PW_KEY_NODE_NAME) + " = " + loopback_output_name + " ";
+    props_loopback += std::string(PW_KEY_NODE_NAME) + " = easyeffects_loopback ";
     props_loopback += std::string(PW_KEY_MEDIA_NAME) + " = \"EasyEffects Channel Remapping Loopback\" ";
     props_loopback += std::string(PW_KEY_NODE_DESCRIPTION) + " = \"EasyEffects Channel Remapping Loopback\" ";
-    props_loopback += std::string(PW_KEY_MEDIA_CLASS) + " = Stream/Output/Audio ";
     props_loopback += "capture.props = " + props_lb_capture + " ";
+    props_loopback += "playback.props = " + props_lb_playback + " ";
     props_loopback += "}";
 
     // loading EasyEffects Channel Remapping Loopback

--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -1207,8 +1207,6 @@ PipeManager::PipeManager(const bool& lb_mode) : loopback_mode(lb_mode) {
     props_lb_capture += std::string(PW_KEY_NODE_DESCRIPTION) + " = \"EasyEffects Loopback Sink\" ";
     props_lb_capture += std::string(PW_KEY_MEDIA_CLASS) + " = Audio/Sink ";
     props_lb_capture += std::string(PW_KEY_NODE_AUTOCONNECT) + " = false ";
-    props_lb_capture += std::string(PW_KEY_NODE_PASSIVE) + " = true ";
-    props_lb_capture += std::string(PW_KEY_STREAM_DONT_REMIX) + " = true ";
     props_lb_capture += "}";
 
     props_loopback += "{ ";

--- a/src/plugin_base.cpp
+++ b/src/plugin_base.cpp
@@ -102,7 +102,7 @@ PluginBase::PluginBase(std::string tag,
   auto* props_in_left = pw_properties_new(nullptr, nullptr);
 
   pw_properties_set(props_in_left, PW_KEY_FORMAT_DSP, "32 bit float mono audio");
-  pw_properties_set(props_in_left, PW_KEY_PORT_NAME, "input_fl");
+  pw_properties_set(props_in_left, PW_KEY_PORT_NAME, "input_FL");
   pw_properties_set(props_in_left, "audio.channel", "FL");
 
   pf_data.in_left = static_cast<port*>(pw_filter_add_port(filter, PW_DIRECTION_INPUT, PW_FILTER_PORT_FLAG_MAP_BUFFERS,
@@ -113,7 +113,7 @@ PluginBase::PluginBase(std::string tag,
   auto* props_in_right = pw_properties_new(nullptr, nullptr);
 
   pw_properties_set(props_in_right, PW_KEY_FORMAT_DSP, "32 bit float mono audio");
-  pw_properties_set(props_in_right, PW_KEY_PORT_NAME, "input_fr");
+  pw_properties_set(props_in_right, PW_KEY_PORT_NAME, "input_FR");
   pw_properties_set(props_in_right, "audio.channel", "FR");
 
   pf_data.in_right = static_cast<port*>(pw_filter_add_port(filter, PW_DIRECTION_INPUT, PW_FILTER_PORT_FLAG_MAP_BUFFERS,
@@ -124,7 +124,7 @@ PluginBase::PluginBase(std::string tag,
   auto* props_out_left = pw_properties_new(nullptr, nullptr);
 
   pw_properties_set(props_out_left, PW_KEY_FORMAT_DSP, "32 bit float mono audio");
-  pw_properties_set(props_out_left, PW_KEY_PORT_NAME, "output_fl");
+  pw_properties_set(props_out_left, PW_KEY_PORT_NAME, "output_FL");
   pw_properties_set(props_out_left, "audio.channel", "FL");
 
   pf_data.out_left = static_cast<port*>(pw_filter_add_port(filter, PW_DIRECTION_OUTPUT, PW_FILTER_PORT_FLAG_MAP_BUFFERS,
@@ -135,7 +135,7 @@ PluginBase::PluginBase(std::string tag,
   auto* props_out_right = pw_properties_new(nullptr, nullptr);
 
   pw_properties_set(props_out_right, PW_KEY_FORMAT_DSP, "32 bit float mono audio");
-  pw_properties_set(props_out_right, PW_KEY_PORT_NAME, "output_fr");
+  pw_properties_set(props_out_right, PW_KEY_PORT_NAME, "output_FR");
   pw_properties_set(props_out_right, "audio.channel", "FR");
 
   pf_data.out_right = static_cast<port*>(pw_filter_add_port(
@@ -147,7 +147,7 @@ PluginBase::PluginBase(std::string tag,
     auto* props_left = pw_properties_new(nullptr, nullptr);
 
     pw_properties_set(props_left, PW_KEY_FORMAT_DSP, "32 bit float mono audio");
-    pw_properties_set(props_left, PW_KEY_PORT_NAME, "probe_fl");
+    pw_properties_set(props_left, PW_KEY_PORT_NAME, "probe_FL");
     pw_properties_set(props_left, "audio.channel", "PROBE_FL");
 
     pf_data.probe_left = static_cast<port*>(pw_filter_add_port(
@@ -158,7 +158,7 @@ PluginBase::PluginBase(std::string tag,
     auto* props_right = pw_properties_new(nullptr, nullptr);
 
     pw_properties_set(props_right, PW_KEY_FORMAT_DSP, "32 bit float mono audio");
-    pw_properties_set(props_right, PW_KEY_PORT_NAME, "probe_fr");
+    pw_properties_set(props_right, PW_KEY_PORT_NAME, "probe_FR");
     pw_properties_set(props_right, "audio.channel", "PROBE_FR");
 
     pf_data.probe_right = static_cast<port*>(pw_filter_add_port(

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -103,21 +103,21 @@ StreamInputEffects::~StreamInputEffects() {
   disconnect_filters();
 }
 
-void StreamInputEffects::on_app_added(const uint id, const std::string name, const std::string media_class) {
+void StreamInputEffects::on_app_added(const uint id, const std::string name) {
   const auto& blocklist = settings->get_string_array("blocklist");
 
   const auto& is_blocklisted = std::ranges::find(blocklist, name.c_str()) != blocklist.end();
   ;
 
   if (is_blocklisted) {
-    pm->disconnect_stream_input(id, media_class);
+    pm->disconnect_stream_input(id);
   } else if (global_settings->get_boolean("process-all-inputs")) {
-    pm->connect_stream_input(id, media_class);
+    pm->connect_stream_input(id);
   }
 }
 
 void StreamInputEffects::on_link_changed(LinkInfo link_info) {
-  if (pm->default_input_device.id == pm->pe_source_node.id) {
+  if (pm->default_input_device.id == pm->ee_source_node.id) {
     return;
   }
 
@@ -132,7 +132,7 @@ void StreamInputEffects::on_link_changed(LinkInfo link_info) {
   auto want_to_play = false;
 
   for (const auto& link : pm->list_links) {
-    if (link.output_node_id == pm->pe_source_node.id) {
+    if (link.output_node_id == pm->ee_source_node.id) {
       if (link.state == PW_LINK_STATE_ACTIVE) {
         want_to_play = true;
 
@@ -210,7 +210,7 @@ void StreamInputEffects::connect_filters(const bool& bypass) {
 
   // link spectrum, output level meter and source node
 
-  for (const auto& node_id : {spectrum->get_node_id(), output_level->get_node_id(), pm->pe_source_node.id}) {
+  for (const auto& node_id : {spectrum->get_node_id(), output_level->get_node_id(), pm->ee_source_node.id}) {
     next_node_id = node_id;
 
     const auto& links = pm->link_nodes(prev_node_id, next_node_id);
@@ -270,7 +270,7 @@ void StreamInputEffects::set_bypass(const bool& state) {
 
 void StreamInputEffects::set_listen_to_mic(const bool& state) {
   if (state) {
-    for (const auto& link : pm->link_nodes(pm->pe_source_node.id, pm->output_device.id, false, false)) {
+    for (const auto& link : pm->link_nodes(pm->ee_source_node.id, pm->output_device.id, false, false)) {
       list_proxies_listen_mic.emplace_back(link);
     }
   } else {

--- a/src/stream_input_effects_ui.cpp
+++ b/src/stream_input_effects_ui.cpp
@@ -41,7 +41,7 @@ StreamInputEffectsUi::StreamInputEffectsUi(BaseObjectType* cobject,
 
   for (const auto& [id, node] : pm->node_map) {
     if (node.media_class == "Stream/Input/Audio") {
-      on_app_added(node.id, node.name, node.media_class);
+      on_app_added(node.id, node.name);
     }
   }
 
@@ -60,16 +60,16 @@ StreamInputEffectsUi::StreamInputEffectsUi(BaseObjectType* cobject,
   connections.emplace_back(sie->pm->source_changed.connect([&](auto nd_info) {
     // nd_info is a reference of a copy previously made
 
-    if (nd_info.id == sie->pm->pe_source_node.id) {
+    if (nd_info.id == sie->pm->ee_source_node.id) {
       const auto& v = Glib::ustring::format(std::setprecision(1), std::fixed,
-                                            static_cast<float>(sie->pm->pe_source_node.rate) * 0.001F);
+                                            static_cast<float>(sie->pm->ee_source_node.rate) * 0.001F);
 
       device_state->set_text(v + " kHz" + Glib::ustring(5, ' '));
     }
   }));
 
   const auto& v = Glib::ustring::format(std::setprecision(1), std::fixed,
-                                        static_cast<float>(sie->pm->pe_source_node.rate) * 0.001F);
+                                        static_cast<float>(sie->pm->ee_source_node.rate) * 0.001F);
 
   device_state->set_text(v + " kHz" + Glib::ustring(5, ' '));
 }

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -30,13 +30,15 @@ StreamOutputEffects::StreamOutputEffects(PipeManager* pipe_manager)
 
     const auto* output_device = settings->get_string("output-device").c_str();
 
-    for (const auto& [id, node] : pm->node_map) {
-      if (node.name == output_device) {
-        pm->output_device = node;
+    if (output_device != pm->ee_sink_name && output_device != pm->loopback_output_name) {
+      for (const auto& [id, node] : pm->node_map) {
+        if (node.name == output_device) {
+          pm->output_device = node;
 
-        found = true;
+          found = true;
 
-        break;
+          break;
+        }
       }
     }
 
@@ -47,7 +49,7 @@ StreamOutputEffects::StreamOutputEffects(PipeManager* pipe_manager)
 
   auto* PULSE_SINK = std::getenv("PULSE_SINK");
 
-  if (PULSE_SINK != nullptr) {
+  if (PULSE_SINK != nullptr && PULSE_SINK != pm->ee_sink_name && PULSE_SINK != pm->loopback_output_name) {
     for (const auto& [id, node] : pm->node_map) {
       if (node.name == PULSE_SINK) {
         pm->output_device = node;
@@ -64,7 +66,23 @@ StreamOutputEffects::StreamOutputEffects(PipeManager* pipe_manager)
 
   connect_filters();
 
-  settings->signal_changed("output-device").connect([&, this](const auto& key) {
+  auto reset_filter_connection = [=, this]() {
+    if (global_settings->get_boolean("bypass")) {
+      global_settings->set_boolean("bypass", false);
+
+      return;  // filter connected through update_bypass_state
+    }
+
+    disconnect_filters();
+
+    connect_filters();
+  };
+
+  settings->signal_changed("output-device").connect([=, this](const auto& key) {
+    if (pm->use_output_loopback) {
+      return;
+    }
+
     const auto name = settings->get_string(key).raw();
 
     if (name.empty()) {
@@ -75,26 +93,15 @@ StreamOutputEffects::StreamOutputEffects(PipeManager* pipe_manager)
       if (node.name == name) {
         pm->output_device = node;
 
-        disconnect_filters();
-
-        connect_filters();
+        reset_filter_connection();
 
         break;
       }
     }
   });
 
-  settings->signal_changed("plugins").connect([&, this](const auto& key) {
-    if (global_settings->get_boolean("bypass")) {
-      global_settings->set_boolean("bypass", false);
-
-      return;  // filter connected through update_bypass_state
-    }
-
-    disconnect_filters();
-
-    connect_filters();
-  });
+  settings->signal_changed("plugins").connect([=, this](const auto& key) { reset_filter_connection(); });
+  pm->loopback_mode_disabled.connect(reset_filter_connection);
 }
 
 StreamOutputEffects::~StreamOutputEffects() {
@@ -103,15 +110,15 @@ StreamOutputEffects::~StreamOutputEffects() {
   util::debug(log_tag + "destroyed");
 }
 
-void StreamOutputEffects::on_app_added(const uint id, const std::string name, const std::string media_class) {
+void StreamOutputEffects::on_app_added(const uint id, const std::string name) {
   const auto& blocklist = settings->get_string_array("blocklist");
 
   const auto& is_blocklisted = std::ranges::find(blocklist, name.c_str()) != blocklist.end();
 
   if (is_blocklisted) {
-    pm->disconnect_stream_output(id, media_class);
+    pm->disconnect_stream_output(id);
   } else if (global_settings->get_boolean("process-all-outputs")) {
-    pm->connect_stream_output(id, media_class);
+    pm->connect_stream_output(id);
   }
 }
 
@@ -127,7 +134,7 @@ void StreamOutputEffects::on_link_changed(LinkInfo link_info) {
   auto want_to_play = false;
 
   for (const auto& link : pm->list_links) {
-    if (link.input_node_id == pm->pe_sink_node.id) {
+    if (link.input_node_id == pm->ee_sink_node.id) {
       if (link.state == PW_LINK_STATE_ACTIVE) {
         want_to_play = true;
 
@@ -150,7 +157,7 @@ void StreamOutputEffects::on_link_changed(LinkInfo link_info) {
 void StreamOutputEffects::connect_filters(const bool& bypass) {
   const auto& list = (bypass) ? std::vector<Glib::ustring>() : settings->get_string_array("plugins");
 
-  uint prev_node_id = pm->pe_sink_node.id;
+  uint prev_node_id = pm->ee_sink_node.id;
   uint next_node_id = 0U;
 
   // link plugins
@@ -182,7 +189,10 @@ void StreamOutputEffects::connect_filters(const bool& bypass) {
     for (const auto& name : list) {
       if (name == plugin_name::echo_canceller) {
         if (plugins[name]->connected_to_pw) {
-          for (const auto& link : pm->link_nodes(pm->output_device.id, plugins[name]->get_node_id(), true)) {
+          const auto& links = pm->link_nodes((pm->use_output_loopback) ? pm->ee_loopback_sink.id : pm->output_device.id,
+                                             plugins[name]->get_node_id(), true);
+
+          for (const auto& link : links) {
             list_proxies.emplace_back(link);
           }
         }
@@ -215,7 +225,7 @@ void StreamOutputEffects::connect_filters(const bool& bypass) {
 
   // link output device
 
-  next_node_id = pm->output_device.id;
+  next_node_id = (pm->use_output_loopback) ? pm->ee_loopback_sink.id : pm->output_device.id;
 
   const auto& links = pm->link_nodes(prev_node_id, next_node_id);
 

--- a/src/stream_output_effects_ui.cpp
+++ b/src/stream_output_effects_ui.cpp
@@ -26,7 +26,7 @@ StreamOutputEffectsUi::StreamOutputEffectsUi(BaseObjectType* cobject,
                                              const std::string& schema)
     : Gtk::Box(cobject), EffectsBaseUi(refBuilder, icon_ptr, soe_ptr, schema), soe(soe_ptr) {
   for (const auto& [id, node] : pm->node_map) {
-    if (node.media_class == "Stream/Output/Audio" && node.name != pm->loopback_output_name) {
+    if (node.media_class == "Stream/Output/Audio" && node.name != pm->loopback_playback_name) {
       on_app_added(node.id, node.name);
     }
   }

--- a/src/stream_output_effects_ui.cpp
+++ b/src/stream_output_effects_ui.cpp
@@ -26,8 +26,8 @@ StreamOutputEffectsUi::StreamOutputEffectsUi(BaseObjectType* cobject,
                                              const std::string& schema)
     : Gtk::Box(cobject), EffectsBaseUi(refBuilder, icon_ptr, soe_ptr, schema), soe(soe_ptr) {
   for (const auto& [id, node] : pm->node_map) {
-    if (node.media_class == "Stream/Output/Audio") {
-      on_app_added(node.id, node.name, node.media_class);
+    if (node.media_class == "Stream/Output/Audio" && node.name != pm->loopback_output_name) {
+      on_app_added(node.id, node.name);
     }
   }
 
@@ -44,16 +44,16 @@ StreamOutputEffectsUi::StreamOutputEffectsUi(BaseObjectType* cobject,
       soe->pm->stream_output_removed.connect(sigc::mem_fun(*this, &StreamOutputEffectsUi::on_app_removed)));
 
   connections.emplace_back(soe->pm->sink_changed.connect([&](auto nd_info) {
-    if (nd_info.id == soe->pm->pe_sink_node.id) {
+    if (nd_info.id == soe->pm->ee_sink_node.id) {
       const auto& v = Glib::ustring::format(std::setprecision(1), std::fixed,
-                                            static_cast<float>(soe->pm->pe_sink_node.rate) * 0.001F);
+                                            static_cast<float>(soe->pm->ee_sink_node.rate) * 0.001F);
 
       device_state->set_text(v + " kHz" + Glib::ustring(5, ' '));
     }
   }));
 
   const auto& v =
-      Glib::ustring::format(std::setprecision(1), std::fixed, static_cast<float>(soe->pm->pe_sink_node.rate) * 0.001F);
+      Glib::ustring::format(std::setprecision(1), std::fixed, static_cast<float>(soe->pm->ee_sink_node.rate) * 0.001F);
 
   device_state->set_text(v + " kHz" + Glib::ustring(5, ' '));
 }

--- a/src/test_signals.cpp
+++ b/src/test_signals.cpp
@@ -111,7 +111,7 @@ TestSignals::TestSignals(PipeManager* pipe_manager) : pm(pipe_manager), random_g
   auto* props_out_left = pw_properties_new(nullptr, nullptr);
 
   pw_properties_set(props_out_left, PW_KEY_FORMAT_DSP, "32 bit float mono audio");
-  pw_properties_set(props_out_left, PW_KEY_PORT_NAME, "output_fl");
+  pw_properties_set(props_out_left, PW_KEY_PORT_NAME, "output_FL");
   pw_properties_set(props_out_left, "audio.channel", "FL");
 
   pf_data.out_left = static_cast<port*>(pw_filter_add_port(filter, PW_DIRECTION_OUTPUT, PW_FILTER_PORT_FLAG_MAP_BUFFERS,
@@ -122,7 +122,7 @@ TestSignals::TestSignals(PipeManager* pipe_manager) : pm(pipe_manager), random_g
   auto* props_out_right = pw_properties_new(nullptr, nullptr);
 
   pw_properties_set(props_out_right, PW_KEY_FORMAT_DSP, "32 bit float mono audio");
-  pw_properties_set(props_out_right, PW_KEY_PORT_NAME, "output_fr");
+  pw_properties_set(props_out_right, PW_KEY_PORT_NAME, "output_FR");
   pw_properties_set(props_out_right, "audio.channel", "FR");
 
   pf_data.out_right = static_cast<port*>(pw_filter_add_port(
@@ -161,7 +161,7 @@ void TestSignals::set_state(const bool& state) {
   sine_phase = 0.0F;
 
   if (state) {
-    for (const auto& link : pm->link_nodes(node_id, pm->pe_sink_node.id, false, false)) {
+    for (const auto& link : pm->link_nodes(node_id, pm->ee_sink_node.id, false, false)) {
       list_proxies.emplace_back(link);
     }
   } else {


### PR DESCRIPTION
Related to #1142, #1126 and #1041.

This is a test and I made it only for curiosity following directives [here](https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/1447#note_1006488). 

It implements a loopback output stream for downmixing and upmixing, hopefully performed by Pipewire on the output device. I can't test it because I have only stereo devices, but at least It's playing audio unlike the previous attempt with a virtual source that it's not working with the latest Pipewire versions.

The loopback mode is enabled with a gsettings key. At the default the operating mode is the traditional with manual linking on the output device. I added a check on links to disable the loopback mode if a bad configuration is made by the user.

I also changed other small things, plus the addition of a workaround to the issue related to Pavucontrol not blocklisted in localized sessions.

Anyway I made the pull request only for reference, I don't feel it's worth to merge it and introduce a loopback stream to make the channel remapping on non-stereo devices, this should be handled automatically by Pipewire without the need to spawn another stream and make it visible to users that can mess with it.

But I hope someone can test this because I'd like to know just for the curiosity if the upmixing is really done on output stream. Later or in the next days I'll backport the changes without the loopback mode in a different PR.  