### PR TITLE
Stream monitor detection and various code optimizations

### DIFF
--- a/include/effects_base_ui.hpp
+++ b/include/effects_base_ui.hpp
@@ -102,7 +102,7 @@ class EffectsBaseUi {
 
   std::vector<sigc::connection> connections;
 
-  void on_app_added(const uint id, const std::string name, const std::string media_class);
+  void on_app_added(const uint id, const std::string name);
   void on_app_changed(const uint id);
   void on_app_removed(const uint id);
 

--- a/include/pipe_info_ui.hpp
+++ b/include/pipe_info_ui.hpp
@@ -131,8 +131,7 @@ class PipeInfoUi : public Gtk::Box {
 
   std::vector<sigc::connection> connections;
 
-  static void setup_dropdown_devices(Gtk::DropDown* dropdown,
-                                     const Glib::RefPtr<Gio::ListStore<NodeInfoHolder>>& model);
+  void setup_dropdown_devices(Gtk::DropDown* dropdown, const Glib::RefPtr<Gio::ListStore<NodeInfoHolder>>& model);
 
   void setup_dropdown_presets(PresetType preset_type, const Glib::RefPtr<Gtk::StringList>& string_list);
 

--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -190,7 +190,16 @@ class PipeManager {
 
   std::vector<DeviceInfo> list_devices;
 
-  NodeInfo pe_sink_node, pe_source_node;
+  const std::string ee_source_name = "easyeffects_source";
+  const std::string ee_sink_name = "easyeffects_sink";
+
+  const std::string media_class_sink = "Audio/Sink";
+  const std::string media_class_source = "Audio/Source";
+  const std::string media_class_virtual_source = "Audio/Source/Virtual";
+  const std::string media_class_input_stream = "Stream/Input/Audio";
+  const std::string media_class_output_stream = "Stream/Output/Audio";
+
+  NodeInfo ee_sink_node, ee_source_node, ee_loopback_sink, ee_loopback_output;
 
   NodeInfo default_output_device, default_input_device;
 
@@ -218,13 +227,13 @@ class PipeManager {
 
   auto stream_is_connected(const uint& id, const std::string& media_class) -> bool;
 
-  void connect_stream_output(const uint& id, const std::string& media_class) const;
+  void connect_stream_output(const uint& id) const;
 
-  void connect_stream_input(const uint& id, const std::string& media_class) const;
+  void connect_stream_input(const uint& id) const;
 
-  void disconnect_stream_output(const uint& id, const std::string& media_class) const;
+  void disconnect_stream_output(const uint& id) const;
 
-  void disconnect_stream_input(const uint& id, const std::string& media_class) const;
+  void disconnect_stream_input(const uint& id) const;
 
   static void set_node_volume(pw_proxy* proxy, const int& n_vol_ch, const float& value);
 
@@ -255,8 +264,8 @@ class PipeManager {
 
   static auto json_object_find(const char* obj, const char* key, char* value, const size_t& len) -> int;
 
-  sigc::signal<void(const uint, const std::string, const std::string)> stream_output_added;
-  sigc::signal<void(const uint, const std::string, const std::string)> stream_input_added;
+  sigc::signal<void(const uint, const std::string)> stream_output_added;
+  sigc::signal<void(const uint, const std::string)> stream_input_added;
   sigc::signal<void(const uint)> stream_output_changed;
   sigc::signal<void(const uint)> stream_input_changed;
   sigc::signal<void(const uint)> stream_output_removed;
@@ -286,6 +295,8 @@ class PipeManager {
   pw_proxy *proxy_stream_output_sink = nullptr, *proxy_stream_input_source = nullptr;
 
   spa_hook core_listener{}, registry_listener{};
+
+  void set_metadata_target_node(const uint& origin_id, const uint& target_id) const;
 };
 
 #endif

--- a/include/stream_input_effects.hpp
+++ b/include/stream_input_effects.hpp
@@ -42,7 +42,7 @@ class StreamInputEffects : public EffectsBase {
 
   void disconnect_filters();
 
-  void on_app_added(const uint id, const std::string name, const std::string media_class);
+  void on_app_added(const uint id, const std::string name);
 
   void on_link_changed(LinkInfo link_info);
 };

--- a/include/stream_output_effects.hpp
+++ b/include/stream_output_effects.hpp
@@ -40,7 +40,7 @@ class StreamOutputEffects : public EffectsBase {
 
   void disconnect_filters();
 
-  void on_app_added(const uint id, const std::string name, const std::string media_class);
+  void on_app_added(const uint id, const std::string name);
 
   void on_link_changed(LinkInfo link_info);
 };

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -127,7 +127,7 @@ void Application::on_startup() {
 
     if (soe_settings->get_boolean("use-default-output-device")) {
       /*
-        Depending on the hardware headphones can cause a node recreation hwere the id and the name are kept.
+        Depending on the hardware headphones can cause a node recreation here the id and the name are kept.
         So we clear the key to force the callbacks to be called
       */
 
@@ -160,7 +160,7 @@ void Application::on_startup() {
     NodeInfo target_node;
 
     for (const auto& [id, node] : pm->node_map) {
-      if (node.device_id == device.id && node.media_class == "Audio/Source") {
+      if (node.device_id == device.id && node.media_class == pm->media_class_source) {
         target_node = node;
 
         break;
@@ -188,7 +188,7 @@ void Application::on_startup() {
     NodeInfo target_node;
 
     for (const auto& [id, node] : pm->node_map) {
-      if (node.device_id == device.id && node.media_class == "Audio/Sink") {
+      if (node.device_id == device.id && node.media_class == pm->media_class_sink) {
         target_node = node;
 
         break;

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -33,7 +33,7 @@ Compressor::Compressor(const std::string& tag,
     if (settings->get_string(key) == "External") {
       const auto* device_name = settings->get_string("sidechain-input-device").c_str();
 
-      NodeInfo input_device = pm->pe_source_node;
+      NodeInfo input_device = pm->ee_source_node;
 
       for (const auto& [id, node] : pm->node_map) {
         if (node.name == device_name) {
@@ -57,7 +57,7 @@ Compressor::Compressor(const std::string& tag,
     if (settings->get_string("sidechain-type") == "External") {
       const auto* device_name = settings->get_string(key).c_str();
 
-      NodeInfo input_device = pm->pe_source_node;
+      NodeInfo input_device = pm->ee_source_node;
 
       for (const auto& [id, node] : pm->node_map) {
         if (node.name == device_name) {

--- a/src/compressor_ui.cpp
+++ b/src/compressor_ui.cpp
@@ -471,10 +471,10 @@ void CompressorUi::setup_dropdown_input_devices() {
 void CompressorUi::set_pipe_manager_ptr(PipeManager* pipe_manager) {
   pm = pipe_manager;
 
-  input_devices_model->append(NodeInfoHolder::create(pm->pe_source_node));
+  input_devices_model->append(NodeInfoHolder::create(pm->ee_source_node));
 
   for (const auto& [id, node] : pm->node_map) {
-    if (node.media_class == "Audio/Source") {
+    if (node.media_class == pm->media_class_source) {
       input_devices_model->append(NodeInfoHolder::create(node));
     }
   }

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -841,18 +841,18 @@ void EffectsBaseUi::setup_listview_players() {
 }
 
 void EffectsBaseUi::connect_stream(const uint& id, const std::string& media_class) {
-  if (media_class == "Stream/Output/Audio") {
-    pm->connect_stream_output(id, media_class);
-  } else if (media_class == "Stream/Input/Audio") {
-    pm->connect_stream_input(id, media_class);
+  if (media_class == pm->media_class_output_stream) {
+    pm->connect_stream_output(id);
+  } else if (media_class == pm->media_class_input_stream) {
+    pm->connect_stream_input(id);
   }
 }
 
 void EffectsBaseUi::disconnect_stream(const uint& id, const std::string& media_class) {
-  if (media_class == "Stream/Output/Audio") {
-    pm->disconnect_stream_output(id, media_class);
-  } else if (media_class == "Stream/Input/Audio") {
-    pm->disconnect_stream_input(id, media_class);
+  if (media_class == pm->media_class_output_stream) {
+    pm->disconnect_stream_output(id);
+  } else if (media_class == pm->media_class_input_stream) {
+    pm->disconnect_stream_input(id);
   }
 }
 
@@ -1064,7 +1064,7 @@ void EffectsBaseUi::setup_listview_plugins() {
 
       const auto& list_size = list.size();
 
-      const auto limiter_plugins = {plugin_name::limiter, plugin_name::maximizer};
+      static const auto limiter_plugins = {plugin_name::limiter, plugin_name::maximizer};
 
       if (list_size > 0U && std::any_of(limiter_plugins.begin(), limiter_plugins.end(),
                                         [&](const auto& str) { return str == list.at(list_size - 1); })) {
@@ -1334,7 +1334,7 @@ void EffectsBaseUi::setup_listview_selected_plugins() {
   });
 }
 
-void EffectsBaseUi::on_app_added(const uint id, const std::string name, const std::string media_class) {
+void EffectsBaseUi::on_app_added(const uint id, const std::string name) {
   // do not add the same stream twice
 
   for (guint n = 0U; n < all_players_model->get_n_items(); n++) {

--- a/src/pipe_info_ui.cpp
+++ b/src/pipe_info_ui.cpp
@@ -38,13 +38,13 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
       output_presets_string_list(Gtk::StringList::create({"initial_value"})),
       input_presets_string_list(Gtk::StringList::create({"initial_value"})) {
   for (const auto& [id, node] : pm->node_map) {
-    if (node.name == "easyeffects_sink" || node.name == "easyeffects_source") {
+    if (node.name == pm->ee_sink_name || node.name == pm->ee_source_name) {
       continue;
     }
 
-    if (node.media_class == "Audio/Sink") {
+    if (node.media_class == pm->media_class_sink) {
       output_devices_model->append(NodeInfoHolder::create(node));
-    } else if (node.media_class == "Audio/Source") {
+    } else if (node.media_class == pm->media_class_source) {
       input_devices_model->append(NodeInfoHolder::create(node));
     }
   }
@@ -545,15 +545,15 @@ void PipeInfoUi::setup_dropdown_devices(Gtk::DropDown* dropdown,
     list_item->set_child(*box);
   });
 
-  factory->signal_bind().connect([=](const Glib::RefPtr<Gtk::ListItem>& list_item) {
+  factory->signal_bind().connect([=, this](const Glib::RefPtr<Gtk::ListItem>& list_item) {
     auto* const label = static_cast<Gtk::Label*>(list_item->get_data("name"));
     auto* const icon = static_cast<Gtk::Image*>(list_item->get_data("icon"));
 
     auto holder = std::dynamic_pointer_cast<NodeInfoHolder>(list_item->get_item());
 
-    if (holder->info.media_class == "Audio/Sink") {
+    if (holder->info.media_class == pm->media_class_sink) {
       icon->set_from_icon_name("audio-card-symbolic");
-    } else if (holder->info.media_class == "Audio/Source") {
+    } else if (holder->info.media_class == pm->media_class_source) {
       icon->set_from_icon_name("audio-input-microphone-symbolic");
     }
 

--- a/src/plugin_base.cpp
+++ b/src/plugin_base.cpp
@@ -102,7 +102,7 @@ PluginBase::PluginBase(std::string tag,
   auto* props_in_left = pw_properties_new(nullptr, nullptr);
 
   pw_properties_set(props_in_left, PW_KEY_FORMAT_DSP, "32 bit float mono audio");
-  pw_properties_set(props_in_left, PW_KEY_PORT_NAME, "input_fl");
+  pw_properties_set(props_in_left, PW_KEY_PORT_NAME, "input_FL");
   pw_properties_set(props_in_left, "audio.channel", "FL");
 
   pf_data.in_left = static_cast<port*>(pw_filter_add_port(filter, PW_DIRECTION_INPUT, PW_FILTER_PORT_FLAG_MAP_BUFFERS,
@@ -113,7 +113,7 @@ PluginBase::PluginBase(std::string tag,
   auto* props_in_right = pw_properties_new(nullptr, nullptr);
 
   pw_properties_set(props_in_right, PW_KEY_FORMAT_DSP, "32 bit float mono audio");
-  pw_properties_set(props_in_right, PW_KEY_PORT_NAME, "input_fr");
+  pw_properties_set(props_in_right, PW_KEY_PORT_NAME, "input_FR");
   pw_properties_set(props_in_right, "audio.channel", "FR");
 
   pf_data.in_right = static_cast<port*>(pw_filter_add_port(filter, PW_DIRECTION_INPUT, PW_FILTER_PORT_FLAG_MAP_BUFFERS,
@@ -124,7 +124,7 @@ PluginBase::PluginBase(std::string tag,
   auto* props_out_left = pw_properties_new(nullptr, nullptr);
 
   pw_properties_set(props_out_left, PW_KEY_FORMAT_DSP, "32 bit float mono audio");
-  pw_properties_set(props_out_left, PW_KEY_PORT_NAME, "output_fl");
+  pw_properties_set(props_out_left, PW_KEY_PORT_NAME, "output_FL");
   pw_properties_set(props_out_left, "audio.channel", "FL");
 
   pf_data.out_left = static_cast<port*>(pw_filter_add_port(filter, PW_DIRECTION_OUTPUT, PW_FILTER_PORT_FLAG_MAP_BUFFERS,
@@ -135,7 +135,7 @@ PluginBase::PluginBase(std::string tag,
   auto* props_out_right = pw_properties_new(nullptr, nullptr);
 
   pw_properties_set(props_out_right, PW_KEY_FORMAT_DSP, "32 bit float mono audio");
-  pw_properties_set(props_out_right, PW_KEY_PORT_NAME, "output_fr");
+  pw_properties_set(props_out_right, PW_KEY_PORT_NAME, "output_FR");
   pw_properties_set(props_out_right, "audio.channel", "FR");
 
   pf_data.out_right = static_cast<port*>(pw_filter_add_port(
@@ -147,7 +147,7 @@ PluginBase::PluginBase(std::string tag,
     auto* props_left = pw_properties_new(nullptr, nullptr);
 
     pw_properties_set(props_left, PW_KEY_FORMAT_DSP, "32 bit float mono audio");
-    pw_properties_set(props_left, PW_KEY_PORT_NAME, "probe_fl");
+    pw_properties_set(props_left, PW_KEY_PORT_NAME, "probe_FL");
     pw_properties_set(props_left, "audio.channel", "PROBE_FL");
 
     pf_data.probe_left = static_cast<port*>(pw_filter_add_port(
@@ -158,7 +158,7 @@ PluginBase::PluginBase(std::string tag,
     auto* props_right = pw_properties_new(nullptr, nullptr);
 
     pw_properties_set(props_right, PW_KEY_FORMAT_DSP, "32 bit float mono audio");
-    pw_properties_set(props_right, PW_KEY_PORT_NAME, "probe_fr");
+    pw_properties_set(props_right, PW_KEY_PORT_NAME, "probe_FR");
     pw_properties_set(props_right, "audio.channel", "PROBE_FR");
 
     pf_data.probe_right = static_cast<port*>(pw_filter_add_port(

--- a/src/stream_input_effects_ui.cpp
+++ b/src/stream_input_effects_ui.cpp
@@ -40,8 +40,8 @@ StreamInputEffectsUi::StreamInputEffectsUi(BaseObjectType* cobject,
   toggle_listen_mic->signal_toggled().connect([&, this]() { sie->set_listen_to_mic(toggle_listen_mic->get_active()); });
 
   for (const auto& [id, node] : pm->node_map) {
-    if (node.media_class == "Stream/Input/Audio") {
-      on_app_added(node.id, node.name, node.media_class);
+    if (node.media_class == pm->media_class_input_stream) {
+      on_app_added(node.id, node.name);
     }
   }
 
@@ -60,16 +60,16 @@ StreamInputEffectsUi::StreamInputEffectsUi(BaseObjectType* cobject,
   connections.emplace_back(sie->pm->source_changed.connect([&](auto nd_info) {
     // nd_info is a reference of a copy previously made
 
-    if (nd_info.id == sie->pm->pe_source_node.id) {
+    if (nd_info.id == sie->pm->ee_source_node.id) {
       const auto& v = Glib::ustring::format(std::setprecision(1), std::fixed,
-                                            static_cast<float>(sie->pm->pe_source_node.rate) * 0.001F);
+                                            static_cast<float>(sie->pm->ee_source_node.rate) * 0.001F);
 
       device_state->set_text(v + " kHz" + Glib::ustring(5, ' '));
     }
   }));
 
   const auto& v = Glib::ustring::format(std::setprecision(1), std::fixed,
-                                        static_cast<float>(sie->pm->pe_source_node.rate) * 0.001F);
+                                        static_cast<float>(sie->pm->ee_source_node.rate) * 0.001F);
 
   device_state->set_text(v + " kHz" + Glib::ustring(5, ' '));
 }

--- a/src/stream_output_effects_ui.cpp
+++ b/src/stream_output_effects_ui.cpp
@@ -26,8 +26,8 @@ StreamOutputEffectsUi::StreamOutputEffectsUi(BaseObjectType* cobject,
                                              const std::string& schema)
     : Gtk::Box(cobject), EffectsBaseUi(refBuilder, icon_ptr, soe_ptr, schema), soe(soe_ptr) {
   for (const auto& [id, node] : pm->node_map) {
-    if (node.media_class == "Stream/Output/Audio") {
-      on_app_added(node.id, node.name, node.media_class);
+    if (node.media_class == pm->media_class_output_stream) {
+      on_app_added(node.id, node.name);
     }
   }
 
@@ -44,16 +44,16 @@ StreamOutputEffectsUi::StreamOutputEffectsUi(BaseObjectType* cobject,
       soe->pm->stream_output_removed.connect(sigc::mem_fun(*this, &StreamOutputEffectsUi::on_app_removed)));
 
   connections.emplace_back(soe->pm->sink_changed.connect([&](auto nd_info) {
-    if (nd_info.id == soe->pm->pe_sink_node.id) {
+    if (nd_info.id == soe->pm->ee_sink_node.id) {
       const auto& v = Glib::ustring::format(std::setprecision(1), std::fixed,
-                                            static_cast<float>(soe->pm->pe_sink_node.rate) * 0.001F);
+                                            static_cast<float>(soe->pm->ee_sink_node.rate) * 0.001F);
 
       device_state->set_text(v + " kHz" + Glib::ustring(5, ' '));
     }
   }));
 
   const auto& v =
-      Glib::ustring::format(std::setprecision(1), std::fixed, static_cast<float>(soe->pm->pe_sink_node.rate) * 0.001F);
+      Glib::ustring::format(std::setprecision(1), std::fixed, static_cast<float>(soe->pm->ee_sink_node.rate) * 0.001F);
 
   device_state->set_text(v + " kHz" + Glib::ustring(5, ' '));
 }

--- a/src/test_signals.cpp
+++ b/src/test_signals.cpp
@@ -90,7 +90,7 @@ const struct pw_filter_events filter_events = {.process = on_process};
 TestSignals::TestSignals(PipeManager* pipe_manager) : pm(pipe_manager), random_generator(rd()) {
   pf_data.ts = this;
 
-  const auto* filter_name = "pe_test_signals";
+  const auto* filter_name = "ee_test_signals";
 
   pm->lock();
 
@@ -102,7 +102,7 @@ TestSignals::TestSignals(PipeManager* pipe_manager) : pm(pipe_manager), random_g
   pw_properties_set(props_filter, PW_KEY_MEDIA_TYPE, "Audio");
   pw_properties_set(props_filter, PW_KEY_MEDIA_CATEGORY, "Source");
   pw_properties_set(props_filter, PW_KEY_MEDIA_ROLE, "DSP");
-  // pw_properties_set(props_filter, PW_KEY_MEDIA_CLASS, "Stream/Output/Audio");
+  // pw_properties_set(props_filter, PW_KEY_MEDIA_CLASS, pm->media_class_output_stream);
 
   filter = pw_filter_new(pm->core, filter_name, props_filter);
 
@@ -111,7 +111,7 @@ TestSignals::TestSignals(PipeManager* pipe_manager) : pm(pipe_manager), random_g
   auto* props_out_left = pw_properties_new(nullptr, nullptr);
 
   pw_properties_set(props_out_left, PW_KEY_FORMAT_DSP, "32 bit float mono audio");
-  pw_properties_set(props_out_left, PW_KEY_PORT_NAME, "output_fl");
+  pw_properties_set(props_out_left, PW_KEY_PORT_NAME, "output_FL");
   pw_properties_set(props_out_left, "audio.channel", "FL");
 
   pf_data.out_left = static_cast<port*>(pw_filter_add_port(filter, PW_DIRECTION_OUTPUT, PW_FILTER_PORT_FLAG_MAP_BUFFERS,
@@ -122,7 +122,7 @@ TestSignals::TestSignals(PipeManager* pipe_manager) : pm(pipe_manager), random_g
   auto* props_out_right = pw_properties_new(nullptr, nullptr);
 
   pw_properties_set(props_out_right, PW_KEY_FORMAT_DSP, "32 bit float mono audio");
-  pw_properties_set(props_out_right, PW_KEY_PORT_NAME, "output_fr");
+  pw_properties_set(props_out_right, PW_KEY_PORT_NAME, "output_FR");
   pw_properties_set(props_out_right, "audio.channel", "FR");
 
   pf_data.out_right = static_cast<port*>(pw_filter_add_port(
@@ -161,7 +161,7 @@ void TestSignals::set_state(const bool& state) {
   sine_phase = 0.0F;
 
   if (state) {
-    for (const auto& link : pm->link_nodes(node_id, pm->pe_sink_node.id, false, false)) {
+    for (const auto& link : pm->link_nodes(node_id, pm->ee_sink_node.id, false, false)) {
       list_proxies.emplace_back(link);
     }
   } else {


### PR DESCRIPTION
This fixes #1128 adding a workaround. Since localized Pavucontrol can't be blocklisted inside `on_registry_global`, we detect it inside `on_node_info` and remove it.

```
(easyeffects:8737): easyeffects-DEBUG: 22:11:25.355: pipe_manager: Stream/Input/Audio 116 Regolazione del volume PulseAudio was added
(easyeffects:8737): easyeffects-DEBUG: 22:11:25.355: pipe_manager: Stream/Input/Audio 98 Regolazione del volume PulseAudio was added
(easyeffects:8737): easyeffects-DEBUG: 22:11:25.356: pipe_manager: Stream/Input/Audio 97 Regolazione del volume PulseAudio was added
(easyeffects:8737): easyeffects-DEBUG: 22:11:25.356: pipe_manager: Stream/Input/Audio 89 Regolazione del volume PulseAudio was added
(easyeffects:8737): easyeffects-DEBUG: 22:11:25.356: pipe_manager:  monitor stream Stream/Input/Audio Regolazione del volume PulseAudio was removed
(easyeffects:8737): easyeffects-DEBUG: 22:11:25.356: pipe_manager:  monitor stream Stream/Input/Audio Regolazione del volume PulseAudio was removed
(easyeffects:8737): easyeffects-DEBUG: 22:11:25.356: pipe_manager:  monitor stream Stream/Input/Audio Regolazione del volume PulseAudio was removed
(easyeffects:8737): easyeffects-DEBUG: 22:11:25.356: pipe_manager:  monitor stream Stream/Input/Audio Regolazione del volume PulseAudio was removed
(easyeffects:8737): easyeffects-DEBUG: 22:11:25.397: pipe_manager: Stream/Input/Audio 189 Regolazione del volume PulseAudio was added
(easyeffects:8737): easyeffects-DEBUG: 22:11:25.398: pipe_manager:  monitor stream Stream/Input/Audio Regolazione del volume PulseAudio was removed
```

Other optimizations have been made:

* made a single private method to set the target node id and removed media class parameter in various connection methods
* EE sink and source names saved in constants
* media class types saved in constants 
* implemented static constant arrays where possible
* ports in port names made uppercase as Pipewire convention

Anyway I have a doubt @wwmm. In stream output effects we link echo canceller probe to output device:

https://github.com/Digitalone1/easyeffects/blob/27131fa6716bad3b9715521cf889c6b80d65814c/src/stream_output_effects.cpp#L185

And we do the same in stream input effects:

https://github.com/Digitalone1/easyeffects/blob/27131fa6716bad3b9715521cf889c6b80d65814c/src/stream_input_effects.cpp#L200

But in the last case shouldn't it be linked to the input device?