### PR TITLE
Fix enabled_app_list insertion

### DIFF
--- a/include/effects_base_ui.hpp
+++ b/include/effects_base_ui.hpp
@@ -160,8 +160,10 @@ class EffectsBaseUi {
                                                        {plugin_name::rnnoise, _("Noise Reduction")},
                                                        {plugin_name::stereo_tools, _("Stereo Tools")}};
 
-  /* enabled_app_list saves the "enabled state" of processed apps regardless of their presence in the blocklist,
-     useful to restore the enabled state when the app is removed from the blocklist */
+  /*
+    enabled_app_list map saves the "enabled state" of processed apps regardless of their presence in the blocklist,
+     useful to restore the enabled state when the app is removed from the blocklist
+  */
 
   std::map<uint, bool> enabled_app_list;
 

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -757,8 +757,8 @@ void EffectsBaseUi::setup_listview_players() {
 
       // save app "enabled state" only the first time when it is not present in the enabled_app_list map
 
-      if (auto state_it = enabled_app_list.find(node_info.id); state_it == enabled_app_list.end()) {
-        state_it->second = is_enabled;
+      if (enabled_app_list.find(node_info.id) == enabled_app_list.end()) {
+        enabled_app_list.insert({node_info.id, is_enabled});
       }
 
       // set the icon name


### PR DESCRIPTION
Fixed another mistake of mine. I had to use `insert`, not accessing to `second`. I'm surprised the compiler didn't complain and the tests I made didn't lead to a crash since that iterator should point to an area outside the map.

`tryemplace` was useful on only one line, but emplace methods use references to construct "in-place", so it's better to use `insert` in that context which make copies, even if no issues with tryemplace were showing, but we want to be safe and not run the risk.