### PR TITLE
Optimize safety

### DIFF
--- a/include/application_ui.hpp
+++ b/include/application_ui.hpp
@@ -44,8 +44,6 @@ class ApplicationUi : public Gtk::ApplicationWindow {
 
   static auto setup_icon_theme() -> Glib::RefPtr<Gtk::IconTheme>;
 
-  inline static Glib::RefPtr<Gtk::IconTheme> icon_theme = nullptr;
-
  private:
   inline static const std::string log_tag = "application_ui: ";
 

--- a/include/convolver.hpp
+++ b/include/convolver.hpp
@@ -22,9 +22,7 @@
 
 #include <zita-convolver.h>
 #include <algorithm>
-#include <ranges>
 #include <sndfile.hh>
-#include <vector>
 #include "plugin_base.hpp"
 #include "resampler.hpp"
 

--- a/include/convolver.hpp
+++ b/include/convolver.hpp
@@ -22,6 +22,7 @@
 
 #include <zita-convolver.h>
 #include <algorithm>
+#include <deque>
 #include <sndfile.hh>
 #include "plugin_base.hpp"
 #include "resampler.hpp"

--- a/include/convolver_ui.hpp
+++ b/include/convolver_ui.hpp
@@ -26,9 +26,7 @@
 #include <filesystem>
 #include <mutex>
 #include <numbers>
-#include <ranges>
 #include <sndfile.hh>
-#include <thread>
 #include "plot.hpp"
 #include "plugin_ui_base.hpp"
 

--- a/include/crossfeed.hpp
+++ b/include/crossfeed.hpp
@@ -21,7 +21,6 @@
 #define CROSSFEED_HPP
 
 #include <bs2bclass.h>
-#include <vector>
 #include "plugin_base.hpp"
 
 class Crossfeed : public PluginBase {

--- a/include/crystalizer.hpp
+++ b/include/crystalizer.hpp
@@ -20,7 +20,6 @@
 #ifndef CRYSTALIZER_HPP
 #define CRYSTALIZER_HPP
 
-#include <vector>
 #include "fir_filter_bandpass.hpp"
 #include "fir_filter_highpass.hpp"
 #include "fir_filter_lowpass.hpp"

--- a/include/crystalizer.hpp
+++ b/include/crystalizer.hpp
@@ -20,6 +20,7 @@
 #ifndef CRYSTALIZER_HPP
 #define CRYSTALIZER_HPP
 
+#include <deque>
 #include "fir_filter_bandpass.hpp"
 #include "fir_filter_highpass.hpp"
 #include "fir_filter_lowpass.hpp"

--- a/include/echo_canceller.hpp
+++ b/include/echo_canceller.hpp
@@ -21,7 +21,6 @@
 #define ECHO_CANCELLER_HPP
 
 #include <speex/speex_echo.h>
-#include <vector>
 #include "plugin_base.hpp"
 
 class EchoCanceller : public PluginBase {

--- a/include/echo_canceller.hpp
+++ b/include/echo_canceller.hpp
@@ -21,6 +21,7 @@
 #define ECHO_CANCELLER_HPP
 
 #include <speex/speex_echo.h>
+#include <deque>
 #include "plugin_base.hpp"
 
 class EchoCanceller : public PluginBase {

--- a/include/effects_base_ui.hpp
+++ b/include/effects_base_ui.hpp
@@ -25,7 +25,6 @@
 #include <glibmm/i18n.h>
 #include <gtkmm.h>
 #include <memory>
-#include <vector>
 #include "autogain_ui.hpp"
 #include "bass_enhancer_ui.hpp"
 #include "bass_loudness_ui.hpp"

--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -30,8 +30,8 @@
 #include <spa/utils/result.h>
 #include <algorithm>
 #include <array>
+#include <map>
 #include <memory>
-#include <string>
 #include "util.hpp"
 
 struct NodeInfo {

--- a/include/pitch.hpp
+++ b/include/pitch.hpp
@@ -21,6 +21,7 @@
 #define PITCH_HPP
 
 #include <rubberband/RubberBandStretcher.h>
+#include <deque>
 #include "plugin_base.hpp"
 
 class Pitch : public PluginBase {

--- a/include/presets_manager.hpp
+++ b/include/presets_manager.hpp
@@ -28,7 +28,6 @@
 #include <fstream>
 #include <memory>
 #include <nlohmann/json.hpp>
-#include <vector>
 #include "autogain_preset.hpp"
 #include "bass_enhancer_preset.hpp"
 #include "bass_loudness_preset.hpp"

--- a/include/rnnoise.hpp
+++ b/include/rnnoise.hpp
@@ -21,6 +21,7 @@
 #define RNNOISE_HPP
 
 #include <rnnoise.h>
+#include <deque>
 #include <memory>
 #include "plugin_base.hpp"
 #include "resampler.hpp"

--- a/include/rnnoise.hpp
+++ b/include/rnnoise.hpp
@@ -74,7 +74,7 @@ class RNNoise : public PluginBase {
   template <typename T1, typename T2>
   void remove_noise(const T1& left_in, const T1& right_in, T2& out_L, T2& out_R) {
     for (const auto& v : left_in) {
-      data_L.emplace_back(v);
+      data_L.push_back(v);
 
       if (data_L.size() == blocksize) {
         if (state_left != nullptr) {
@@ -86,7 +86,7 @@ class RNNoise : public PluginBase {
         }
 
         for (const auto& v : data_L) {
-          out_L.emplace_back(v);
+          out_L.push_back(v);
         }
 
         data_L.resize(0);
@@ -94,7 +94,7 @@ class RNNoise : public PluginBase {
     }
 
     for (const auto& v : right_in) {
-      data_R.emplace_back(v);
+      data_R.push_back(v);
 
       if (data_R.size() == blocksize) {
         if (state_right != nullptr) {
@@ -106,7 +106,7 @@ class RNNoise : public PluginBase {
         }
 
         for (const auto& v : data_R) {
-          out_R.emplace_back(v);
+          out_R.push_back(v);
         }
 
         data_R.resize(0);

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -26,6 +26,7 @@
 #include <chrono>
 #include <cmath>
 #include <iostream>
+#include <string>
 #include <thread>
 #include <vector>
 

--- a/src/application_ui.cpp
+++ b/src/application_ui.cpp
@@ -39,9 +39,7 @@ ApplicationUi::ApplicationUi(BaseObjectType* cobject,
   GeneralSettingsUi::add_to_stack(stack_menu_settings, app);
   SpectrumSettingsUi::add_to_stack(stack_menu_settings, app);
 
-  if (icon_theme == nullptr) {
-    icon_theme = setup_icon_theme();
-  }
+  auto icon_theme = setup_icon_theme();
 
   soe_ui = StreamOutputEffectsUi::add_to_stack(stack, app->soe.get(), icon_theme);
   sie_ui = StreamInputEffectsUi::add_to_stack(stack, app->sie.get(), icon_theme);

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -44,7 +44,7 @@ Compressor::Compressor(const std::string& tag,
       }
 
       for (const auto& link : pm->link_nodes(input_device.id, get_node_id(), true)) {
-        list_proxies.emplace_back(link);
+        list_proxies.push_back(link);
       }
     } else {
       pm->destroy_links(list_proxies);
@@ -72,7 +72,7 @@ Compressor::Compressor(const std::string& tag,
       list_proxies.clear();
 
       for (const auto& link : pm->link_nodes(input_device.id, get_node_id(), true)) {
-        list_proxies.emplace_back(link);
+        list_proxies.push_back(link);
       }
     }
   });

--- a/src/compressor_ui.cpp
+++ b/src/compressor_ui.cpp
@@ -480,7 +480,7 @@ void CompressorUi::set_pipe_manager_ptr(PipeManager* pipe_manager) {
   }
 
   connections.push_back(pm->source_added.connect([=, this](const NodeInfo info) {
-    for (guint n = 0U, list_size = input_devices_model->get_n_items(); n < list_size; n++) {
+    for (guint n = 0U; n < input_devices_model->get_n_items(); n++) {
       if (input_devices_model->get_item(n)->id == info.id) {
         return;
       }
@@ -490,7 +490,7 @@ void CompressorUi::set_pipe_manager_ptr(PipeManager* pipe_manager) {
   }));
 
   connections.push_back(pm->source_removed.connect([=, this](const NodeInfo info) {
-    for (guint n = 0U, list_size = input_devices_model->get_n_items(); n < list_size; n++) {
+    for (guint n = 0U; n < input_devices_model->get_n_items(); n++) {
       if (input_devices_model->get_item(n)->id == info.id) {
         input_devices_model->remove(n);
 

--- a/src/compressor_ui.cpp
+++ b/src/compressor_ui.cpp
@@ -284,7 +284,7 @@ CompressorUi::CompressorUi(BaseObjectType* cobject,
   g_settings_bind_with_mapping(settings->gobj(), "lpf-mode", lpf_mode->gobj(), "active", G_SETTINGS_BIND_DEFAULT,
                                filter_mode_enum_to_int, int_to_filter_mode_enum, nullptr, nullptr);
 
-  connections.emplace_back(settings->signal_changed("sidechain-type").connect([=, this](const auto& key) {
+  connections.push_back(settings->signal_changed("sidechain-type").connect([=, this](const auto& key) {
     if (settings->get_string(key) != "External") {
       dropdown_input_devices->set_sensitive(false);
     } else {
@@ -479,7 +479,7 @@ void CompressorUi::set_pipe_manager_ptr(PipeManager* pipe_manager) {
     }
   }
 
-  connections.emplace_back(pm->source_added.connect([=, this](const NodeInfo info) {
+  connections.push_back(pm->source_added.connect([=, this](const NodeInfo info) {
     for (guint n = 0U, list_size = input_devices_model->get_n_items(); n < list_size; n++) {
       if (input_devices_model->get_item(n)->id == info.id) {
         return;
@@ -489,7 +489,7 @@ void CompressorUi::set_pipe_manager_ptr(PipeManager* pipe_manager) {
     input_devices_model->append(NodeInfoHolder::create(info));
   }));
 
-  connections.emplace_back(pm->source_removed.connect([=, this](const NodeInfo info) {
+  connections.push_back(pm->source_removed.connect([=, this](const NodeInfo info) {
     for (guint n = 0U, list_size = input_devices_model->get_n_items(); n < list_size; n++) {
       if (input_devices_model->get_item(n)->id == info.id) {
         input_devices_model->remove(n);

--- a/src/convolver.cpp
+++ b/src/convolver.cpp
@@ -170,7 +170,7 @@ void Convolver::process(std::span<float>& left_in,
 
     do_convolution(left_out, right_out);
   } else {
-    for (size_t j = 0U, li_size = left_in.size(); j < li_size; j++) {
+    for (size_t j = 0U; j < left_in.size(); j++) {
       data_L.push_back(left_in[j]);
       data_R.push_back(right_in[j]);
 
@@ -311,7 +311,7 @@ void Convolver::read_kernel_file() {
 
   file.readf(buffer.data(), file.frames());
 
-  for (size_t n = 0U, bl_size = buffer_L.size(); n < bl_size; n++) {
+  for (size_t n = 0U; n < buffer_L.size(); n++) {
     buffer_L[n] = buffer[2U * n];
     buffer_R[n] = buffer[2U * n + 1U];
   }
@@ -378,7 +378,7 @@ void Convolver::set_kernel_stereo_width() {
   const float w = static_cast<float>(ir_width) * 0.01F;
   const float x = (1.0F - w) / (1.0F + w);  // M-S coeff.; L_out = L + x*R; R_out = R + x*L
 
-  for (uint i = 0U, okl_size = original_kernel_L.size(); i < okl_size; i++) {
+  for (uint i = 0U; i < original_kernel_L.size(); i++) {
     const auto& L = original_kernel_L[i];
     const auto& R = original_kernel_R[i];
 

--- a/src/convolver.cpp
+++ b/src/convolver.cpp
@@ -171,18 +171,18 @@ void Convolver::process(std::span<float>& left_in,
     do_convolution(left_out, right_out);
   } else {
     for (size_t j = 0U, li_size = left_in.size(); j < li_size; j++) {
-      data_L.emplace_back(left_in[j]);
-      data_R.emplace_back(right_in[j]);
+      data_L.push_back(left_in[j]);
+      data_R.push_back(right_in[j]);
 
       if (data_L.size() == blocksize) {
         do_convolution(data_L, data_R);
 
         for (const auto& v : data_L) {
-          deque_out_L.emplace_back(v);
+          deque_out_L.push_back(v);
         }
 
         for (const auto& v : data_R) {
-          deque_out_R.emplace_back(v);
+          deque_out_R.push_back(v);
         }
 
         data_L.resize(0);

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -115,7 +115,7 @@ ConvolverUi::ConvolverUi(BaseObjectType* cobject,
      is loaded
   */
 
-  connections.emplace_back(settings->signal_changed("kernel-path").connect([=, this](const auto& key) {
+  connections.push_back(settings->signal_changed("kernel-path").connect([=, this](const auto& key) {
     std::jthread jt{[this]() {
       std::scoped_lock<std::mutex> lock(lock_guard_irs_info);
 
@@ -300,7 +300,7 @@ auto ConvolverUi::get_irs_names() -> std::vector<Glib::ustring> {
   for (std::filesystem::directory_iterator it{irs_dir}; it != std::filesystem::directory_iterator{}; ++it) {
     if (std::filesystem::is_regular_file(it->status())) {
       if (it->path().extension().c_str() == irs_ext) {
-        names.emplace_back(it->path().stem().c_str());
+        names.push_back(it->path().stem().c_str());
       }
     }
   }
@@ -394,7 +394,7 @@ void ConvolverUi::get_irs_info() {
   if (file.channels() != 2 || file.frames() == 0) {
     // warning user that there is a problem
 
-    connections.emplace_back(Glib::signal_idle().connect([=, this]() {
+    connections.push_back(Glib::signal_idle().connect([=, this]() {
       label_sampling_rate->set_text(_("Failed"));
       label_samples->set_text(_("Failed"));
 
@@ -443,24 +443,24 @@ void ConvolverUi::get_irs_info() {
     size_t bin_size = std::ceil(file.frames() / spectrum_settings->get_int("n-points"));
 
     for (int n = 0; n < file.frames(); n++) {
-      bin_x.emplace_back(time_axis[n]);
+      bin_x.push_back(time_axis[n]);
 
-      bin_l_y.emplace_back(left_mag[n]);
-      bin_r_y.emplace_back(right_mag[n]);
+      bin_l_y.push_back(left_mag[n]);
+      bin_r_y.push_back(right_mag[n]);
 
       if (bin_x.size() == bin_size) {
         const auto& [min, max] = std::ranges::minmax_element(bin_l_y);
 
-        t.emplace_back(bin_x[min - bin_l_y.begin()]);
-        t.emplace_back(bin_x[max - bin_l_y.begin()]);
+        t.push_back(bin_x[min - bin_l_y.begin()]);
+        t.push_back(bin_x[max - bin_l_y.begin()]);
 
-        l.emplace_back(*min);
-        l.emplace_back(*max);
+        l.push_back(*min);
+        l.push_back(*max);
 
         const auto& [minr, maxr] = std::ranges::minmax_element(bin_r_y);
 
-        r.emplace_back(*minr);
-        r.emplace_back(*maxr);
+        r.push_back(*minr);
+        r.push_back(*maxr);
 
         bin_x.resize(0);
         bin_l_y.resize(0);
@@ -476,15 +476,15 @@ void ConvolverUi::get_irs_info() {
   // ensure that the fft can be computed
 
   if (time_axis.size() % 2U != 0U) {
-    time_axis.emplace_back(static_cast<float>(time_axis.size() - 1U) * dt);
+    time_axis.push_back(static_cast<float>(time_axis.size() - 1U) * dt);
   }
 
   if (left_mag.size() % 2U != 0U) {
-    left_mag.emplace_back(0.0F);
+    left_mag.push_back(0.0F);
   }
 
   if (right_mag.size() % 2U != 0U) {
-    right_mag.emplace_back(0.0F);
+    right_mag.push_back(0.0F);
   }
 
   time_axis.shrink_to_fit();
@@ -508,7 +508,7 @@ void ConvolverUi::get_irs_info() {
 
   // updating interface with ir file info
 
-  connections.emplace_back(Glib::signal_idle().connect([=, this]() {
+  connections.push_back(Glib::signal_idle().connect([=, this]() {
     label_sampling_rate->set_text(Glib::ustring::format(file.samplerate()) + " Hz");
     label_samples->set_text(Glib::ustring::format(file.frames()));
 
@@ -664,7 +664,7 @@ void ConvolverUi::get_irs_spectrum(const int& rate) {
     right_spectrum[n] = (right_spectrum[n] - fft_min_right) / (fft_max_right - fft_min_right);
   }
 
-  connections.emplace_back(Glib::signal_idle().connect([=, this]() {
+  connections.push_back(Glib::signal_idle().connect([=, this]() {
     plot_fft();
 
     return false;

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -93,9 +93,7 @@ ConvolverUi::ConvolverUi(BaseObjectType* cobject,
     }
   });
 
-  show_fft->signal_toggled().connect([=, this]() {
-    (show_fft->get_active()) ? plot_fft() : plot_waveform();
-  });
+  show_fft->signal_toggled().connect([=, this]() { (show_fft->get_active()) ? plot_fft() : plot_waveform(); });
 
   // gsettings bindings
 
@@ -126,42 +124,42 @@ ConvolverUi::ConvolverUi(BaseObjectType* cobject,
   folder_monitor = Gio::File::create_for_path(irs_dir.string())->monitor_directory();
 
   folder_monitor->signal_changed().connect(
-    [=, this](const Glib::RefPtr<Gio::File>& file, const auto& other_f, const auto& event) {
-      const auto& irs_filename = util::remove_filename_extension(file->get_basename());
+      [=, this](const Glib::RefPtr<Gio::File>& file, const auto& other_f, const auto& event) {
+        const auto& irs_filename = util::remove_filename_extension(file->get_basename());
 
-      if (irs_filename.empty()) {
-        util::warning("Can't retrieve information about irs file");
+        if (irs_filename.empty()) {
+          util::warning("Can't retrieve information about irs file");
 
-        return;
-      }
-
-      switch (event) {
-        case Gio::FileMonitor::Event::CREATED: {
-          for (guint n = 0, list_size = string_list->get_n_items(); n < list_size; n++) {
-            if (string_list->get_string(n) == irs_filename) {
-              return;
-            }
-          }
-
-          string_list->append(irs_filename);
-
-          break;
+          return;
         }
-        case Gio::FileMonitor::Event::DELETED: {
-          for (guint n = 0, list_size = string_list->get_n_items(); n < list_size; n++) {
-            if (string_list->get_string(n) == irs_filename) {
-              string_list->remove(n);
 
-              break;
+        switch (event) {
+          case Gio::FileMonitor::Event::CREATED: {
+            for (guint n = 0; n < string_list->get_n_items(); n++) {
+              if (string_list->get_string(n) == irs_filename) {
+                return;
+              }
             }
-          }
 
-          break;
+            string_list->append(irs_filename);
+
+            break;
+          }
+          case Gio::FileMonitor::Event::DELETED: {
+            for (guint n = 0; n < string_list->get_n_items(); n++) {
+              if (string_list->get_string(n) == irs_filename) {
+                string_list->remove(n);
+
+                break;
+              }
+            }
+
+            break;
+          }
+          default:
+            break;
         }
-        default:
-          break;
-      }
-    });
+      });
 }
 
 ConvolverUi::~ConvolverUi() {
@@ -175,8 +173,8 @@ ConvolverUi::~ConvolverUi() {
 auto ConvolverUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> ConvolverUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/convolver.ui");
 
-  auto* const ui = Gtk::Builder::get_widget_derived<ConvolverUi>(builder, "top_box", "com.github.wwmm.easyeffects.convolver",
-                                                           schema_path + "convolver/");
+  auto* const ui = Gtk::Builder::get_widget_derived<ConvolverUi>(
+      builder, "top_box", "com.github.wwmm.easyeffects.convolver", schema_path + "convolver/");
 
   stack->add(*ui, plugin_name::convolver);
 
@@ -501,7 +499,7 @@ void ConvolverUi::get_irs_info() {
 
   // rescaling between 0 and 1
 
-  for (size_t n = 0U, lm_size = left_mag.size(); n < lm_size; n++) {
+  for (size_t n = 0U; n < left_mag.size(); n++) {
     left_mag[n] = (left_mag[n] - min_left) / (max_left - min_left);
     right_mag[n] = (right_mag[n] - min_right) / (max_right - min_right);
   }
@@ -536,12 +534,11 @@ void ConvolverUi::get_irs_spectrum(const int& rate) {
 
   auto real_input = left_mag;
 
-  for (uint n = 0U, ri_size = real_input.size(); n < ri_size; n++) {
+  for (uint n = 0U; n < real_input.size(); n++) {
     // https://en.wikipedia.org/wiki/Hann_function
 
-    const float w =
-        0.5F * (1.0F - std::cos(2.0F * std::numbers::pi_v<float> * static_cast<float>(n) /
-        static_cast<float>(real_input.size() - 1U)));
+    const float w = 0.5F * (1.0F - std::cos(2.0F * std::numbers::pi_v<float> * static_cast<float>(n) /
+                                            static_cast<float>(real_input.size() - 1U)));
 
     real_input[n] *= w;
   }
@@ -553,7 +550,7 @@ void ConvolverUi::get_irs_spectrum(const int& rate) {
 
   fftwf_execute(plan);
 
-  for (uint i = 0U, ls_size = left_spectrum.size(); i < ls_size; i++) {
+  for (uint i = 0U; i < left_spectrum.size(); i++) {
     float sqr = complex_output[i][0] * complex_output[i][0] + complex_output[i][1] * complex_output[i][1];
 
     sqr /= static_cast<float>(left_spectrum.size() * left_spectrum.size());
@@ -565,19 +562,18 @@ void ConvolverUi::get_irs_spectrum(const int& rate) {
 
   real_input = right_mag;
 
-  for (uint n = 0U, ri_size = real_input.size(); n < ri_size; n++) {
+  for (uint n = 0U; n < real_input.size(); n++) {
     // https://en.wikipedia.org/wiki/Hann_function
 
-    const float w =
-        0.5F * (1.0F - std::cos(2.0F * std::numbers::pi_v<float> * static_cast<float>(n) /
-        static_cast<float>(real_input.size() - 1U)));
+    const float w = 0.5F * (1.0F - std::cos(2.0F * std::numbers::pi_v<float> * static_cast<float>(n) /
+                                            static_cast<float>(real_input.size() - 1U)));
 
     real_input[n] *= w;
   }
 
   fftwf_execute(plan);
 
-  for (uint i = 0U, rs_size = right_spectrum.size(); i < rs_size; i++) {
+  for (uint i = 0U; i < right_spectrum.size(); i++) {
     float sqr = complex_output[i][0] * complex_output[i][0] + complex_output[i][1] * complex_output[i][1];
 
     sqr /= static_cast<float>(right_spectrum.size() * right_spectrum.size());
@@ -597,13 +593,14 @@ void ConvolverUi::get_irs_spectrum(const int& rate) {
 
   freq_axis.resize(left_spectrum.size());
 
-  for (uint n = 0U, ls_size = left_spectrum.size(); n < ls_size; n++) {
+  for (uint n = 0U; n < left_spectrum.size(); n++) {
     freq_axis[n] = 0.5F * static_cast<float>(rate) * static_cast<float>(n) / static_cast<float>(left_spectrum.size());
   }
 
   // initializing the logarithmic frequency axis
 
-  const auto& log_axis = util::logspace(std::log10(20.0F), std::log10(22000.0F), spectrum_settings->get_int("n-points"));
+  const auto& log_axis =
+      util::logspace(std::log10(20.0F), std::log10(22000.0F), spectrum_settings->get_int("n-points"));
   // auto log_axis = util::linspace(20.0F, 22000.0F, spectrum_settings->get_int("n-points"));
 
   std::vector<float> l(log_axis.size());
@@ -616,8 +613,8 @@ void ConvolverUi::get_irs_spectrum(const int& rate) {
 
   // reducing the amount of data we have to plot and converting the frequency axis to the logarithimic scale
 
-  for (size_t j = 0U, fa_size = freq_axis.size(); j < fa_size; j++) {
-    for (size_t n = 0U, la_size = log_axis.size(); n < la_size; n++) {
+  for (size_t j = 0U; j < freq_axis.size(); j++) {
+    for (size_t n = 0U; n < log_axis.size(); n++) {
       if (n > 0U) {
         if (freq_axis[j] <= log_axis[n] && freq_axis[j] > log_axis[n - 1U]) {
           l[n] += left_spectrum[j];
@@ -638,7 +635,7 @@ void ConvolverUi::get_irs_spectrum(const int& rate) {
 
   // fillint empty bins with their neighbors value
 
-  for (size_t n = 0U, bc_size = bin_count.size(); n < bc_size; n++) {
+  for (size_t n = 0U; n < bin_count.size(); n++) {
     if (bin_count[n] == 0U && n > 0U) {
       l[n] = l[n - 1U];
       r[n] = r[n - 1U];
@@ -659,7 +656,7 @@ void ConvolverUi::get_irs_spectrum(const int& rate) {
 
   // rescaling between 0 and 1
 
-  for (uint n = 0, ls_size = left_spectrum.size(); n < ls_size; n++) {
+  for (uint n = 0; n < left_spectrum.size(); n++) {
     left_spectrum[n] = (left_spectrum[n] - fft_min_left) / (fft_max_left - fft_min_left);
     right_spectrum[n] = (right_spectrum[n] - fft_min_right) / (fft_max_right - fft_min_right);
   }

--- a/src/crossfeed.cpp
+++ b/src/crossfeed.cpp
@@ -76,14 +76,14 @@ void Crossfeed::process(std::span<float>& left_in,
     apply_gain(left_in, right_in, input_gain);
   }
 
-  for (size_t n = 0U, li_size = left_in.size(); n < li_size; n++) {
+  for (size_t n = 0U; n < left_in.size(); n++) {
     data[n * 2U] = left_in[n];
     data[n * 2U + 1U] = right_in[n];
   }
 
   bs2b.cross_feed(data.data(), n_samples);
 
-  for (size_t n = 0U, lo_size = left_out.size(); n < lo_size; n++) {
+  for (size_t n = 0U; n < left_out.size(); n++) {
     left_out[n] = data[n * 2U];
     right_out[n] = data[n * 2U + 1U];
   }

--- a/src/crystalizer.cpp
+++ b/src/crystalizer.cpp
@@ -151,18 +151,18 @@ void Crystalizer::process(std::span<float>& left_in,
     enhance_peaks(left_out, right_out);
   } else {
     for (size_t j = 0U, li_size = left_in.size(); j < li_size; j++) {
-      data_L.emplace_back(left_in[j]);
-      data_R.emplace_back(right_in[j]);
+      data_L.push_back(left_in[j]);
+      data_R.push_back(right_in[j]);
 
       if (data_L.size() == blocksize) {
         enhance_peaks(data_L, data_R);
 
         for (const auto& v : data_L) {
-          deque_out_L.emplace_back(v);
+          deque_out_L.push_back(v);
         }
 
         for (const auto& v : data_R) {
-          deque_out_R.emplace_back(v);
+          deque_out_R.push_back(v);
         }
 
         data_L.resize(0);

--- a/src/crystalizer.cpp
+++ b/src/crystalizer.cpp
@@ -150,7 +150,7 @@ void Crystalizer::process(std::span<float>& left_in,
 
     enhance_peaks(left_out, right_out);
   } else {
-    for (size_t j = 0U, li_size = left_in.size(); j < li_size; j++) {
+    for (size_t j = 0U; j < left_in.size(); j++) {
       data_L.push_back(left_in[j]);
       data_R.push_back(right_in[j]);
 
@@ -193,7 +193,7 @@ void Crystalizer::process(std::span<float>& left_in,
         notify_latency = true;
       }
 
-      for (uint n = 0U, lo_size = left_out.size(); !deque_out_L.empty() && n < lo_size; n++) {
+      for (uint n = 0U; !deque_out_L.empty() && n < left_out.size(); n++) {
         if (n < offset) {
           left_out[n] = 0.0F;
           right_out[n] = 0.0F;

--- a/src/crystalizer_ui.cpp
+++ b/src/crystalizer_ui.cpp
@@ -87,7 +87,7 @@ void CrystalizerUi::build_bands(const int& nbands) {
 
     // connections
 
-    connections.emplace_back(band_mute->signal_toggled().connect([=]() {
+    connections.push_back(band_mute->signal_toggled().connect([=]() {
       if (band_mute->get_active()) {
         band_intensity->set_sensitive(false);
       } else {

--- a/src/echo_canceller.cpp
+++ b/src/echo_canceller.cpp
@@ -99,7 +99,7 @@ void EchoCanceller::process(std::span<float>& left_in,
     apply_gain(left_in, right_in, input_gain);
   }
 
-  for (size_t j = 0U, li_size = left_in.size(); j < li_size; j++) {
+  for (size_t j = 0U; j < left_in.size(); j++) {
     data_L.push_back(left_in[j] * (SHRT_MAX + 1));
     data_R.push_back(right_in[j] * (SHRT_MAX + 1));
 

--- a/src/echo_canceller.cpp
+++ b/src/echo_canceller.cpp
@@ -100,22 +100,22 @@ void EchoCanceller::process(std::span<float>& left_in,
   }
 
   for (size_t j = 0U, li_size = left_in.size(); j < li_size; j++) {
-    data_L.emplace_back(left_in[j] * (SHRT_MAX + 1));
-    data_R.emplace_back(right_in[j] * (SHRT_MAX + 1));
+    data_L.push_back(left_in[j] * (SHRT_MAX + 1));
+    data_R.push_back(right_in[j] * (SHRT_MAX + 1));
 
-    probe_L.emplace_back(probe_left[j] * (SHRT_MAX + 1));
-    probe_R.emplace_back(probe_right[j] * (SHRT_MAX + 1));
+    probe_L.push_back(probe_left[j] * (SHRT_MAX + 1));
+    probe_R.push_back(probe_right[j] * (SHRT_MAX + 1));
 
     if (data_L.size() == blocksize) {
       speex_echo_cancellation(echo_state_L, data_L.data(), probe_L.data(), filtered_L.data());
       speex_echo_cancellation(echo_state_R, data_R.data(), probe_R.data(), filtered_R.data());
 
       for (const auto& v : filtered_L) {
-        deque_out_L.emplace_back(static_cast<float>(v) * inv_short_max);
+        deque_out_L.push_back(static_cast<float>(v) * inv_short_max);
       }
 
       for (const auto& v : filtered_R) {
-        deque_out_R.emplace_back(static_cast<float>(v) * inv_short_max);
+        deque_out_R.push_back(static_cast<float>(v) * inv_short_max);
       }
 
       data_L.resize(0);

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -1070,12 +1070,10 @@ void EffectsBaseUi::setup_listview_plugins() {
         return;
       }
 
-      const auto& list_size = list.size();
-
       static const auto limiter_plugins = {plugin_name::limiter, plugin_name::maximizer};
 
-      if (list_size > 0U && std::any_of(limiter_plugins.begin(), limiter_plugins.end(),
-                                        [&](const auto& str) { return str == list.at(list_size - 1); })) {
+      if (list.size() > 0U && std::any_of(limiter_plugins.begin(), limiter_plugins.end(),
+                                          [&](const auto& str) { return str == list.at(list.size() - 1U); })) {
         // If the user is careful protecting his/her device with a plugin of
         // type limiter at the last position of the filter chain, we follow
         // this behaviour inserting the new plugin at the second last position
@@ -1145,7 +1143,7 @@ void EffectsBaseUi::setup_listview_selected_plugins() {
           }
         }
       } else {
-        for (size_t m = 0U, list_size = list.size(); m < list_size; m++) {
+        for (size_t m = 0U; m < list.size(); m++) {
           if (list[m] == visible_page_name) {
             listview_selected_plugins->get_model()->select_item(m, true);
 

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -181,7 +181,7 @@ EffectsBaseUi::EffectsBaseUi(const Glib::RefPtr<Gtk::Builder>& builder,
   effects_base->spectrum->post_messages = true;
   effects_base->stereo_tools->post_messages = true;
 
-  connections.emplace_back(effects_base->pipeline_latency.connect([=, this](const auto& v) {
+  connections.push_back(effects_base->pipeline_latency.connect([=, this](const auto& v) {
     const auto& lv = Glib::ustring::format(std::setprecision(1), std::fixed, v);
 
     latency_status->set_text(lv + " ms" + Glib::ustring(5, ' '));
@@ -1080,9 +1080,9 @@ void EffectsBaseUi::setup_listview_plugins() {
         // type limiter at the last position of the filter chain, we follow
         // this behaviour inserting the new plugin at the second last position
 
-        list.emplace(list.cend() - 1U, key_name);
+        list.insert(list.cend() - 1U, key_name);
       } else {
-        list.emplace_back(key_name);
+        list.push_back(key_name);
       }
 
       settings->set_string_array("plugins", list);
@@ -1488,7 +1488,7 @@ auto EffectsBaseUi::add_new_blocklist_entry(const Glib::ustring& name) -> bool {
     return false;
   }
 
-  bl.emplace_back(name);
+  bl.push_back(name);
 
   settings->set_string_array("blocklist", bl);
 

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -1417,7 +1417,7 @@ auto EffectsBaseUi::node_state_to_ustring(const pw_node_state& state) -> Glib::u
 
 auto EffectsBaseUi::get_app_icon_name(const NodeInfo& node_info) -> Glib::ustring {
   // map to handle cases where PipeWire does not set icon name string or app name equal to icon name.
-  static std::map<Glib::ustring, Glib::ustring> icon_map{
+  static const std::map<Glib::ustring, Glib::ustring> icon_map{
       {"chromium-browser", "chromium"}, {"firefox", "firefox"}, {"obs", "com.obsproject.Studio"}};
 
   Glib::ustring icon_name;
@@ -1446,7 +1446,7 @@ auto EffectsBaseUi::icon_available(const Glib::ustring& icon_name) -> bool {
   // the icon object can't loopup icons in pixmaps directories,
   // so we check their existence there also
 
-  static auto pixmaps_dirs = {"/usr/share/pixmaps", "/usr/local/share/pixmaps"};
+  static const auto pixmaps_dirs = {"/usr/share/pixmaps", "/usr/local/share/pixmaps"};
 
   for (const auto& dir : pixmaps_dirs) {
     try {

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -247,7 +247,7 @@ EqualizerUi::EqualizerUi(BaseObjectType* cobject,
 
   import_apo->signal_clicked().connect(sigc::mem_fun(*this, &EqualizerUi::on_import_apo_preset_clicked));
 
-  connections.emplace_back(settings->signal_changed("split-channels").connect([=, this](const auto& sc) {
+  connections.push_back(settings->signal_changed("split-channels").connect([=, this](const auto& sc) {
     stack->set_visible_child("page_left_channel");
 
     on_nbands_changed();
@@ -381,19 +381,19 @@ void EqualizerUi::build_bands(Gtk::Box* bands_box,
 
     // connections
 
-    connections_bands.emplace_back(band_frequency->signal_value_changed().connect(update_quality_width));
+    connections_bands.push_back(band_frequency->signal_value_changed().connect(update_quality_width));
 
-    connections_bands.emplace_back(band_frequency->signal_value_changed().connect(update_band_label));
+    connections_bands.push_back(band_frequency->signal_value_changed().connect(update_band_label));
 
-    connections_bands.emplace_back(band_quality->signal_value_changed().connect(update_quality_width));
+    connections_bands.push_back(band_quality->signal_value_changed().connect(update_quality_width));
 
     if (split_mode) {
       // split channels mode
 
-      connections_bands.emplace_back(
+      connections_bands.push_back(
           reset_frequency->signal_clicked().connect([=]() { cfg->reset(bandn + "-frequency"); }));
 
-      connections_bands.emplace_back(reset_quality->signal_clicked().connect([=]() { cfg->reset(bandn + "-q"); }));
+      connections_bands.push_back(reset_quality->signal_clicked().connect([=]() { cfg->reset(bandn + "-q"); }));
     } else {
       // unified mode
 
@@ -402,46 +402,46 @@ void EqualizerUi::build_bands(Gtk::Box* bands_box,
          They have to be done before the bindings for the left channel.
        */
 
-      connections_bands.emplace_back(band_scale->signal_value_changed().connect(
+      connections_bands.push_back(band_scale->signal_value_changed().connect(
           [=, this]() { settings_right->set_double(bandn + "-gain", band_scale->get_value()); }));
 
-      connections_bands.emplace_back(band_frequency->signal_value_changed().connect(
+      connections_bands.push_back(band_frequency->signal_value_changed().connect(
           [=, this]() { settings_right->set_double(bandn + "-frequency", band_frequency->get_value()); }));
 
-      connections_bands.emplace_back(band_quality->signal_value_changed().connect(
+      connections_bands.push_back(band_quality->signal_value_changed().connect(
           [=, this]() { settings_right->set_double(bandn + "-q", band_quality->get_value()); }));
 
-      connections_bands.emplace_back(band_type->signal_changed().connect(
+      connections_bands.push_back(band_type->signal_changed().connect(
           [=, this]() { settings_right->set_enum(bandn + "-type", band_type->get_active_row_number()); }));
 
-      connections_bands.emplace_back(band_mode->signal_changed().connect(
+      connections_bands.push_back(band_mode->signal_changed().connect(
           [=, this]() { settings_right->set_enum(bandn + "-mode", band_mode->get_active_row_number()); }));
 
-      connections_bands.emplace_back(band_slope->signal_changed().connect(
+      connections_bands.push_back(band_slope->signal_changed().connect(
           [=, this]() { settings_right->set_enum(bandn + "-slope", band_slope->get_active_row_number()); }));
 
-      connections_bands.emplace_back(band_solo->signal_toggled().connect(
+      connections_bands.push_back(band_solo->signal_toggled().connect(
           [=, this]() { settings_right->set_boolean(bandn + "-solo", band_solo->get_active()); }));
 
-      connections_bands.emplace_back(band_mute->signal_toggled().connect(
+      connections_bands.push_back(band_mute->signal_toggled().connect(
           [=, this]() { settings_right->set_boolean(bandn + "-mute", band_mute->get_active()); }));
 
       // Left channel
 
-      connections_bands.emplace_back(reset_frequency->signal_clicked().connect([=, this]() {
+      connections_bands.push_back(reset_frequency->signal_clicked().connect([=, this]() {
         settings_left->reset(bandn + "-frequency");
 
         settings_right->reset(bandn + "-frequency");
       }));
 
-      connections_bands.emplace_back(reset_quality->signal_clicked().connect([=, this]() {
+      connections_bands.push_back(reset_quality->signal_clicked().connect([=, this]() {
         settings_left->reset(bandn + "-q");
 
         settings_right->reset(bandn + "-q");
       }));
     }
 
-    connections_bands.emplace_back(band_type->signal_changed().connect([=]() {
+    connections_bands.push_back(band_type->signal_changed().connect([=]() {
       // disable gain scale if type is "Off", "Hi-pass" or "Lo-pass"
 
       const auto& row = band_type->get_active_row_number();

--- a/src/fir_filter_bandpass.cpp
+++ b/src/fir_filter_bandpass.cpp
@@ -40,7 +40,7 @@ void FirFilterBandpass::setup() {
     Creating a bandpass from a band reject through spectral inversion https://www.dspguide.com/ch16/4.htm
   */
 
-  for (size_t n = 0U, k_size = kernel.size(); n < k_size; n++) {
+  for (size_t n = 0U; n < kernel.size(); n++) {
     kernel[n] = lowpass_kernel[n] + highpass_kernel[n];
   }
 

--- a/src/fir_filter_base.cpp
+++ b/src/fir_filter_base.cpp
@@ -98,7 +98,7 @@ auto FirFilterBase::create_lowpass_kernel(const float& cutoff, const float& tran
 
   float sum = 0.0F;
 
-  for (size_t n = 0U, output_size = output.size(); n < output_size; n++) {
+  for (size_t n = 0U; n < output.size(); n++) {
     /*
       windowed-sinc kernel https://www.dspguide.com/ch16/1.htm
     */

--- a/src/multiband_compressor_ui.cpp
+++ b/src/multiband_compressor_ui.cpp
@@ -267,7 +267,8 @@ void MultibandCompressorUi::prepare_bands() {
   for (uint n = 0U; n < n_bands; n++) {
     const auto& nstr = std::to_string(n);
 
-    const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/multiband_compressor_band.ui");
+    const auto& builder =
+        Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/multiband_compressor_band.ui");
 
     if (n > 0U) {
       auto* const split_frequency = builder->get_widget<Gtk::SpinButton>("split_frequency");
@@ -524,25 +525,25 @@ void MultibandCompressorUi::reset() {
 }
 
 void MultibandCompressorUi::on_new_frequency_range(const std::array<float, n_bands>& values) {
-  for (size_t n = 0U, m = values.size(); n < m; n++) {
+  for (size_t n = 0U; n < values.size(); n++) {
     bands_end.at(n)->set_text(level_to_localized_string(values.at(n), 0));
   }
 }
 
 void MultibandCompressorUi::on_new_envelope(const std::array<float, n_bands>& values) {
-  for (size_t n = 0U, m = values.size(); n < m; n++) {
+  for (size_t n = 0U; n < values.size(); n++) {
     bands_envelope_label.at(n)->set_text(level_to_localized_string(util::linear_to_db(values.at(n)), 0));
   }
 }
 
 void MultibandCompressorUi::on_new_curve(const std::array<float, n_bands>& values) {
-  for (size_t n = 0U, m = values.size(); n < m; n++) {
+  for (size_t n = 0U; n < values.size(); n++) {
     bands_curve_label.at(n)->set_text(level_to_localized_string(util::linear_to_db(values.at(n)), 0));
   }
 }
 
 void MultibandCompressorUi::on_new_reduction(const std::array<float, n_bands>& values) {
-  for (size_t n = 0U, m = values.size(); n < m; n++) {
+  for (size_t n = 0U; n < values.size(); n++) {
     bands_gain_label.at(n)->set_text(level_to_localized_string(util::linear_to_db(values.at(n)), 0));
   }
 }

--- a/src/pipe_info_ui.cpp
+++ b/src/pipe_info_ui.cpp
@@ -334,7 +334,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
   soe_settings->bind("use-default-output-device", dropdown_output_devices, "sensitive",
                      Gio::Settings::BindFlags::INVERT_BOOLEAN);
 
-  connections.emplace_back(pm->sink_added.connect([=, this](const NodeInfo info) {
+  connections.push_back(pm->sink_added.connect([=, this](const NodeInfo info) {
     for (guint n = 0U, m = output_devices_model->get_n_items(); n < m; n++) {
       if (output_devices_model->get_item(n)->id == info.id) {
         return;
@@ -344,7 +344,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
     output_devices_model->append(NodeInfoHolder::create(info));
   }));
 
-  connections.emplace_back(pm->sink_removed.connect([=, this](const NodeInfo info) {
+  connections.push_back(pm->sink_removed.connect([=, this](const NodeInfo info) {
     for (guint n = 0U, m = output_devices_model->get_n_items(); n < m; n++) {
       if (output_devices_model->get_item(n)->id == info.id) {
         output_devices_model->remove(n);
@@ -354,7 +354,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
     }
   }));
 
-  connections.emplace_back(pm->source_added.connect([=, this](const NodeInfo info) {
+  connections.push_back(pm->source_added.connect([=, this](const NodeInfo info) {
     for (guint n = 0U, m = input_devices_model->get_n_items(); n < m; n++) {
       if (input_devices_model->get_item(n)->id == info.id) {
         return;
@@ -364,7 +364,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
     input_devices_model->append(NodeInfoHolder::create(info));
   }));
 
-  connections.emplace_back(pm->source_removed.connect([=, this](const NodeInfo info) {
+  connections.push_back(pm->source_removed.connect([=, this](const NodeInfo info) {
     for (guint n = 0U, m = input_devices_model->get_n_items(); n < m; n++) {
       if (input_devices_model->get_item(n)->id == info.id) {
         input_devices_model->remove(n);
@@ -374,7 +374,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
     }
   }));
 
-  connections.emplace_back(
+  connections.push_back(
       presets_manager->user_output_preset_created.connect([=, this](const Glib::RefPtr<Gio::File>& file) {
         const auto& preset_name = util::remove_filename_extension(file->get_basename());
 
@@ -393,7 +393,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
         output_presets_string_list->append(preset_name);
       }));
 
-  connections.emplace_back(
+  connections.push_back(
       presets_manager->user_output_preset_removed.connect([=, this](const Glib::RefPtr<Gio::File>& file) {
         const auto& preset_name = util::remove_filename_extension(file->get_basename());
 
@@ -412,7 +412,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
         }
       }));
 
-  connections.emplace_back(
+  connections.push_back(
       presets_manager->user_input_preset_created.connect([=, this](const Glib::RefPtr<Gio::File>& file) {
         const auto& preset_name = util::remove_filename_extension(file->get_basename());
 
@@ -431,7 +431,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
         input_presets_string_list->append(preset_name);
       }));
 
-  connections.emplace_back(
+  connections.push_back(
       presets_manager->user_input_preset_removed.connect([=, this](const Glib::RefPtr<Gio::File>& file) {
         const auto& preset_name = util::remove_filename_extension(file->get_basename());
 
@@ -450,7 +450,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
         }
       }));
 
-  connections.emplace_back(
+  connections.push_back(
       presets_manager->autoload_output_profiles_changed.connect([=, this](const std::vector<nlohmann::json>& profiles) {
         std::vector<Glib::RefPtr<PresetsAutoloadingHolder>> list;
 
@@ -459,13 +459,13 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
           const auto& device_profile = json.value("device-profile", "");
           const auto& preset_name = json.value("preset-name", "");
 
-          list.emplace_back(PresetsAutoloadingHolder::create(device, device_profile, preset_name));
+          list.push_back(PresetsAutoloadingHolder::create(device, device_profile, preset_name));
         }
 
         autoloading_output_model->splice(0, autoloading_output_model->get_n_items(), list);
       }));
 
-  connections.emplace_back(
+  connections.push_back(
       presets_manager->autoload_input_profiles_changed.connect([=, this](const std::vector<nlohmann::json>& profiles) {
         std::vector<Glib::RefPtr<PresetsAutoloadingHolder>> list;
 
@@ -474,7 +474,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
           const auto& device_profile = json.value("device-profile", "");
           const auto& preset_name = json.value("preset-name", "");
 
-          list.emplace_back(PresetsAutoloadingHolder::create(device, device_profile, preset_name));
+          list.push_back(PresetsAutoloadingHolder::create(device, device_profile, preset_name));
         }
 
         autoloading_input_model->splice(0, autoloading_input_model->get_n_items(), list);
@@ -776,7 +776,7 @@ void PipeInfoUi::update_modules_info() {
   std::vector<Glib::RefPtr<ModuleInfoHolder>> values;
 
   for (const auto& info : pm->list_modules) {
-    values.emplace_back(ModuleInfoHolder::create(info));
+    values.push_back(ModuleInfoHolder::create(info));
   }
 
   modules_model->splice(0, modules_model->get_n_items(), values);
@@ -786,7 +786,7 @@ void PipeInfoUi::update_clients_info() {
   std::vector<Glib::RefPtr<ClientInfoHolder>> values;
 
   for (const auto& info : pm->list_clients) {
-    values.emplace_back(ClientInfoHolder::create(info));
+    values.push_back(ClientInfoHolder::create(info));
   }
 
   clients_model->splice(0, clients_model->get_n_items(), values);

--- a/src/pipe_info_ui.cpp
+++ b/src/pipe_info_ui.cpp
@@ -130,7 +130,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
       const auto* input_device_name = sie_settings->get_string("input-device").c_str();
 
       if (holder_selected->name != input_device_name) {
-        for (guint n = 0U, m = input_devices_model->get_n_items(); n < m; n++) {
+        for (guint n = 0U; n < input_devices_model->get_n_items(); n++) {
           if (input_devices_model->get_item(n)->name == input_device_name) {
             dropdown_input_devices->set_selected(n);
           }
@@ -146,7 +146,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
       const auto* output_device_name = soe_settings->get_string("output-device").c_str();
 
       if (holder_selected->name != output_device_name) {
-        for (guint n = 0U, m = output_devices_model->get_n_items(); n < m; n++) {
+        for (guint n = 0U; n < output_devices_model->get_n_items(); n++) {
           if (output_devices_model->get_item(n)->name == output_device_name) {
             dropdown_output_devices->set_selected(n);
           }
@@ -165,7 +165,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
 
       if (holder != nullptr) {
         if (holder->name != pm->default_input_device.name) {
-          for (guint n = 0U, m = input_devices_model->get_n_items(); n < m; n++) {
+          for (guint n = 0U; n < input_devices_model->get_n_items(); n++) {
             if (input_devices_model->get_item(n)->name == pm->default_input_device.name) {
               dropdown_input_devices->set_selected(n);
 
@@ -185,7 +185,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
 
       if (holder_selected != nullptr) {
         if (holder_selected->name != pm->default_output_device.name) {
-          for (guint n = 0U, m = output_devices_model->get_n_items(); n < m; n++) {
+          for (guint n = 0U; n < output_devices_model->get_n_items(); n++) {
             if (output_devices_model->get_item(n)->name == pm->default_output_device.name) {
               dropdown_output_devices->set_selected(n);
 
@@ -335,7 +335,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
                      Gio::Settings::BindFlags::INVERT_BOOLEAN);
 
   connections.push_back(pm->sink_added.connect([=, this](const NodeInfo info) {
-    for (guint n = 0U, m = output_devices_model->get_n_items(); n < m; n++) {
+    for (guint n = 0U; n < output_devices_model->get_n_items(); n++) {
       if (output_devices_model->get_item(n)->id == info.id) {
         return;
       }
@@ -345,7 +345,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
   }));
 
   connections.push_back(pm->sink_removed.connect([=, this](const NodeInfo info) {
-    for (guint n = 0U, m = output_devices_model->get_n_items(); n < m; n++) {
+    for (guint n = 0U; n < output_devices_model->get_n_items(); n++) {
       if (output_devices_model->get_item(n)->id == info.id) {
         output_devices_model->remove(n);
 
@@ -355,7 +355,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
   }));
 
   connections.push_back(pm->source_added.connect([=, this](const NodeInfo info) {
-    for (guint n = 0U, m = input_devices_model->get_n_items(); n < m; n++) {
+    for (guint n = 0U; n < input_devices_model->get_n_items(); n++) {
       if (input_devices_model->get_item(n)->id == info.id) {
         return;
       }
@@ -365,7 +365,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
   }));
 
   connections.push_back(pm->source_removed.connect([=, this](const NodeInfo info) {
-    for (guint n = 0U, m = input_devices_model->get_n_items(); n < m; n++) {
+    for (guint n = 0U; n < input_devices_model->get_n_items(); n++) {
       if (input_devices_model->get_item(n)->id == info.id) {
         input_devices_model->remove(n);
 
@@ -384,7 +384,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
           return;
         }
 
-        for (guint n = 0, list_size = output_presets_string_list->get_n_items(); n < list_size; n++) {
+        for (guint n = 0; n < output_presets_string_list->get_n_items(); n++) {
           if (output_presets_string_list->get_string(n) == preset_name) {
             return;
           }
@@ -403,7 +403,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
           return;
         }
 
-        for (guint n = 0, list_size = output_presets_string_list->get_n_items(); n < list_size; n++) {
+        for (guint n = 0; n < output_presets_string_list->get_n_items(); n++) {
           if (output_presets_string_list->get_string(n) == preset_name) {
             output_presets_string_list->remove(n);
 
@@ -422,7 +422,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
           return;
         }
 
-        for (guint n = 0, list_size = input_presets_string_list->get_n_items(); n < list_size; n++) {
+        for (guint n = 0; n < input_presets_string_list->get_n_items(); n++) {
           if (input_presets_string_list->get_string(n) == preset_name) {
             return;
           }
@@ -441,7 +441,7 @@ PipeInfoUi::PipeInfoUi(BaseObjectType* cobject,
           return;
         }
 
-        for (guint n = 0, list_size = input_presets_string_list->get_n_items(); n < list_size; n++) {
+        for (guint n = 0; n < input_presets_string_list->get_n_items(); n++) {
           if (input_presets_string_list->get_string(n) == preset_name) {
             input_presets_string_list->remove(n);
 

--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -964,7 +964,7 @@ void on_registry_global(void* data,
 
     link_info.id = id;
 
-    pm->list_links.emplace_back(link_info);
+    pm->list_links.push_back(link_info);
 
     try {
       const auto& input_node = pm->node_map_at_id(link_info.input_node_id);
@@ -997,7 +997,7 @@ void on_registry_global(void* data,
     // std::cout << port_info.name << "\t" << port_info.audio_channel << "\t" << port_info.direction << "\t"
     //           << port_info.format_dsp << "\t" << port_info.port_id << "\t" << port_info.node_id << std::endl;
 
-    pm->list_ports.emplace_back(port_info);
+    pm->list_ports.push_back(port_info);
 
     return;
   }
@@ -1021,7 +1021,7 @@ void on_registry_global(void* data,
       m_info.name = name;
     }
 
-    pm->list_modules.emplace_back(m_info);
+    pm->list_modules.push_back(m_info);
 
     return;
   }
@@ -1041,7 +1041,7 @@ void on_registry_global(void* data,
 
     ClientInfo c_info{.id = id};
 
-    pm->list_clients.emplace_back(c_info);
+    pm->list_clients.push_back(c_info);
 
     return;
   }
@@ -1087,7 +1087,7 @@ void on_registry_global(void* data,
 
         DeviceInfo d_info{.id = id, .media_class = media_class};
 
-        pm->list_devices.emplace_back(d_info);
+        pm->list_devices.push_back(d_info);
       }
     }
 
@@ -1371,7 +1371,7 @@ auto PipeManager::link_nodes(const uint& output_node_id,
 
   for (const auto& port : list_ports) {
     if (port.node_id == output_node_id && port.direction == "out") {
-      list_output_ports.emplace_back(port);
+      list_output_ports.push_back(port);
 
       if (!probe_link) {
         if (port.audio_channel != "FL" && port.audio_channel != "FR") {
@@ -1382,14 +1382,14 @@ auto PipeManager::link_nodes(const uint& output_node_id,
 
     if (port.node_id == input_node_id && port.direction == "in") {
       if (!probe_link) {
-        list_input_ports.emplace_back(port);
+        list_input_ports.push_back(port);
 
         if (port.audio_channel != "FL" && port.audio_channel != "FR") {
           use_audio_channel = false;
         }
       } else {
         if (port.audio_channel == "PROBE_FL" || port.audio_channel == "PROBE_FR") {
-          list_input_ports.emplace_back(port);
+          list_input_ports.push_back(port);
         }
       }
     }
@@ -1441,7 +1441,7 @@ auto PipeManager::link_nodes(const uint& output_node_id,
 
         sync_wait_unlock();
 
-        list.emplace_back(proxy);
+        list.push_back(proxy);
       }
     }
   }

--- a/src/pitch.cpp
+++ b/src/pitch.cpp
@@ -156,8 +156,8 @@ void Pitch::process(std::span<float>& left_in,
     stretcher->retrieve(stretcher_out.data(), n_available);
 
     for (int n = 0; n < n_available; n++) {
-      deque_out_L.emplace_back(data_L[n]);
-      deque_out_R.emplace_back(data_R[n]);
+      deque_out_L.push_back(data_L[n]);
+      deque_out_R.push_back(data_R[n]);
     }
   }
 

--- a/src/pitch.cpp
+++ b/src/pitch.cpp
@@ -182,7 +182,7 @@ void Pitch::process(std::span<float>& left_in,
       notify_latency = true;
     }
 
-    for (uint n = 0U, m = left_out.size(); !deque_out_L.empty() && n < m; n++) {
+    for (uint n = 0U; !deque_out_L.empty() && n < left_out.size(); n++) {
       if (n < offset) {
         left_out[n] = 0.0F;
         right_out[n] = 0.0F;

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -96,13 +96,13 @@ void Plot::init_axes() {
 
   for (const auto& v : original_x) {
     if (v >= x_min && v <= x_max) {
-      x_axis.emplace_back(v);
+      x_axis.push_back(v);
     }
   }
 
   for (const auto& v : original_y) {
     if (v >= y_min && v <= y_max) {
-      y_axis.emplace_back(v);
+      y_axis.push_back(v);
     }
   }
 

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -258,7 +258,7 @@ auto Plot::draw_x_labels(const Cairo::RefPtr<Cairo::Context>& ctx, const int& wi
     would start to be drawn at the border of the window.
   */
 
-  for (size_t n = 0U, m = labels.size(); n < m - 1U; n++) {
+  for (size_t n = 0U; n < labels.size() - 1U; n++) {
     const auto& msg = Glib::ustring::format(std::setprecision(n_x_decimals), std::fixed, labels[n]) + " " + x_unit;
 
     Pango::FontDescription font;
@@ -276,7 +276,7 @@ auto Plot::draw_x_labels(const Cairo::RefPtr<Cairo::Context>& ctx, const int& wi
 
     layout->show_in_cairo_context(ctx);
 
-    if (n == m - 2U) {
+    if (n == labels.size() - 2U) {
       return text_height;
     }
   }

--- a/src/plugin_base.cpp
+++ b/src/plugin_base.cpp
@@ -82,7 +82,7 @@ PluginBase::PluginBase(std::string tag,
       pm(pipe_manager) {
   pf_data.pb = this;
 
-  const auto& filter_name = "pe_" + log_tag.substr(0, log_tag.size() - 2) + "_" + name;
+  const auto& filter_name = "pe_" + log_tag.substr(0, log_tag.size() - 2U) + "_" + name;
 
   pm->lock();
 

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -54,13 +54,13 @@ PresetsManager::PresetsManager()
   // system presets directories provided by Glib
 
   for (const auto& scd : Glib::get_system_config_dirs()) {
-    system_input_dir.emplace_back(scd + "/easyeffects/input");
-    system_output_dir.emplace_back(scd + "/easyeffects/output");
+    system_input_dir.push_back(scd + "/easyeffects/input");
+    system_output_dir.push_back(scd + "/easyeffects/output");
   }
 
   // add "/etc" to system config folders array and remove duplicates
-  system_input_dir.emplace_back("/etc/easyeffects/input");
-  system_output_dir.emplace_back("/etc/easyeffects/output");
+  system_input_dir.push_back("/etc/easyeffects/input");
+  system_output_dir.push_back("/etc/easyeffects/output");
   std::sort(system_input_dir.begin(), system_input_dir.end());
   std::sort(system_output_dir.begin(), system_output_dir.end());
   system_input_dir.erase(std::unique(system_input_dir.begin(), system_input_dir.end()), system_input_dir.end());
@@ -227,7 +227,7 @@ auto PresetsManager::search_names(std::filesystem::directory_iterator& it) -> st
     while (it != std::filesystem::directory_iterator{}) {
       if (std::filesystem::is_regular_file(it->status())) {
         if (it->path().extension().c_str() == json_ext) {
-          names.emplace_back(it->path().stem().c_str());
+          names.push_back(it->path().stem().c_str());
         }
       }
 
@@ -256,7 +256,7 @@ void PresetsManager::save_blocklist(const PresetType& preset_type, nlohmann::jso
   switch (preset_type) {
     case PresetType::output: {
       for (const auto& l : soe_settings->get_string_array("blocklist")) {
-        blocklist.emplace_back(l.c_str());
+        blocklist.push_back(l.c_str());
       }
 
       json["output"]["blocklist"] = blocklist;
@@ -265,7 +265,7 @@ void PresetsManager::save_blocklist(const PresetType& preset_type, nlohmann::jso
     }
     case PresetType::input: {
       for (const auto& l : sie_settings->get_string_array("blocklist")) {
-        blocklist.emplace_back(l.c_str());
+        blocklist.push_back(l.c_str());
       }
 
       json["input"]["blocklist"] = blocklist;
@@ -282,7 +282,7 @@ void PresetsManager::load_blocklist(const PresetType& preset_type, const nlohman
     case PresetType::input: {
       try {
         for (const auto& l : json.at("input").at("blocklist").get<std::vector<std::string>>()) {
-          blocklist.emplace_back(l);
+          blocklist.push_back(l);
         }
 
         sie_settings->set_string_array("blocklist", blocklist);
@@ -297,7 +297,7 @@ void PresetsManager::load_blocklist(const PresetType& preset_type, const nlohman
     case PresetType::output: {
       try {
         for (const auto& l : json.at("output").at("blocklist").get<std::vector<std::string>>()) {
-          blocklist.emplace_back(l);
+          blocklist.push_back(l);
         }
 
         soe_settings->set_string_array("blocklist", blocklist);
@@ -328,7 +328,7 @@ void PresetsManager::save_preset_file(const PresetType& preset_type, const Glib:
       list.reserve(plugins.size());
 
       for (const auto& p : plugins) {
-        list.emplace_back(p.raw());
+        list.push_back(p.raw());
       }
 
       json["output"]["plugins_order"] = list;
@@ -347,7 +347,7 @@ void PresetsManager::save_preset_file(const PresetType& preset_type, const Glib:
       list.reserve(plugins.size());
 
       for (const auto& p : plugins) {
-        list.emplace_back(p.raw());
+        list.push_back(p.raw());
       }
 
       json["input"]["plugins_order"] = list;
@@ -450,7 +450,7 @@ void PresetsManager::load_preset_file(const PresetType& preset_type, const Glib:
 
   switch (preset_type) {
     case PresetType::output: {
-      conf_dirs.emplace_back(user_output_dir);
+      conf_dirs.push_back(user_output_dir);
 
       conf_dirs.insert(conf_dirs.end(), system_output_dir.begin(), system_output_dir.end());
 
@@ -473,7 +473,7 @@ void PresetsManager::load_preset_file(const PresetType& preset_type, const Glib:
           for (const auto& p : json.at("output").at("plugins_order").get<std::vector<std::string>>()) {
             for (const auto& v : plugin_name::list) {
               if (v == p) {
-                plugins.emplace_back(p);
+                plugins.push_back(p);
 
                 break;
               }
@@ -494,7 +494,7 @@ void PresetsManager::load_preset_file(const PresetType& preset_type, const Glib:
       break;
     }
     case PresetType::input: {
-      conf_dirs.emplace_back(user_input_dir);
+      conf_dirs.push_back(user_input_dir);
 
       conf_dirs.insert(conf_dirs.end(), system_input_dir.begin(), system_input_dir.end());
 
@@ -517,7 +517,7 @@ void PresetsManager::load_preset_file(const PresetType& preset_type, const Glib:
           for (const auto& p : json.at("input").at("plugins_order").get<std::vector<std::string>>()) {
             for (const auto& v : plugin_name::list) {
               if (v == p) {
-                plugins.emplace_back(p);
+                plugins.push_back(p);
 
                 break;
               }
@@ -752,7 +752,7 @@ auto PresetsManager::get_autoload_profiles(const PresetType& preset_type) -> std
 
           is >> json;
 
-          list.emplace_back(json);
+          list.push_back(json);
         }
       }
 
@@ -773,7 +773,7 @@ auto PresetsManager::preset_file_exists(const PresetType& preset_type, const Gli
 
   switch (preset_type) {
     case PresetType::output: {
-      conf_dirs.emplace_back(user_output_dir);
+      conf_dirs.push_back(user_output_dir);
 
       conf_dirs.insert(conf_dirs.end(), system_output_dir.begin(), system_output_dir.end());
 
@@ -788,7 +788,7 @@ auto PresetsManager::preset_file_exists(const PresetType& preset_type, const Gli
       break;
     }
     case PresetType::input: {
-      conf_dirs.emplace_back(user_input_dir);
+      conf_dirs.push_back(user_input_dir);
 
       conf_dirs.insert(conf_dirs.end(), system_input_dir.begin(), system_input_dir.end());
 

--- a/src/presets_menu_ui.cpp
+++ b/src/presets_menu_ui.cpp
@@ -100,7 +100,7 @@ PresetsMenuUi::PresetsMenuUi(BaseObjectType* cobject,
       return;
     }
 
-    for (guint n = 0, list_size = output_string_list->get_n_items(); n < list_size; n++) {
+    for (guint n = 0; n < output_string_list->get_n_items(); n++) {
       if (preset_name == output_string_list->get_string(n)) {
         return;
       }
@@ -118,7 +118,7 @@ PresetsMenuUi::PresetsMenuUi(BaseObjectType* cobject,
       return;
     }
 
-    for (guint n = 0, list_size = output_string_list->get_n_items(); n < list_size; n++) {
+    for (guint n = 0; n < output_string_list->get_n_items(); n++) {
       if (preset_name == output_string_list->get_string(n)) {
         output_string_list->remove(n);
 
@@ -136,7 +136,7 @@ PresetsMenuUi::PresetsMenuUi(BaseObjectType* cobject,
       return;
     }
 
-    for (guint n = 0, list_size = input_string_list->get_n_items(); n < list_size; n++) {
+    for (guint n = 0; n < input_string_list->get_n_items(); n++) {
       if (input_string_list->get_string(n) == preset_name) {
         return;
       }
@@ -154,7 +154,7 @@ PresetsMenuUi::PresetsMenuUi(BaseObjectType* cobject,
       return;
     }
 
-    for (guint n = 0, list_size = input_string_list->get_n_items(); n < list_size; n++) {
+    for (guint n = 0; n < input_string_list->get_n_items(); n++) {
       if (input_string_list->get_string(n) == preset_name) {
         input_string_list->remove(n);
 

--- a/src/rnnoise.cpp
+++ b/src/rnnoise.cpp
@@ -167,7 +167,7 @@ void RNNoise::process(std::span<float>& left_in,
       notify_latency = true;
     }
 
-    for (uint n = 0U, m = left_out.size(); !deque_out_L.empty() && n < m; n++) {
+    for (uint n = 0U; !deque_out_L.empty() && n < left_out.size(); n++) {
       if (n < offset) {
         left_out[n] = 0.0F;
         right_out[n] = 0.0F;

--- a/src/rnnoise.cpp
+++ b/src/rnnoise.cpp
@@ -127,19 +127,19 @@ void RNNoise::process(std::span<float>& left_in,
       auto resampled_outR = resampler_outR->process(resampled_data_R, false);
 
       for (const auto& v : resampled_outL) {
-        deque_out_L.emplace_back(v);
+        deque_out_L.push_back(v);
       }
 
       for (const auto& v : resampled_outR) {
-        deque_out_R.emplace_back(v);
+        deque_out_R.push_back(v);
       }
     } else {
       for (const auto& v : left_in) {
-        deque_out_L.emplace_back(v);
+        deque_out_L.push_back(v);
       }
 
       for (const auto& v : right_in) {
-        deque_out_R.emplace_back(v);
+        deque_out_R.push_back(v);
       }
     }
   } else {

--- a/src/rnnoise_ui.cpp
+++ b/src/rnnoise_ui.cpp
@@ -46,7 +46,7 @@ RNNoiseUi::RNNoiseUi(BaseObjectType* cobject,
 
   // gsettings bindings
 
-  connections.emplace_back(
+  connections.push_back(
       settings->signal_changed("model-path").connect([=, this](const auto& key) { set_active_model_label(); }));
 
   // model dir
@@ -280,7 +280,7 @@ auto RNNoiseUi::get_model_names() -> std::vector<Glib::ustring> {
   while (it != std::filesystem::directory_iterator{}) {
     if (std::filesystem::is_regular_file(it->status())) {
       if (it->path().extension().c_str() == rnnn_ext) {
-        names.emplace_back(it->path().stem().c_str());
+        names.push_back(it->path().stem().c_str());
       }
     }
 

--- a/src/rnnoise_ui.cpp
+++ b/src/rnnoise_ui.cpp
@@ -81,7 +81,7 @@ RNNoiseUi::RNNoiseUi(BaseObjectType* cobject,
 
         switch (event) {
           case Gio::FileMonitor::Event::CREATED: {
-            for (guint n = 0, list_size = string_list->get_n_items(); n < list_size; n++) {
+            for (guint n = 0; n < string_list->get_n_items(); n++) {
               if (string_list->get_string(n) == rnn_filename) {
                 return;
               }
@@ -92,7 +92,7 @@ RNNoiseUi::RNNoiseUi(BaseObjectType* cobject,
             break;
           }
           case Gio::FileMonitor::Event::DELETED: {
-            for (guint n = 0, list_size = string_list->get_n_items(); n < list_size; n++) {
+            for (guint n = 0; n < string_list->get_n_items(); n++) {
               if (string_list->get_string(n) == rnn_filename) {
                 string_list->remove(n);
 
@@ -121,8 +121,8 @@ RNNoiseUi::~RNNoiseUi() {
 auto RNNoiseUi::add_to_stack(Gtk::Stack* stack, const std::string& schema_path) -> RNNoiseUi* {
   const auto& builder = Gtk::Builder::create_from_resource("/com/github/wwmm/easyeffects/ui/rnnoise.ui");
 
-  auto* const ui = Gtk::Builder::get_widget_derived<RNNoiseUi>(builder, "top_box", "com.github.wwmm.easyeffects.rnnoise",
-                                                         schema_path + "rnnoise/");
+  auto* const ui = Gtk::Builder::get_widget_derived<RNNoiseUi>(
+      builder, "top_box", "com.github.wwmm.easyeffects.rnnoise", schema_path + "rnnoise/");
 
   stack->add(*ui, plugin_name::rnnoise);
 
@@ -216,7 +216,7 @@ void RNNoiseUi::setup_listview() {
 
   auto single = std::dynamic_pointer_cast<Gtk::SingleSelection>(listview->get_model());
 
-  for (guint n = 0U, m = single->get_n_items(); n < m; n++) {
+  for (guint n = 0U; n < single->get_n_items(); n++) {
     if (single->get_object(n)->get_property<Glib::ustring>("string") == saved_name) {
       single->select_item(n, true);
     }

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -69,7 +69,7 @@ void Spectrum::process(std::span<float>& left_in,
 
   uint count = 0U;
 
-  for (uint n = 0U, m = left_in.size(); n < m; n++, count++) {
+  for (uint n = 0U; n < left_in.size(); n++, count++) {
     if (const uint& k = total_count + n; k < real_input.size()) {
       // https://en.wikipedia.org/wiki/Hann_function
 
@@ -89,7 +89,7 @@ void Spectrum::process(std::span<float>& left_in,
 
     fftwf_execute(plan);
 
-    for (uint i = 0U, m = output.size(); i < m; i++) {
+    for (uint i = 0U; i < output.size(); i++) {
       float sqr = complex_output[i][0] * complex_output[i][0] + complex_output[i][1] * complex_output[i][1];
 
       sqr /= static_cast<float>(n_samples * n_samples);

--- a/src/spectrum_settings_ui.cpp
+++ b/src/spectrum_settings_ui.cpp
@@ -90,7 +90,7 @@ SpectrumSettingsUi::SpectrumSettingsUi(BaseObjectType* cobject,
 
   // signals connection
 
-  connections.emplace_back(settings->signal_changed("color").connect([&](const auto& key) {
+  connections.push_back(settings->signal_changed("color").connect([&](const auto& key) {
     Glib::Variant<std::vector<double>> v;
 
     settings->get_value("color", v);

--- a/src/spectrum_ui.cpp
+++ b/src/spectrum_ui.cpp
@@ -25,33 +25,33 @@ SpectrumUi::SpectrumUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>
 
   // signals connection
 
-  connections.emplace_back(settings->signal_changed("color").connect([&](const auto& key) { init_color(); }));
+  connections.push_back(settings->signal_changed("color").connect([&](const auto& key) { init_color(); }));
 
-  connections.emplace_back(
+  connections.push_back(
       settings->signal_changed("color-axis-labels").connect([&](const auto& key) { init_frequency_labels_color(); }));
 
-  connections.emplace_back(settings->signal_changed("height").connect(
+  connections.push_back(settings->signal_changed("height").connect(
       [&](const auto& key) { set_content_height(settings->get_int("height")); }));
 
-  connections.emplace_back(
+  connections.push_back(
       settings->signal_changed("n-points").connect([&](const auto& key) { init_frequency_axis(); }));
 
-  connections.emplace_back(
+  connections.push_back(
       settings->signal_changed("minimum-frequency").connect([&](const auto& key) { init_frequency_axis(); }));
 
-  connections.emplace_back(
+  connections.push_back(
       settings->signal_changed("maximum-frequency").connect([&](const auto& key) { init_frequency_axis(); }));
 
-  connections.emplace_back(settings->signal_changed("type").connect([&](const auto& key) { init_type(); }));
+  connections.push_back(settings->signal_changed("type").connect([&](const auto& key) { init_type(); }));
 
-  connections.emplace_back(settings->signal_changed("fill").connect(
+  connections.push_back(settings->signal_changed("fill").connect(
       [&](const auto& key) { plot->set_fill_bars(settings->get_boolean(key)); }));
 
-  connections.emplace_back(settings->signal_changed("show-bar-border").connect([&](const auto& key) {
+  connections.push_back(settings->signal_changed("show-bar-border").connect([&](const auto& key) {
     plot->set_draw_bar_border(settings->get_boolean(key));
   }));
 
-  connections.emplace_back(settings->signal_changed("line-width").connect([&](const auto& key) {
+  connections.push_back(settings->signal_changed("line-width").connect([&](const auto& key) {
     plot->set_line_width(static_cast<float>(settings->get_double("line-width")));
   }));
 

--- a/src/spectrum_ui.cpp
+++ b/src/spectrum_ui.cpp
@@ -33,8 +33,7 @@ SpectrumUi::SpectrumUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>
   connections.push_back(settings->signal_changed("height").connect(
       [&](const auto& key) { set_content_height(settings->get_int("height")); }));
 
-  connections.push_back(
-      settings->signal_changed("n-points").connect([&](const auto& key) { init_frequency_axis(); }));
+  connections.push_back(settings->signal_changed("n-points").connect([&](const auto& key) { init_frequency_axis(); }));
 
   connections.push_back(
       settings->signal_changed("minimum-frequency").connect([&](const auto& key) { init_frequency_axis(); }));
@@ -111,8 +110,8 @@ void SpectrumUi::on_new_spectrum(uint rate, uint n_bands, std::vector<float> mag
 
   // reducing the amount of data so we can plot them
 
-  for (size_t j = 0U, y = spectrum_freqs.size(); j < y; j++) {
-    for (size_t n = 0U, m = spectrum_x_axis.size(); n < m; n++) {
+  for (size_t j = 0U; j < spectrum_freqs.size(); j++) {
+    for (size_t n = 0U; n < spectrum_x_axis.size(); n++) {
       if (n > 0U) {
         if (spectrum_freqs[j] <= spectrum_x_axis[n] && spectrum_freqs[j] > spectrum_x_axis[n - 1U]) {
           spectrum_mag[n] += magnitudes[j];
@@ -129,7 +128,7 @@ void SpectrumUi::on_new_spectrum(uint rate, uint n_bands, std::vector<float> mag
     }
   }
 
-  for (size_t n = 0U, m = spectrum_bin_count.size(); n < m; n++) {
+  for (size_t n = 0U; n < spectrum_bin_count.size(); n++) {
     if (spectrum_bin_count[n] == 0U && n > 0U) {
       spectrum_mag[n] = spectrum_mag[n - 1U];
 

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -174,15 +174,13 @@ void StreamInputEffects::connect_filters(const bool& bypass) {
 
         const auto& links = pm->link_nodes(prev_node_id, next_node_id);
 
-        const auto& link_size = links.size();
-
-        for (size_t n = 0U; n < link_size; n++) {
+        for (size_t n = 0U; n < links.size(); n++) {
           list_proxies.push_back(links[n]);
         }
 
-        if (mic_linked && (link_size == 2U)) {
+        if (mic_linked && (links.size() == 2U)) {
           prev_node_id = next_node_id;
-        } else if (!mic_linked && (link_size > 0U)) {
+        } else if (!mic_linked && (links.size() > 0U)) {
           prev_node_id = next_node_id;
           mic_linked = true;
         } else {
@@ -214,15 +212,13 @@ void StreamInputEffects::connect_filters(const bool& bypass) {
 
     const auto& links = pm->link_nodes(prev_node_id, next_node_id);
 
-    const auto& link_size = links.size();
-
-    for (size_t n = 0U; n < link_size; n++) {
+    for (size_t n = 0U; n < links.size(); n++) {
       list_proxies.push_back(links[n]);
     }
 
-    if (mic_linked && (link_size == 2U)) {
+    if (mic_linked && (links.size() == 2U)) {
       prev_node_id = next_node_id;
-    } else if (!mic_linked && (link_size > 0U)) {
+    } else if (!mic_linked && (links.size() > 0U)) {
       prev_node_id = next_node_id;
       mic_linked = true;
     } else {

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -177,7 +177,7 @@ void StreamInputEffects::connect_filters(const bool& bypass) {
         const auto& link_size = links.size();
 
         for (size_t n = 0U; n < link_size; n++) {
-          list_proxies.emplace_back(links[n]);
+          list_proxies.push_back(links[n]);
         }
 
         if (mic_linked && (link_size == 2U)) {
@@ -198,7 +198,7 @@ void StreamInputEffects::connect_filters(const bool& bypass) {
       if (name == plugin_name::echo_canceller) {
         if (plugins[name]->connected_to_pw) {
           for (const auto& link : pm->link_nodes(pm->output_device.id, plugins[name]->get_node_id(), true)) {
-            list_proxies.emplace_back(link);
+            list_proxies.push_back(link);
           }
         }
 
@@ -217,7 +217,7 @@ void StreamInputEffects::connect_filters(const bool& bypass) {
     const auto& link_size = links.size();
 
     for (size_t n = 0U; n < link_size; n++) {
-      list_proxies.emplace_back(links[n]);
+      list_proxies.push_back(links[n]);
     }
 
     if (mic_linked && (link_size == 2U)) {
@@ -270,7 +270,7 @@ void StreamInputEffects::set_bypass(const bool& state) {
 void StreamInputEffects::set_listen_to_mic(const bool& state) {
   if (state) {
     for (const auto& link : pm->link_nodes(pm->ee_source_node.id, pm->output_device.id, false, false)) {
-      list_proxies_listen_mic.emplace_back(link);
+      list_proxies_listen_mic.push_back(link);
     }
   } else {
     pm->destroy_links(list_proxies_listen_mic);

--- a/src/stream_input_effects_ui.cpp
+++ b/src/stream_input_effects_ui.cpp
@@ -47,19 +47,19 @@ StreamInputEffectsUi::StreamInputEffectsUi(BaseObjectType* cobject,
     }
   }
 
-  connections.emplace_back(
+  connections.push_back(
       sie->output_level->output_level.connect(sigc::mem_fun(*this, &StreamInputEffectsUi::on_new_output_level_db)));
 
-  connections.emplace_back(sie->spectrum->power.connect(sigc::mem_fun(*spectrum_ui, &SpectrumUi::on_new_spectrum)));
+  connections.push_back(sie->spectrum->power.connect(sigc::mem_fun(*spectrum_ui, &SpectrumUi::on_new_spectrum)));
 
-  connections.emplace_back(
+  connections.push_back(
       sie->pm->stream_input_added.connect(sigc::mem_fun(*this, &StreamInputEffectsUi::on_app_added)));
-  connections.emplace_back(
+  connections.push_back(
       sie->pm->stream_input_changed.connect(sigc::mem_fun(*this, &StreamInputEffectsUi::on_app_changed)));
-  connections.emplace_back(
+  connections.push_back(
       sie->pm->stream_input_removed.connect(sigc::mem_fun(*this, &StreamInputEffectsUi::on_app_removed)));
 
-  connections.emplace_back(sie->pm->source_changed.connect([&](const auto nd_info) {
+  connections.push_back(sie->pm->source_changed.connect([&](const auto nd_info) {
     // nd_info is a reference of a copy previously made
 
     if (nd_info.id == sie->pm->ee_source_node.id) {

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -162,13 +162,11 @@ void StreamOutputEffects::connect_filters(const bool& bypass) {
 
         const auto& links = pm->link_nodes(prev_node_id, next_node_id);
 
-        const auto& link_size = links.size();
-
-        for (size_t n = 0U; n < link_size; n++) {
+        for (size_t n = 0U; n < links.size(); n++) {
           list_proxies.push_back(links[n]);
         }
 
-        if (link_size == 2U) {
+        if (links.size() == 2U) {
           prev_node_id = next_node_id;
         } else {
           util::warning(log_tag + " link from node " + std::to_string(prev_node_id) + " to node " +
@@ -199,13 +197,11 @@ void StreamOutputEffects::connect_filters(const bool& bypass) {
 
     const auto& links = pm->link_nodes(prev_node_id, next_node_id);
 
-    const auto& link_size = links.size();
-
-    for (size_t n = 0U; n < link_size; n++) {
+    for (size_t n = 0U; n < links.size(); n++) {
       list_proxies.push_back(links[n]);
     }
 
-    if (link_size == 2U) {
+    if (links.size() == 2U) {
       prev_node_id = next_node_id;
     } else {
       util::warning(log_tag + " link from node " + std::to_string(prev_node_id) + " to node " +
@@ -219,13 +215,11 @@ void StreamOutputEffects::connect_filters(const bool& bypass) {
 
   const auto& links = pm->link_nodes(prev_node_id, next_node_id);
 
-  const auto& link_size = links.size();
-
-  for (size_t n = 0U; n < link_size; n++) {
+  for (size_t n = 0U; n < links.size(); n++) {
     list_proxies.push_back(links[n]);
   }
 
-  if (link_size < 2U) {
+  if (links.size() < 2U) {
     util::warning(log_tag + " link from node " + std::to_string(prev_node_id) + " to output device " +
                   std::to_string(next_node_id) + " failed");
   }

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -165,7 +165,7 @@ void StreamOutputEffects::connect_filters(const bool& bypass) {
         const auto& link_size = links.size();
 
         for (size_t n = 0U; n < link_size; n++) {
-          list_proxies.emplace_back(links[n]);
+          list_proxies.push_back(links[n]);
         }
 
         if (link_size == 2U) {
@@ -183,7 +183,7 @@ void StreamOutputEffects::connect_filters(const bool& bypass) {
       if (name == plugin_name::echo_canceller) {
         if (plugins[name]->connected_to_pw) {
           for (const auto& link : pm->link_nodes(pm->output_device.id, plugins[name]->get_node_id(), true)) {
-            list_proxies.emplace_back(link);
+            list_proxies.push_back(link);
           }
         }
 
@@ -202,7 +202,7 @@ void StreamOutputEffects::connect_filters(const bool& bypass) {
     const auto& link_size = links.size();
 
     for (size_t n = 0U; n < link_size; n++) {
-      list_proxies.emplace_back(links[n]);
+      list_proxies.push_back(links[n]);
     }
 
     if (link_size == 2U) {
@@ -222,7 +222,7 @@ void StreamOutputEffects::connect_filters(const bool& bypass) {
   const auto& link_size = links.size();
 
   for (size_t n = 0U; n < link_size; n++) {
-    list_proxies.emplace_back(links[n]);
+    list_proxies.push_back(links[n]);
   }
 
   if (link_size < 2U) {

--- a/src/stream_output_effects_ui.cpp
+++ b/src/stream_output_effects_ui.cpp
@@ -33,19 +33,19 @@ StreamOutputEffectsUi::StreamOutputEffectsUi(BaseObjectType* cobject,
     }
   }
 
-  connections.emplace_back(
+  connections.push_back(
       soe->output_level->output_level.connect(sigc::mem_fun(*this, &StreamOutputEffectsUi::on_new_output_level_db)));
 
-  connections.emplace_back(soe->spectrum->power.connect(sigc::mem_fun(*spectrum_ui, &SpectrumUi::on_new_spectrum)));
+  connections.push_back(soe->spectrum->power.connect(sigc::mem_fun(*spectrum_ui, &SpectrumUi::on_new_spectrum)));
 
-  connections.emplace_back(
+  connections.push_back(
       soe->pm->stream_output_added.connect(sigc::mem_fun(*this, &StreamOutputEffectsUi::on_app_added)));
-  connections.emplace_back(
+  connections.push_back(
       soe->pm->stream_output_changed.connect(sigc::mem_fun(*this, &StreamOutputEffectsUi::on_app_changed)));
-  connections.emplace_back(
+  connections.push_back(
       soe->pm->stream_output_removed.connect(sigc::mem_fun(*this, &StreamOutputEffectsUi::on_app_removed)));
 
-  connections.emplace_back(soe->pm->sink_changed.connect([&](const auto nd_info) {
+  connections.push_back(soe->pm->sink_changed.connect([&](const auto nd_info) {
     if (nd_info.id == soe->pm->ee_sink_node.id) {
       const auto& v = Glib::ustring::format(std::setprecision(1), std::fixed,
                                             static_cast<float>(soe->pm->ee_sink_node.rate) * 0.001F);

--- a/src/test_signals.cpp
+++ b/src/test_signals.cpp
@@ -162,7 +162,7 @@ void TestSignals::set_state(const bool& state) {
 
   if (state) {
     for (const auto& link : pm->link_nodes(node_id, pm->ee_sink_node.id, false, false)) {
-      list_proxies.emplace_back(link);
+      list_proxies.push_back(link);
     }
   } else {
     pm->destroy_links(list_proxies);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -57,7 +57,7 @@ auto logspace(const float& start, const float& stop, const uint& npoints) -> std
   float v = start;
 
   while (v <= stop) {
-    output.emplace_back(std::pow(10.0F, v));
+    output.push_back(std::pow(10.0F, v));
 
     v += delta;
   }
@@ -77,7 +77,7 @@ auto linspace(const float& start, const float& stop, const uint& npoints) -> std
   float v = start;
 
   while (v <= stop) {
-    output.emplace_back(v);
+    output.push_back(v);
 
     v += delta;
   }


### PR DESCRIPTION
These are changes in order to improve safety.

* I read [this](https://stackoverflow.com/a/36919571) and [this](https://abseil.io/tips/112), so switched all `emplace_back` to `push_back`.
* Generally it's better to save the container size before loops, but this may cause issues if the vector has a variable size, so I reverted a previous change of mine restoring the call at `size()` member in loop checks rather than saving the size value.
* I installed `code` and saw suggestions by clang-tidy. Most of them are useless, but one seemed significant. It's better to avoid non-const static data member, so I made the icon theme a variable inside the application ui constructor to pass to effects base ui classes. 