### PR TITLE
Show at least one arrow in plugins stack

### DIFF
--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -1322,17 +1322,16 @@ void EffectsBaseUi::setup_listview_selected_plugins() {
     auto* const plugin_icon = static_cast<Gtk::Image*>(list_item->get_data("plugin_icon"));
 
     const auto name = list_item->get_item()->get_property<Glib::ustring>("string");
-
-    auto translated_name = plugins_names[name];
+    const auto translated_name = plugins_names[name];
 
     label->set_name(name);
     label->set_text(translated_name);
 
-    auto selected_plugins_list = settings->get_string_array("plugins");
+    const auto selected_plugins_list = settings->get_string_array("plugins");
 
-    const auto iter_name = std::ranges::find(selected_plugins_list, name);
-
-    if (iter_name == selected_plugins_list.begin() || iter_name == selected_plugins_list.end() - 1) {
+    if (const auto iter_name = std::ranges::find(selected_plugins_list, name);
+        (iter_name == selected_plugins_list.begin() && iter_name != selected_plugins_list.end() - 2) ||
+        iter_name == selected_plugins_list.end() - 1) {
       // it is Adwaita media-playback-stop-symbolic icon renamed
       plugin_icon->set_from_icon_name("ee-square-symbolic");
     } else {


### PR DESCRIPTION
When plugins are more than one.

Related to #1204 