### PR TITLE
Remember the window maximized state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@
 
 ### Added
 
-- It is now possible to combine impulse responses in the convolver interface. A new impulse file is generated and it
+- It is now possible to combine impulse responses in the Convolver interface. A new impulse file is generated and it
   should be visible in the impulse list.
 - Improved `x axis` drawings in our plots. Now the number of labels is adjusted dynamically depending on our window
   width.
 - The documentation has been updated reflecting the new EasyEffects features. Old references about PulseEffects
   have been removed.
+
+### Fixed
+- When a spinbutton is filled with an out of range value, now it is updated with the lowest/highest value rather than
+  resetting to the previous one.
+- The application window now remembers the maximized state and restores it on the next opening event.
 
 ### Note to packagers
 

--- a/data/schemas/com.github.wwmm.easyeffects.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.gschema.xml
@@ -16,6 +16,9 @@
         <key name="last-used-output-preset" type="s">
             <default l10n="messages">"Presets"</default>
         </key>
+        <key name="window-maximized" type="b">
+            <default>false</default>
+        </key>
         <key name="window-width" type="i">
             <default>0</default>
         </key>

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -294,6 +294,7 @@ void Application::on_activate() {
 
           settings->set_int("window-width", width);
           settings->set_int("window-height", height);
+          settings->set_boolean("window-maximized", window->is_maximized());
 
           // util::warning(std::to_string(width) + " x " + std::to_string(height));
 

--- a/src/application_ui.cpp
+++ b/src/application_ui.cpp
@@ -77,9 +77,15 @@ ApplicationUi::ApplicationUi(BaseObjectType* cobject,
 
   // restore window size
 
-  if (const auto window_width = settings->get_int("window-width"), window_height = settings->get_int("window-height");
-      window_width > 0 && window_height > 0) {
-    set_default_size(window_width, window_height);
+  if (settings->get_boolean("window-maximized")) {
+    maximize();
+  } else {
+    const auto window_width = settings->get_int("window-width");
+    const auto window_height = settings->get_int("window-height");
+
+    if (window_width > 0 && window_height > 0) {
+      set_default_size(window_width, window_height);
+    }
   }
 }
 


### PR DESCRIPTION
I had issues with EE window because sometimes it wasn't saving the window size across sessions.

Then I discovered that GTK does not get the width/height size when the window is maximized, so the previous unmaximized size values are saved in gsettings on close. Therefore when I close EE maximized, at the next window opening I find it at smaller sizes. 

Don't know why this is happening, anyway I tried to find a workaround. We can save the maximized state on close, so we apply it on window showing. Tested and It's working to me.

I wonder if it works also outside Gnome environment. I hope so, it should be tested.