### PR TITLE
APO import: handle comma in center frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- More robust parsing to import APO presets saved with comma as thousands separator in central frequency band.
+
 ## [6.1.5]
 
 ### Added

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -603,7 +603,7 @@ bool EqualizerUi::parse_apo_preamp(const std::string& line, double& preamp) {
 
   static const auto i = std::regex::icase;
 
-  std::regex_search(line, matches, std::regex(R"(preamp:\s*+([+-]?+\d++\.?+\d*+)\s*+db)", i));
+  std::regex_search(line, matches, std::regex(R"(preamp:\s*+([+-]?+\d++(?:\.\d++)*+)\s*+db)", i));
 
   if (matches.size() != 2U) {
     return false;
@@ -637,19 +637,21 @@ auto EqualizerUi::parse_apo_filter(const std::string& line, struct ImportedBand&
 
   // get center frequency
 
-  std::regex_search(line, matches, std::regex(R"(fc\s++(\d++\.?+\d*+)\s*+hz)", i));
+  std::regex_search(line, matches, std::regex(R"(fc\s++(\d++(?:,\d++)*+(?:\.\d++)*+)\s*+hz)", i));
 
   if (matches.size() != 2U) {
     return false;
   }
 
-  filter.freq = std::stof(matches.str(1));
+  // frequency could have a comma as thousands separator to be removed
+
+  filter.freq = std::stof(std::regex_replace(matches.str(1), std::regex(","), ""));
 
   // get slope
 
   if ((filter.type & (LOW_SHELF_xdB | HIGH_SHELF_xdB | LOW_SHELF | HIGH_SHELF)) != 0U) {
     std::regex_search(line, matches,
-                      std::regex(R"(filter\s++\d*+:\s*+on\s++[a-z]++\s++([+-]?+\d++\.?+\d*+)\s*+db)", i));
+                      std::regex(R"(filter\s++\d*+:\s*+on\s++[a-z]++\s++([+-]?+\d++(?:\.\d++)*+)\s*+db)", i));
 
     // _xdB variants require the dB parameter
 
@@ -667,7 +669,7 @@ auto EqualizerUi::parse_apo_filter(const std::string& line, struct ImportedBand&
   // get gain
 
   if ((filter.type & (PEAKING | LOW_SHELF_xdB | HIGH_SHELF_xdB | LOW_SHELF | HIGH_SHELF)) != 0U) {
-    std::regex_search(line, matches, std::regex(R"(gain\s++([+-]?+\d++\.?+\d*+)\s*+db)", i));
+    std::regex_search(line, matches, std::regex(R"(gain\s++([+-]?+\d++(?:\.\d++)*+)\s*+db)", i));
 
     // all Shelf types (i.e. all above except for Peaking) require the gain parameter
 
@@ -682,7 +684,7 @@ auto EqualizerUi::parse_apo_filter(const std::string& line, struct ImportedBand&
 
   // get quality factor
   if ((filter.type & (PEAKING | LOW_PASS_Q | HIGH_PASS_Q | LOW_SHELF_xdB | HIGH_SHELF_xdB | NOTCH | ALL_PASS)) != 0U) {
-    std::regex_search(line, matches, std::regex(R"(q\s++(\d++\.?+\d*+))", i));
+    std::regex_search(line, matches, std::regex(R"(q\s++(\d++(?:\.\d++)*+))", i));
 
     // Peaking and All-Pass filter types require the quality factor parameter
 


### PR DESCRIPTION
More robust regular expression to handle comma as thousands separator in central frequency band.

Fixes #1271 