### PR TITLE
Add Flatpak manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,17 @@ debian/*
 
 ppastats
 .autobuild
+
+# exclude most of flatpak directory
+util/flatpak/*
+!util/flatpak/com.github.wwmm.easyeffects.json
+!util/flatpak/patch
+!util/flatpak/easyeffects-wrapper.sh
+!util/flatpak/shared-modules
+# include patch files
+!util/flatpak/patch/bs2b/001-fix-automake-dist-lzma.patch
+!util/flatpak/patch/easyeffects/001-fix-about-page-icon.patch
+!util/flatpak/patch/easyeffects/002-fix-desktop-file.patch
+!util/flatpak/patch/easyeffects/003-libportal-autostart.patch
+!util/flatpak/patch/zita-convolver/0001-Fix-makefile.patch
+

--- a/util/flatpak/com.github.wwmm.easyeffects.json
+++ b/util/flatpak/com.github.wwmm.easyeffects.json
@@ -1,0 +1,423 @@
+{
+    "id" : "com.github.wwmm.easyeffects",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "41",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "easyeffects",
+    "rename-icon" : "easyeffects",
+    "copy-icon" : true,
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--filesystem=xdg-run/pipewire-0:ro",
+        "--env=LV2_PATH=/app/lib/lv2:/app/extensions/Plugins/lv2"
+    ],
+    "cleanup" : [
+        "*.a",
+        "*.h",
+        "*.la",
+        "/bin/analyseplugin",
+        "/bin/applyplugin",
+        "/bin/listplugins",
+        "/include",
+        "/lib/pkgconfig",
+        "/lib/python*",
+        "/share/info"
+    ],
+    "add-extensions" : {
+        "org.freedesktop.LinuxAudio.Plugins" : {
+            "directory" : "extensions/Plugins",
+            "version" : "20.08",
+            "add-ld-path" : "lib",
+            "merge-dirs" : "lv2",
+            "subdirectories" : true,
+            "no-autodownload" : true
+        },
+        "org.freedesktop.LinuxAudio.Plugins.LSP" : {
+            "directory" : "extensions/Plugins/LSP",
+            "version" : "20.08",
+            "add-ld-path" : "lib",
+            "merge-dirs" : "lv2",
+            "autodelete" : false,
+            "subdirectories" : true
+        },
+        "org.freedesktop.LinuxAudio.Plugins.ZamPlugins" : {
+            "directory" : "extensions/Plugins/ZamPlugins",
+            "version" : "20.08",
+            "add-ld-path" : "lib",
+            "merge-dirs" : "lv2",
+            "autodelete" : false,
+            "subdirectories" : true
+        }
+    },
+    "modules" : [
+        {
+            "name" : "easyeffects",
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type" : "dir",
+                    "path" : "../../"
+                },
+                {
+                    "type" : "file",
+                    "path" : "easyeffects-wrapper.sh"
+                },
+                {
+                    "type" : "shell",
+                    "commands" : [
+                        "install -Dvm 755 easyeffects-wrapper.sh $FLATPAK_DEST/bin/easyeffects-wrapper"
+                    ]
+                }
+            ],
+            "post-install" : [
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/$FLATPAK_ID ../LICENSE.md",
+                "mkdir -pm755 $FLATPAK_DEST/extensions/Plugins"
+            ],
+            "modules" : [
+                {
+                    "name" : "libsigc++",
+                    "buildsystem" : "meson",
+                    "config-opts" : [
+                        "-Dbuild-examples=false"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "https://download.gnome.org/sources/libsigc++/3.0/libsigc++-3.0.7.tar.xz",
+                            "sha256" : "bfbe91c0d094ea6bbc6cbd3909b7d98c6561eea8b6d9c0c25add906a6e83d733",
+                            "x-checker-data" : {
+                                "type" : "gnome",
+                                "name" : "libsigc++",
+                                "stable-only" : true
+                            }
+                        }
+                    ],
+                    "cleanup" : [
+                        "/lib/sigc++*"
+                    ]
+                },
+                {
+                    "name" : "libebur128",
+                    "buildsystem" : "cmake-ninja",
+                    "config-opts" : [
+                        "-DCMAKE_BUILD_TYPE=Release",
+                        "-DBUILD_STATIC_LIBS=OFF",
+                        "-DCMAKE_INSTALL_LIBDIR=lib"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "git",
+                            "url" : "https://github.com/jiixyj/libebur128.git",
+                            "tag" : "v1.2.6",
+                            "commit" : "67b33abe1558160ed76ada1322329b0e9e058b02",
+                            "x-checker-data" : {
+                                "type" : "git",
+                                "tag-pattern" : "^v([\\d.]+)"
+                            }
+                        }
+                    ],
+                    "post-install" : [
+                        "install -Dm644 -t $FLATPAK_DEST/share/licenses/libebur128 COPYING"
+                    ]
+                },
+                {
+                    "name" : "zita-convolver",
+                    "no-autogen" : true,
+                    "subdir" : "source",
+                    "make-install-args" : [
+                        "PREFIX=${FLATPAK_DEST}",
+                        "LIBDIR=${FLATPAK_DEST}/lib"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "https://kokkinizita.linuxaudio.org/linuxaudio/downloads/zita-convolver-4.0.3.tar.bz2",
+                            "sha512" : "62d7841757f10c094e43ed755e187f947c5743f302ed2a1ee6064a850c18921466f4505d8a2a7b3ad23619db7f1ad7307e1dfb2e8a1e7685e60ece2ffff4f6ca"
+                        },
+                        {
+                            "type" : "patch",
+                            "path" : "patch/zita-convolver/0001-Fix-makefile.patch"
+                        }
+                    ],
+                    "modules" : [
+                        "shared-modules/linux-audio/fftw3f.json",
+                        "shared-modules/linux-audio/lv2.json",
+                        "shared-modules/linux-audio/lilv.json",
+                        {
+                            "name" : "bs2b",
+                            "rm-configure" : true,
+                            "sources" : [
+                                {
+                                    "type" : "archive",
+                                    "url" : "https://downloads.sourceforge.net/sourceforge/bs2b/libbs2b-3.1.0.tar.gz",
+                                    "sha256" : "6aaafd81aae3898ee40148dd1349aab348db9bfae9767d0e66e0b07ddd4b2528"
+                                },
+                                {
+                                    "type" : "script",
+                                    "dest-filename" : "autogen.sh",
+                                    "commands" : [
+                                        "cp -p /usr/share/automake-*/config.{sub,guess} build-aux",
+                                        "autoreconf -vfi"
+                                    ]
+                                },
+                                {
+                                    "type" : "patch",
+                                    "path" : "patch/bs2b/001-fix-automake-dist-lzma.patch"
+                                }
+                            ],
+                            "post-install" : [
+                                "install -Dm644 -t $FLATPAK_DEST/share/licenses/bs2b COPYING"
+                            ],
+                            "cleanup" : [
+                                "/bin"
+                            ]
+                        },
+                        {
+                            "name" : "speexdsp",
+                            "buildsystem" : "autotools",
+                            "sources" : [
+                                {
+                                    "type" : "git",
+                                    "url" : "https://gitlab.xiph.org/xiph/speexdsp",
+                                    "tag" : "SpeexDSP-1.2.0",
+                                    "commit" : "64cbfa9bca7479a758351aa02bb4abdd76baa9e7",
+                                    "x-checker-data" : {
+                                        "type" : "git",
+                                        "tag-pattern" : "^SpeexDSP-([\\d.]+)"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name" : "rubberband",
+                            "buildsystem" : "meson",
+                            "cleanup" : [
+                                "/include",
+                                "/lib/*.a",
+                                "/lib/pkgconfig"
+                            ],
+                            "sources" : [
+                                {
+                                    "type" : "archive",
+                                    "url" : "https://breakfastquay.com/files/releases/rubberband-2.0.0.tar.bz2",
+                                    "sha256" : "eccbf0545496ce3386a2433ceec31e6576a76ed6884310e4b465003bfe260286",
+                                    "x-checker-data" : {
+                                        "type" : "html",
+                                        "url" : "https://www.breakfastquay.com/rubberband/",
+                                        "version-pattern" : "Rubber Band Library v(\\d\\.\\d+\\.?\\d*) source",
+                                        "url-template" : "https://breakfastquay.com/files/releases/rubberband-$version.tar.bz2"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name" : "calf",
+                            "sources" : [
+                                {
+                                    "type" : "git",
+                                    "url" : "https://github.com/calf-studio-gear/calf.git",
+                                    "tag" : "0.90.3",
+                                    "commit" : "41a2b7fb029cf0099fc05b7a9c569208034018de",
+                                    "x-checker-data" : {
+                                        "type" : "git",
+                                        "tag-pattern" : "^([\\d.]+)"
+                                    }
+                                }
+                            ],
+                            "post-install" : [
+                                "install -Dm644 -t $FLATPAK_DEST/share/licenses/calf COPYING"
+                            ],
+                            "cleanup" : [
+                                "/bin",
+                                "/share/applications",
+                                "/share/bash-completion",
+                                "/share/calf",
+                                "/share/doc",
+                                "/share/icons",
+                                "/share/man"
+                            ],
+                            "modules" : [
+                                "shared-modules/linux-audio/fluidsynth2.json"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name" : "rnnoise",
+                    "sources" : [
+                        {
+                            "type" : "git",
+                            "url" : "https://github.com/xiph/rnnoise.git",
+                            "commit" : "1cbdbcf1283499bbb2230a6b0f126eb9b236defd"
+                        }
+                    ],
+                    "cleanup" : [
+                        "/share/doc/rnnoise"
+                    ]
+                },
+                {
+                    "name" : "pipewire",
+                    "buildsystem" : "meson",
+                    "config-opts" : [
+                        "-Dgstreamer=disabled",
+                        "-Dman=disabled",
+                        "-Dsystemd=disabled",
+                        "-Dudev=disabled",
+                        "-Dudevrulesdir=disabled"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "git",
+                            "url" : "https://gitlab.freedesktop.org/pipewire/pipewire.git",
+                            "tag" : "0.3.31",
+                            "commit" : "c43dabcc96e2e072cdf08e5f094bb677d9017c6b"
+                        }
+                    ]
+                },
+                {
+                    "name" : "nlohmann-json",
+                    "buildsystem" : "cmake-ninja",
+                    "config-opts" : [
+                        "-DCMAKE_BUILD_TYPE=Release"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "https://github.com/nlohmann/json/archive/v3.10.4.tar.gz",
+                            "sha256" : "1155fd1a83049767360e9a120c43c578145db3204d2b309eba49fbbedd0f4ed3",
+                            "x-checker-data" : {
+                                "type" : "anitya",
+                                "project-id" : 141453,
+                                "url-template" : "https://github.com/nlohmann/json/archive/v$version.tar.gz"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name" : "tbb",
+                    "buildsystem" : "simple",
+                    "build-commands" : [
+                        "make tbb tbbmalloc tbbproxy",
+                        "install -d usr/lib/",
+                        "install -m755 build/linux_*/*.so* /app/lib/",
+                        "install -d usr/include",
+                        "cp -a include/tbb /app/include/",
+                        "cmake -DINSTALL_DIR=/app/lib/cmake/TBB -DSYSTEM_NAME=Linux -DTBB_VERSION_FILE=/app/include/tbb/tbb_stddef.h -P cmake/tbb_config_installer.cmake"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "https://github.com/intel/tbb/archive/v2020.3.tar.gz",
+                            "sha256" : "ebc4f6aa47972daed1f7bf71d100ae5bf6931c2e3144cf299c8cc7d041dca2f3"
+                        }
+                    ],
+                    "cleanup" : [
+                        "/include"
+                    ]
+                },
+                {
+                    "name" : "libportal",
+                    "buildsystem" : "meson",
+                    "sources" : [
+                        {
+                            "type" : "git",
+                            "url" : "https://github.com/flatpak/libportal.git",
+                            "tag" : "0.4",
+                            "commit" : "f68764e288ede516d902b131cc4fadded3804059"
+                        }
+                    ]
+                },
+                {
+                    "name" : "zenity",
+                    "buildsystem" : "meson",
+                    "sources" : [
+                        {
+                            "type" : "git",
+                            "url" : "https://gitlab.gnome.org/GNOME/zenity",
+                            "tag" : "3.41.0",
+                            "commit" : "d8857f446b602d5fb4a41fef3d8a63507a12b72c"
+                        }
+                    ]
+                },
+                {
+                    "name" : "libadwaita",
+                    "buildsystem" : "meson",
+                    "config-opts" : [
+                        "-Dintrospection=disabled",
+                        "-Dgtk_doc=false",
+                        "-Dtests=false",
+                        "-Dexamples=false",
+                        "-Dvapi=false"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "git",
+                            "url" : "https://gitlab.gnome.org/GNOME/libadwaita.git",
+                            "tag" : "1.0.0.alpha.4",
+                            "commit" : "6b447fde8f270001a0dc29ef59d3e9bf6d32dae9"
+                        }
+                    ],
+                    "cleanup" : [
+                        "/include",
+                        "/lib/pkgconfig"
+                    ],
+                    "modules" : [
+                        {
+                            "name" : "libsass",
+                            "buildsystem" : "meson",
+                            "cleanup" : [
+                                "*"
+                            ],
+                            "sources" : [
+                                {
+                                    "type" : "git",
+                                    "url" : "https://github.com/lazka/libsass.git",
+                                    "branch" : "meson",
+                                    "commit" : "302397c0c8ae2d7ab02f45ea461c2c3d768f248e"
+                                }
+                            ]
+                        },
+                        {
+                            "name" : "sassc",
+                            "buildsystem" : "meson",
+                            "cleanup" : [
+                                "*"
+                            ],
+                            "sources" : [
+                                {
+                                    "type" : "git",
+                                    "url" : "https://github.com/lazka/sassc.git",
+                                    "branch" : "meson",
+                                    "commit" : "82803377c33247265d779af034eceb5949e78354"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name" : "fmt",
+                    "buildsystem" : "cmake",
+                    "config-opts" : [
+                        "-DCMAKE_INSTALL_PREFIX=/app",
+                        "-DCMAKE_INSTALL_LIBDIR=/app/lib",
+                        "-DBUILD_SHARED_LIBS=ON",
+                        "-DFMT_TEST=Off"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "https://github.com/fmtlib/fmt/releases/download/8.0.1/fmt-8.0.1.zip",
+                            "sha256" : "a627a56eab9554fc1e5dd9a623d0768583b3a383ff70a4312ba68f94c9d415bf"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "build-options" : {
+        "env" : {        }
+    }
+}

--- a/util/flatpak/easyeffects-wrapper.sh
+++ b/util/flatpak/easyeffects-wrapper.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# this checks the PipeWire version on the host, and then compares it to what we need.
+# current baseline to compile EasyEffects is 0.3.31, thus the host needs minimum that as well.
+
+# get host's PipeWire version:
+
+# https://stackoverflow.com/a/48066872
+# we can't use jq to parse JSON as that will fail to run with flatpak run or from desktop file; gives "command not found", even though jq is in the runtime/sdk.
+found_pipewire_version="$(pw-dump | grep -Po '"version":.*?[^\\]",' |  sed 's/"//g' | sed 's/://g' | sed 's/,//g' | cut -c9-18)"
+
+required_pipewire_version="0.3.31" # from EasyEffects' build requirements
+
+# compare versions
+# from https://unix.stackexchange.com/a/285928
+
+if [ "$(printf '%s\n' "$required_pipewire_version" "$found_pipewire_version" | sort -V | head -n1)" = "$required_pipewire_version" ]; then 
+      echo "You have PipeWire ${found_pipewire_version} installed"
+      echo "This is newer or the same as PipeWire ${required_pipewire_version} required to run EasyEffects"
+
+else
+
+  if pw-dump >/dev/null ; then # TRY
+      # https://stackoverflow.com/a/6852427
+      # https://stackoverflow.com/a/428118
+      echo "pw-dump succeeded; system likely has PipeWire 0.3.x or later."
+      echo "You have PipeWire ${found_pipewire_version} installed"
+      echo "This is less than PipeWire ${required_pipewire_version} recommended to run EasyEffects"
+
+      # put all the text here so we can use variable as part of output, it is helpful to the user.
+      zenity --info --title="PipeWire version warning" --no-wrap \
+        --text="Could not find compatible PipeWire.
+It is recommended to install PipeWire ${required_pipewire_version} or newer for EasyEffects to work correctly. \n
+More info:
+PipeWire ${found_pipewire_version} was found, which is not considered recent enough for EasyEffects. 
+If on Ubuntu or an Ubuntu-based system you may install newer PipeWire from: https://pipewire-debian.github.io
+You may try PulseEffects which does not require PipeWire.
+You may dismiss this warning by clicking \"OK\", please note PipeWire ${found_pipewire_version} is not tested to work with EasyEffects. \n
+If you believe this message was shown in error, please report it to: https://github.com/wwmm/easyeffects"
+      
+  else # CATCH
+      echo 'pw-dump failed; system likely has PipeWire 0.2.x or older, or no PipeWire package exists.'
+      echo "Your system does not appear to have PipeWire 0.3.0 or later installed"
+      echo "This is less than PipeWire ${required_pipewire_version} required to run EasyEffects"
+
+      # put all the text here so we can use variable as part of output, it is helpful to the user.
+      zenity --info --title="PipeWire version warning" --no-wrap \
+        --text="Could not find compatible PipeWire.
+Install PipeWire ${required_pipewire_version} or newer for EasyEffects to work correctly. \n
+More info:
+Either PipeWire is not installed or is not recent enough for EasyEffects. 
+If on Ubuntu or an Ubuntu-based system you may install newer PipeWire from: https://pipewire-debian.github.io
+You may try PulseEffects which does not require PipeWire. \n
+If you believe this message was shown in error, please report it to: https://github.com/wwmm/easyeffects"
+      
+  fi
+
+fi
+
+# launch the normal app without checking again
+exec easyeffects "$@"

--- a/util/flatpak/patch/bs2b/001-fix-automake-dist-lzma.patch
+++ b/util/flatpak/patch/bs2b/001-fix-automake-dist-lzma.patch
@@ -1,0 +1,13 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -4,8 +4,8 @@
+ AC_PREREQ([2.63])
+ AC_INIT([libbs2b], [3.1.0], [boris_mikhaylov@users.sourceforge.net])
+ AC_CONFIG_AUX_DIR([build-aux])
+-AM_INIT_AUTOMAKE([1.10.1 -Wall foreign subdir-objects
+-                  dist-zip dist-bzip2 dist-lzma])
++AM_INIT_AUTOMAKE([1.11.2 -Wall foreign subdir-objects
++                  dist-zip dist-bzip2 dist-xz])
+ AC_CONFIG_SRCDIR([src/bs2b.h])
+ 
+ # Checks for programs.

--- a/util/flatpak/patch/easyeffects/001-fix-about-page-icon.patch
+++ b/util/flatpak/patch/easyeffects/001-fix-about-page-icon.patch
@@ -1,0 +1,24 @@
+From 31abfa4adce288b4e5aac37307ff5f0e63b6f590 Mon Sep 17 00:00:00 2001
+From: Vincent Chernin <38842733+vchernin@users.noreply.github.com>
+Date: Fri, 6 Aug 2021 15:06:02 -0700
+Subject: [PATCH] About menu icon fix. The value of the icon name in the about menu is hardcoded to the Flatpak App ID so the icon loads.
+This is the simplest solution I could come up with, as the .desktop file itself wants the Flatpak App ID as well, it's easier to be consistent everywhere.
+One could also try making multiple copies of the icon, or symlinks, but that seemed unnecessarily complex.
+
+---
+ src/application.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/application.cpp b/src/application.cpp
+index a4961ac4..7d618bce 100644
+--- a/src/application.cpp
++++ b/src/application.cpp
+@@ -353,7 +353,7 @@ void Application::create_actions() {
+     dialog->set_version(VERSION);
+     dialog->set_comments(_("Audio effects for PipeWire applications"));
+     dialog->set_authors({"Wellington Wallace"});
+-    dialog->set_logo_icon_name("easyeffects");
++    dialog->set_logo_icon_name("com.github.wwmm.easyeffects");
+     dialog->set_license_type(Gtk::License::GPL_3_0);
+     dialog->set_website("https://github.com/wwmm/pulseeffects");
+ 

--- a/util/flatpak/patch/easyeffects/002-fix-desktop-file.patch
+++ b/util/flatpak/patch/easyeffects/002-fix-desktop-file.patch
@@ -1,0 +1,43 @@
+From 1eba69fef4c800289485bee3544660e9baa45de6 Mon Sep 17 00:00:00 2001
+From: Vincent Chernin <38842733+vchernin@users.noreply.github.com>
+Date: Thu, 26 Aug 2021 10:45:37 -0700
+Subject: [PATCH 1/2] Rename the Exec line to launch the wrapper script.
+This was the only way I could get a wrapper script to launch from using the app launcher (i.e. triggering the desktop file.)
+
+---
+ data/com.github.wwmm.easyeffects.desktop.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/com.github.wwmm.easyeffects.desktop.in b/data/com.github.wwmm.easyeffects.desktop.in
+index 69912196..8c210e53 100644
+--- a/data/com.github.wwmm.easyeffects.desktop.in
++++ b/data/com.github.wwmm.easyeffects.desktop.in
+@@ -4,7 +4,7 @@ GenericName=Equalizer, Compressor and Other Audio Effects
+ Comment=Audio Effects for PipeWire Applications
+ Keywords=limiter;compressor;reverberation;equalizer;autovolume;
+ Categories=GTK;AudioVideo;Audio;
+-Exec=easyeffects
++Exec=easyeffects-wrapper
+ # Translators: This is an icon name, don't translate!
+ Icon=easyeffects
+ StartupNotify=true
+
+From df4cc6bb435c9a4694c6a807154609e9af4fe65f Mon Sep 17 00:00:00 2001
+From: Vincent Chernin <38842733+vchernin@users.noreply.github.com>
+Date: Thu, 26 Aug 2021 10:46:01 -0700
+Subject: [PATCH 2/2] Update com.github.wwmm.easyeffects.service.in
+
+---
+ data/com.github.wwmm.easyeffects.service.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/com.github.wwmm.easyeffects.service.in b/data/com.github.wwmm.easyeffects.service.in
+index 0493f584..9e56bc6b 100644
+--- a/data/com.github.wwmm.easyeffects.service.in
++++ b/data/com.github.wwmm.easyeffects.service.in
+@@ -1,3 +1,3 @@
+ [D-BUS Service]
+ Name=com.github.wwmm.easyeffects
+-Exec=@bindir@/easyeffects --gapplication-service
++Exec=@bindir@/easyeffects-wrapper --gapplication-service
+

--- a/util/flatpak/patch/easyeffects/003-libportal-autostart.patch
+++ b/util/flatpak/patch/easyeffects/003-libportal-autostart.patch
@@ -1,0 +1,185 @@
+From 76bfc35d1f3a690089df70344f0deadfcb040b66 Mon Sep 17 00:00:00 2001
+From: Digitalone <kurmikon@libero.it>
+Date: Mon, 13 Sep 2021 11:07:19 +0200
+Subject: [PATCH 1/1] attempt to integrate libportal
+
+This was made a patch and not integrated upstream due to complexity. The background portal apparently does not work on the host currently (as of 2021-09-16).
+There was no easy way of ensuring this code could be a build time option.
+See https://github.com/wwmm/easyeffects/pull/1141
+---
+ .../com.github.wwmm.easyeffects.gschema.xml   |  5 +-
+ include/general_settings_ui.hpp               | 13 +++--
+ src/general_settings_ui.cpp                   | 54 +++++++++++++++++--
+ src/meson.build                               |  1 +
+ 4 files changed, 66 insertions(+), 7 deletions(-)
+
+diff --git a/data/schemas/com.github.wwmm.easyeffects.gschema.xml b/data/schemas/com.github.wwmm.easyeffects.gschema.xml
+index 47dad2d9..1ffa98a8 100644
+--- a/data/schemas/com.github.wwmm.easyeffects.gschema.xml
++++ b/data/schemas/com.github.wwmm.easyeffects.gschema.xml
+@@ -7,6 +7,9 @@
+         <key name="process-all-inputs" type="b">
+             <default>false</default>
+         </key>
++        <key name="enable-autostart" type="b">
++            <default>false</default>
++        </key>
+         <key name="use-dark-theme" type="b">
+             <default>false</default>
+         </key>
+diff --git a/include/general_settings_ui.hpp b/include/general_settings_ui.hpp
+index 8fe60be2..9e0aafc1 100644
+--- a/include/general_settings_ui.hpp
++++ b/include/general_settings_ui.hpp
+@@ -22,8 +22,9 @@
+ 
+ #include <giomm.h>
+ #include <glibmm/i18n.h>
+-#include <filesystem>
++//#include <filesystem>
+ #include "application.hpp"
++#include "libportal/background.h"
+ #include "util.hpp"
+ 
+ class GeneralSettingsUi : public Gtk::Box {
+@@ -35,8 +36,14 @@ class GeneralSettingsUi : public Gtk::Box {
+   auto operator=(const GeneralSettingsUi&&) -> GeneralSettingsUi& = delete;
+   ~GeneralSettingsUi() override;
+ 
++  inline static XdpPortal* portal = nullptr;
++
+   static void add_to_stack(Gtk::Stack* stack, Application* app);
+ 
++  static void update_background_portal(const bool& state);
++
++  static void on_request_background_called(GObject* source, GAsyncResult* result, gpointer data);
++
+  private:
+   inline static const std::string log_tag = "general_settings_ui: ";
+ 
+@@ -51,9 +58,9 @@ class GeneralSettingsUi : public Gtk::Box {
+ 
+   std::vector<sigc::connection> connections;
+ 
+-  void init_autostart_switch();
++  // void init_autostart_switch();
+ 
+-  auto on_enable_autostart(bool state) -> bool;
++  // auto on_enable_autostart(const bool& state) -> bool;
+ 
+   void on_reset_settings();
+ };
+diff --git a/src/general_settings_ui.cpp b/src/general_settings_ui.cpp
+index 007da982..4b0dc4ac 100644
+--- a/src/general_settings_ui.cpp
++++ b/src/general_settings_ui.cpp
+@@ -23,6 +23,13 @@ GeneralSettingsUi::GeneralSettingsUi(BaseObjectType* cobject,
+                                      const Glib::RefPtr<Gtk::Builder>& builder,
+                                      Application* application)
+     : Gtk::Box(cobject), settings(Gio::Settings::create("com.github.wwmm.easyeffects")), app(application) {
++  // portal initialization
++  if (portal == nullptr) {
++    portal = xdp_portal_new();
++  }
++
++  update_background_portal(settings->get_boolean("enable-autostart"));
++
+   // loading builder widgets
+ 
+   theme_switch = builder->get_widget<Gtk::Switch>("theme_switch");
+@@ -37,7 +44,7 @@ GeneralSettingsUi::GeneralSettingsUi(BaseObjectType* cobject,
+ 
+   // signals connection
+ 
+-  enable_autostart->signal_state_set().connect(sigc::mem_fun(*this, &GeneralSettingsUi::on_enable_autostart), false);
++  // enable_autostart->signal_state_set().connect(sigc::mem_fun(*this, &GeneralSettingsUi::on_enable_autostart), false);
+ 
+   reset_settings->signal_clicked().connect(sigc::mem_fun(*this, &GeneralSettingsUi::on_reset_settings));
+ 
+@@ -48,8 +55,13 @@ GeneralSettingsUi::GeneralSettingsUi(BaseObjectType* cobject,
+   settings->bind("process-all-outputs", process_all_outputs, "active");
+   settings->bind("shutdown-on-window-close", shutdown_on_window_close, "active");
+   settings->bind("use-cubic-volumes", use_cubic_volumes, "active");
++  settings->bind("enable-autostart", enable_autostart, "active");
+ 
+-  init_autostart_switch();
++  settings->signal_changed("enable-autostart").connect([=, this](const auto& key) {
++    update_background_portal(settings->get_boolean(key));
++  });
++
++  // init_autostart_switch();
+ }
+ 
+ GeneralSettingsUi::~GeneralSettingsUi() {
+@@ -68,13 +80,48 @@ void GeneralSettingsUi::add_to_stack(Gtk::Stack* stack, Application* app) {
+   stack->add(*ui, "general_spectrum", _("General"));
+ }
+ 
++void GeneralSettingsUi::update_background_portal(const bool& state) {
++  XdpBackgroundFlags background_flags = XDP_BACKGROUND_FLAG_NONE;
++
++  g_autoptr(GPtrArray) command_line = nullptr;
++
++  if (state) {
++    command_line = g_ptr_array_new_with_free_func(g_free);
++
++    g_ptr_array_add(command_line, g_strdup("easyeffects"));
++    g_ptr_array_add(command_line, g_strdup("--gapplication-service"));
++
++    background_flags = XDP_BACKGROUND_FLAG_AUTOSTART;
++  }
++
++  auto* reason = g_strdup("EasyEffects Autostart");
++
++  xdp_portal_request_background(portal, nullptr, reason, command_line, background_flags, NULL,
++                                on_request_background_called, nullptr);
++
++  g_free(reason);
++}
++
++void GeneralSettingsUi::on_request_background_called(GObject* source, GAsyncResult* result, gpointer data) {
++  g_autoptr(GError) error = nullptr;
++
++  if (!xdp_portal_request_background_finish(portal, result, &error)) {
++    util::warning(std::string("portal: background request failed:") + ((error) ? error->message : "unknown reason"));
++
++    return;
++  }
++
++  util::debug("portal: background request successfully completed");
++}
++
++/*
+ void GeneralSettingsUi::init_autostart_switch() {
+   const auto path = Glib::get_user_config_dir() + "/autostart/easyeffects-service.desktop";
+ 
+   enable_autostart->set_active(std::filesystem::is_regular_file(path) ? true : false);
+ }
+ 
+-auto GeneralSettingsUi::on_enable_autostart(bool state) -> bool {
++auto GeneralSettingsUi::on_enable_autostart(const bool& state) -> bool {
+   std::filesystem::path autostart_dir{Glib::get_user_config_dir() + "/autostart"};
+ 
+   if (!std::filesystem::is_directory(autostart_dir)) {
+@@ -110,6 +157,7 @@ auto GeneralSettingsUi::on_enable_autostart(bool state) -> bool {
+ 
+   return false;
+ }
++*/
+ 
+ void GeneralSettingsUi::on_reset_settings() {
+   settings->reset("");
+diff --git a/src/meson.build b/src/meson.build
+index cd66d6de..0af79e78 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -118,6 +118,7 @@ easyeffects_deps = [
+ 	dependency('sndfile'),
+ 	dependency('fftw3f'),
+ 	dependency('libebur128',version: '>=1.2.0'),
++	dependency('libportal'),
+ 	dependency('rnnoise'),
+ 	dependency('samplerate'),
+ 	dependency('rubberband'),
+-- 
+2.32.0

--- a/util/flatpak/patch/zita-convolver/0001-Fix-makefile.patch
+++ b/util/flatpak/patch/zita-convolver/0001-Fix-makefile.patch
@@ -1,0 +1,33 @@
+From 5980950dbae82c6a03b38b8e66e07a8b29068a00 Mon Sep 17 00:00:00 2001
+From: AsavarTzeth <asavartzeth@gmail.com>
+Date: Thu, 19 Jul 2018 21:55:38 +0200
+Subject: [PATCH] Fix makefile
+
+- ldconfig should not be called by Makefile
+- Add missing symlink for major version of lib
+---
+ source/Makefile | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/source/Makefile b/source/Makefile
+index 776c067..a15bea9 100644
+--- a/source/Makefile
++++ b/source/Makefile
+@@ -34,7 +34,6 @@ VERSION = $(MAJVERS).$(MINVERS)
+ CPPFLAGS += -I. -D_REENTRANT -D_POSIX_PTHREAD_SEMANTICS
+ CPPFLAGS += -DENABLE_VECTOR_MODE 
+ CXXFLAGS += -fPIC -Wall -ffast-math -funroll-loops -O2
+-CXXFLAGS += -march=native
+ LDLFAGS += 
+ LDLIBS +=
+ 
+@@ -56,8 +55,8 @@ install:	$(ZITA-CONVOLVER_MIN)
+ 	install -d $(DESTDIR)$(LIBDIR)
+ 	install -m 644 $(ZITA-CONVOLVER_H) $(DESTDIR)$(INCDIR)
+ 	install -m 755 $(ZITA-CONVOLVER_MIN) $(DESTDIR)$(LIBDIR)
+-	ldconfig
+ 	ln -sf $(ZITA-CONVOLVER_MIN) $(DESTDIR)$(LIBDIR)/$(ZITA-CONVOLVER_SO)
++	ln -sf $(ZITA-CONVOLVER_MIN) $(DESTDIR)$(LIBDIR)/$(ZITA-CONVOLVER_MAJ)
+ 
+ uninstall:
+ 	rm -rf $(DESTDIR)$(INCDIR)/$(ZITA-CONVOLVER_H)

--- a/util/flatpak/shared-modules/linux-audio/fftw3f.json
+++ b/util/flatpak/shared-modules/linux-audio/fftw3f.json
@@ -1,0 +1,41 @@
+{
+    "name": "fftw3f",
+    "config-opts": [
+        "--enable-threads",
+        "--enable-shared",
+        "--disable-static",
+        "--enable-float"
+    ],
+    "build-options": {
+        "arch": {
+            "x86_64": {
+                "config-opts": [
+                    "--enable-sse2",
+                    "--enable-avx",
+                    "--enable-avx-128-fma"
+                ]
+            },
+            "aarch64": {
+                "config-opts": [
+                    "--enable-neon"
+                ]
+            }
+        }
+    },
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://www.fftw.org/fftw-3.3.10.tar.gz",
+            "sha256": "56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467"
+        }
+    ],
+    "cleanup": [
+        "/bin",
+        "/include",
+        "/lib/cmake",
+        "/lib/pkgconfig",
+        "/share/man",
+        "*.la",
+        "*.so"
+    ]
+}

--- a/util/flatpak/shared-modules/linux-audio/fluidsynth2.json
+++ b/util/flatpak/shared-modules/linux-audio/fluidsynth2.json
@@ -1,0 +1,21 @@
+{
+    "name": "fluidsynth",
+    "buildsystem": "cmake-ninja",
+    "config-opts": [
+        "-DLIB_SUFFIX="
+    ],
+    "cleanup": [
+        "/bin",
+        "/include",
+        "/lib/pkgconfig",
+        "/share/man",
+        "*.so"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://github.com/FluidSynth/fluidsynth/archive/v2.2.4.tar.gz",
+            "sha256": "83cb1dba04c632ede74f0c0717018b062c0e00b639722203b23f77a961afd390"
+        }
+    ]
+}

--- a/util/flatpak/shared-modules/linux-audio/lilv.json
+++ b/util/flatpak/shared-modules/linux-audio/lilv.json
@@ -1,0 +1,100 @@
+{
+  "name": "lilv",
+  "buildsystem": "simple",
+  "build-commands": [
+    "python3 ./waf configure --prefix=$FLATPAK_DEST",
+    "python3 ./waf build -j $FLATPAK_BUILDER_N_JOBS",
+    "python3 ./waf install"
+  ],
+  "modules": [
+    {
+      "name": "serd",
+      "buildsystem": "simple",
+      "build-commands": [
+        "python3 ./waf configure --prefix=$FLATPAK_DEST",
+        "python3 ./waf build -j $FLATPAK_BUILDER_N_JOBS",
+        "python3 ./waf install"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.drobilla.net/serd-0.30.10.tar.bz2",
+          "sha256": "affa80deec78921f86335e6fc3f18b80aefecf424f6a5755e9f2fa0eb0710edf"
+        }
+      ],
+      "post-install": [
+        "install -Dm644 -t /app/share/licenses/serd COPYING"
+      ],
+      "cleanup": [
+        "/bin",
+        "/include",
+        "/lib/pkgconfig",
+        "/share/man"
+      ]
+    },
+    {
+      "name": "sord",
+      "buildsystem": "simple",
+      "build-commands": [
+        "python3 ./waf configure --prefix=$FLATPAK_DEST",
+        "python3 ./waf build -j $FLATPAK_BUILDER_N_JOBS",
+        "python3 ./waf install"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.drobilla.net/sord-0.16.8.tar.bz2",
+          "sha256": "7c289d2eaabf82fa6ac219107ce632d704672dcfb966e1a7ff0bbc4ce93f5e14"
+        }
+      ],
+      "post-install": [
+        "install -Dm644 -t /app/share/licenses/sord COPYING"
+      ],
+      "cleanup": [
+        "/bin",
+        "/include",
+        "/lib/pkgconfig",
+        "/share/man"
+      ]
+    },
+    {
+      "name": "sratom",
+      "buildsystem": "simple",
+      "build-commands": [
+        "python3 ./waf configure --prefix=$FLATPAK_DEST",
+        "python3 ./waf build -j $FLATPAK_BUILDER_N_JOBS",
+        "python3 ./waf install"
+      ],
+      "cleanup": [
+        "/include",
+        "/lib/pkgconfig"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.drobilla.net/sratom-0.6.8.tar.bz2",
+          "sha256": "3acb32b1adc5a2b7facdade2e0818bcd6c71f23f84a1ebc17815bb7a0d2d02df"
+        }
+      ],
+      "post-install": [
+        "install -Dm644 -t /app/share/licenses/sratom COPYING"
+      ]
+    }
+  ],
+  "sources": [
+    {
+      "type": "archive",
+      "url": "https://download.drobilla.net/lilv-0.24.12.tar.bz2",
+      "sha256": "26a37790890c9c1f838203b47f5b2320334fe92c02a4d26ebbe2669dbd769061"
+    }
+  ],
+  "post-install": [
+    "install -Dm644 -t /app/share/licenses/lilv COPYING"
+  ],
+  "cleanup": [
+    "/bin",
+    "/etc",
+    "/lib/pkgconfig",
+    "/share/man"
+  ]
+}

--- a/util/flatpak/shared-modules/linux-audio/lv2.json
+++ b/util/flatpak/shared-modules/linux-audio/lv2.json
@@ -1,0 +1,26 @@
+{
+    "name": "lv2",
+    "buildsystem": "simple",
+    "build-commands": [
+        "python3 ./waf configure --prefix=$FLATPAK_DEST --lv2dir=$FLATPAK_DEST/lib/lv2 --copy-headers",
+        "python3 ./waf build -j $FLATPAK_BUILDER_N_JOBS",
+        "python3 ./waf install"
+    ],
+    "cleanup": [
+        "/bin",
+        "/include",
+        "/lib/pkgconfig",
+        "/share"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://lv2plug.in/spec/lv2-1.18.2.tar.bz2",
+            "sha256": "4e891fbc744c05855beb5dfa82e822b14917dd66e98f82b8230dbd1c7ab2e05e"
+        }
+    ],
+    "post-install": [
+        "install -Dm644 -t $FLATPAK_DEST/share/licenses/lv2 COPYING",
+        "ln -sf lv2.pc $FLATPAK_DEST/lib/pkgconfig/lv2core.pc"
+    ]
+}


### PR DESCRIPTION
So you can clone and start building with gnome builder without dependency hunting.
Note `org.freedesktop.LinuxAudio.Plugins.LSP` and `org.freedesktop.LinuxAudio.Plugins.ZamPlugins` are not automatically installed, so plugins like the convolver do not work after building in gnome builder.
- Maybe there are ways of workarounding, see https://gitlab.gnome.org/GNOME/gnome-builder/-/issues/1586

Manually copied 4 modules from flathub shared-modules/linux-audio to avoid a git submodule.