### PR TITLE
Make node descriptions unique

### DIFF
--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -990,11 +990,13 @@ void on_registry_global(void* data,
 
         if (g_strcmp0(key_media_category, "Filter") == 0) {
           const auto* key_node_description = spa_dict_lookup(props, PW_KEY_NODE_DESCRIPTION);
+          std::string description(key_node_description);
+          if (description.length() > 3) {
+            if (g_strcmp0(description.substr(0, 2).c_str(), "ee_") == 0) {
+              const auto* node_name = spa_dict_lookup(props, PW_KEY_NODE_NAME);
 
-          if (g_strcmp0(key_node_description, "easyeffects_filter") == 0) {
-            const auto* node_name = spa_dict_lookup(props, PW_KEY_NODE_NAME);
-
-            util::debug(PipeManager::log_tag + "Filter " + node_name + ", id = " + std::to_string(id) + ", was added");
+              util::debug(PipeManager::log_tag + "Filter " + node_name + ", id = " + std::to_string(id) + ", was added");
+          	}
           }
         }
       }

--- a/src/plugin_base.cpp
+++ b/src/plugin_base.cpp
@@ -90,7 +90,7 @@ PluginBase::PluginBase(std::string tag,
 
   pw_properties_set(props_filter, PW_KEY_NODE_NAME, filter_name.c_str());
   pw_properties_set(props_filter, PW_KEY_NODE_NICK, name.c_str());
-  pw_properties_set(props_filter, PW_KEY_NODE_DESCRIPTION, "easyeffects_filter");
+  pw_properties_set(props_filter, PW_KEY_NODE_DESCRIPTION, filter_name.c_str());
   pw_properties_set(props_filter, PW_KEY_MEDIA_TYPE, "Audio");
   pw_properties_set(props_filter, PW_KEY_MEDIA_CATEGORY, "Filter");
   pw_properties_set(props_filter, PW_KEY_MEDIA_ROLE, "DSP");


### PR DESCRIPTION
Using the `filter_name` instead of my suggested `name` for the description should fix the problem of not knowing from which pipeline an effect is from https://github.com/wwmm/easyeffects/issues/1332#issuecomment-1012176820.

There is one more occurrence of `easyeffects_filter` in https://github.com/wwmm/easyeffects/blob/4f49d29434ffe6efb44af79828517af415f3bf9c/src/test_signals.cpp#L104 but I've left that unchanged for now. Is that fine so or does it need to be changed as well?