### PR TITLE
Acquire realtime priority on PipeWire

### DIFF
--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -1343,6 +1343,7 @@ PipeManager::PipeManager() {
 
   pw_properties* props_context = pw_properties_new(nullptr, nullptr);
 
+  pw_properties_set(props_context, PW_KEY_CONFIG_NAME, "client-rt.conf");
   pw_properties_set(props_context, PW_KEY_MEDIA_TYPE, "Audio");
   pw_properties_set(props_context, PW_KEY_MEDIA_CATEGORY, "Manager");
   pw_properties_set(props_context, PW_KEY_MEDIA_ROLE, "Music");


### PR DESCRIPTION
Due to a poorly documented behavior [1] in PipeWire, EasyEffects was
running under normal scheduling policy which lead to an excessive amount
of audio dropouts.

Fix this by requesting the realtime client config profile.

[1] https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/2024