### PR TITLE
Fix NEWS formatting and regenerate release files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,8 @@
 
 ### Features:
 - Support for the next PipeWire release `0.3.44`
-- The autogain filter should deal better with PipeWire's dynamic latency switches. Jumps in volume level should not
-happen anymore in these situations.
-- We added an option that allows the volume and mute state of our virtual devices to be reset when EasyEffects starts.
-It should help with the cases were our devices are muted by the audio server for unknown reasons.
+- The autogain filter should deal better with PipeWire's dynamic latency switches. Jumps in volume level should not happen anymore in these situations.
+- We added an option that allows the volume and mute state of our virtual devices to be reset when EasyEffects starts. It should help with the cases were our devices are muted by the audio server for unknown reasons.
 - Better support for computer suspending. 
 - Updated translations
 

--- a/data/com.github.wwmm.easyeffects.metainfo.xml.in
+++ b/data/com.github.wwmm.easyeffects.metainfo.xml.in
@@ -38,10 +38,8 @@
         <p>This release adds the following features:</p>
         <ul>
           <li>Support for the next PipeWire release `0.3.44`</li>
-          <li>The autogain filter should deal better with PipeWire's dynamic latency switches. Jumps in volume level should not</li>
-          <li>happen anymore in these situations.</li>
-          <li>We added an option that allows the volume and mute state of our virtual devices to be reset when EasyEffects starts.</li>
-          <li>It should help with the cases were our devices are muted by the audio server for unknown reasons.</li>
+          <li>The autogain filter should deal better with PipeWire's dynamic latency switches. Jumps in volume level should not happen anymore in these situations.</li>
+          <li>We added an option that allows the volume and mute state of our virtual devices to be reset when EasyEffects starts. It should help with the cases were our devices are muted by the audio server for unknown reasons.</li>
           <li>Better support for computer suspending.</li>
           <li>Updated translations</li>
         </ul>

--- a/util/NEWS
+++ b/util/NEWS
@@ -3,8 +3,7 @@ Version UNRELEASED_VERSION
 Released: UNRELEASED_DATE
 
 Features:
-- The crossfeed filter should deal better with PipeWire's dynamic latency switches. Jumps in volume level should not
-happen anymore in these situations.
+- The crossfeed filter should deal better with PipeWire's dynamic latency switches. Jumps in volume level should not happen anymore in these situations.
 
 Bugfixes:
 - Fixed a bug that prevented mono microphones from properly work with EasyEffects
@@ -18,10 +17,8 @@ Released: 2022-01-27
 
 Features:
 - Support for the next PipeWire release `0.3.44`
-- The autogain filter should deal better with PipeWire's dynamic latency switches. Jumps in volume level should not
-happen anymore in these situations.
-- We added an option that allows the volume and mute state of our virtual devices to be reset when EasyEffects starts.
-It should help with the cases were our devices are muted by the audio server for unknown reasons.
+- The autogain filter should deal better with PipeWire's dynamic latency switches. Jumps in volume level should not happen anymore in these situations.
+- We added an option that allows the volume and mute state of our virtual devices to be reset when EasyEffects starts. It should help with the cases were our devices are muted by the audio server for unknown reasons.
 - Better support for computer suspending. 
 - Updated translations
 


### PR DESCRIPTION
Some of the formatting in NEWS was slightly off.
The generated markdown looked fine (there's no diff in the rendered markdown, only the source), but the appstream release notes split off "It should help with " into a new bullet point, which seems unintended.
Fixed by simply ensuring everything that should be in one bullet point is one line.