### PR TITLE
Set target.object metadata in addition to target.node

### DIFF
--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -42,6 +42,8 @@ struct NodeInfo {
 
   uint device_id = SPA_ID_INVALID;
 
+  uint64_t serial = SPA_ID_INVALID;
+
   std::string name;
 
   std::string description;
@@ -301,7 +303,7 @@ class PipeManager {
 
   spa_hook core_listener{}, registry_listener{};
 
-  void set_metadata_target_node(const uint& origin_id, const uint& target_id) const;
+  void set_metadata_target_node(const uint& origin_id, const uint& target_id, const uint64_t &target_serial) const;
 };
 
 #endif


### PR DESCRIPTION
Pipewire session managers will prioritize target.object metadata, which
uses object.serial values instead of ids.

--------

There's a plan to soft-deprecate target.node, to address the issue that id values are not good for long-term references, since they are reused. Setting target.node will still continue working, but for forward compatibility it's better to also set the other value.