### PR TITLE
Set last-used-x-preset when changed from CLI

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -316,10 +316,12 @@ void application_class_init(ApplicationClass* klass) {
       if (g_variant_dict_lookup(options, "load-preset", "&s", &name) != 0) {
         if (self->presets_manager->preset_file_exists(PresetType::input, name)) {
           self->presets_manager->load_preset_file(PresetType::input, name);
+          g_settings_set_string(self->settings, "last-used-input-preset", name);
         }
 
         if (self->presets_manager->preset_file_exists(PresetType::output, name)) {
           self->presets_manager->load_preset_file(PresetType::output, name);
+          g_settings_set_string(self->settings, "last-used-output-preset", name);
         }
       }
     } else if (g_variant_dict_contains(options, "reset") != 0) {


### PR DESCRIPTION
Hi,

if preset was loaded via CLI, the GUI didn't show the change and checking the selected preset via dconf yielded the wrong result.
Please let me know if there are some contributing procedures I should follow, I couldn't find any.