### PR TITLE
UI improvements

### DIFF
--- a/data/ui/app_info.ui
+++ b/data/ui/app_info.ui
@@ -87,11 +87,12 @@
                                                     </object>
                                                 </child>
 
-                                                <!-- middle dot -->
+                                                <!-- Middle dot -->
                                                 <child>
                                                     <object class="GtkLabel">
                                                         <property name="halign">start</property>
-                                                        <property name="margin-end">5</property>
+                                                        <property name="margin-start">4</property>
+                                                        <property name="margin-end">4</property>
                                                         <property name="label">·</property>
                                                         <style>
                                                             <class name="dim-label" />
@@ -109,11 +110,12 @@
                                                     </object>
                                                 </child>
 
-                                                <!-- middle dot -->
+                                                <!-- Middle dot -->
                                                 <child>
                                                     <object class="GtkLabel">
                                                         <property name="halign">start</property>
-                                                        <property name="margin-end">5</property>
+                                                        <property name="margin-start">4</property>
+                                                        <property name="margin-end">4</property>
                                                         <property name="label">·</property>
                                                         <style>
                                                             <class name="dim-label" />
@@ -131,11 +133,12 @@
                                                     </object>
                                                 </child>
 
-                                                <!-- middle dot -->
+                                                <!-- Middle dot -->
                                                 <child>
                                                     <object class="GtkLabel">
                                                         <property name="halign">start</property>
-                                                        <property name="margin-end">5</property>
+                                                        <property name="margin-start">4</property>
+                                                        <property name="margin-end">4</property>
                                                         <property name="label">·</property>
                                                         <style>
                                                             <class name="dim-label" />
@@ -153,11 +156,12 @@
                                                     </object>
                                                 </child>
 
-                                                <!-- middle dot -->
+                                                <!-- Middle dot -->
                                                 <child>
                                                     <object class="GtkLabel">
                                                         <property name="halign">start</property>
-                                                        <property name="margin-end">5</property>
+                                                        <property name="margin-start">4</property>
+                                                        <property name="margin-end">4</property>
                                                         <property name="label">·</property>
                                                         <style>
                                                             <class name="dim-label" />

--- a/data/ui/app_info.ui
+++ b/data/ui/app_info.ui
@@ -194,6 +194,7 @@
                             <object class="GtkBox" id="enable_box">
                                 <property name="halign">end</property>
                                 <property name="valign">center</property>
+                                <property name="spacing">8</property>
                                 <!-- Enable section -->
                                 <child>
                                     <object class="GtkCheckButton" id="enable">
@@ -217,7 +218,6 @@
                                         </accessibility>
                                     </object>
                                 </child>
-
                             </object>
                         </child>
 

--- a/data/ui/app_info.ui
+++ b/data/ui/app_info.ui
@@ -248,6 +248,9 @@
                                         <property name="sensitive" bind-source="mute" bind-property="active" bind-flags="sync-create|invert-boolean" />
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="xalign">0.5</property>
+                                        <property name="digits">0</property>
+                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">0</property>
@@ -257,8 +260,6 @@
                                                 <property name="page-increment">10</property>
                                             </object>
                                         </property>
-                                        <property name="digits">0</property>
-                                        <property name="update-policy">if-valid</property>
                                         <accessibility>
                                             <property name="label" translatable="yes">Application Volume</property>
                                         </accessibility>

--- a/data/ui/app_info.ui
+++ b/data/ui/app_info.ui
@@ -39,21 +39,16 @@
                                         <property name="valign">center</property>
                                         <property name="spacing">6</property>
                                         <property name="orientation">vertical</property>
-                                        <!-- Application name and state -->
+                                        <!-- Application name -->
                                         <child>
-                                            <object class="GtkBox">
+                                            <object class="GtkLabel" id="app_name">
                                                 <property name="halign">start</property>
+                                                <property name="xalign">0</property>
                                                 <property name="valign">center</property>
-                                                <property name="spacing">3</property>
-                                                <child>
-                                                    <object class="GtkLabel" id="app_name">
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="wrap">1</property>
-                                                        <property name="wrap-mode">PANGO_WRAP_WORD_CHAR</property>
-                                                        <property name="label">App</property>
-                                                    </object>
-                                                </child>
+                                                <property name="wrap">1</property>
+                                                <property name="wrap-mode">word-char</property>
+                                                <property name="selectable">1</property>
+                                                <property name="label">App</property>
                                             </object>
                                         </child>
 
@@ -61,9 +56,11 @@
                                         <child>
                                             <object class="GtkLabel" id="media_name">
                                                 <property name="halign">start</property>
+                                                <property name="xalign">0</property>
                                                 <property name="valign">center</property>
                                                 <property name="wrap">1</property>
-                                                <property name="wrap-mode">PANGO_WRAP_WORD_CHAR</property>
+                                                <property name="wrap-mode">word-char</property>
+                                                <property name="selectable">1</property>
                                                 <property name="label">Description</property>
                                                 <style>
                                                     <class name="dim-label" />

--- a/data/ui/autoload_row.ui
+++ b/data/ui/autoload_row.ui
@@ -23,6 +23,7 @@
                 <child>
                     <object class="GtkLabel" id="device">
                         <property name="halign">start</property>
+                        <property name="ellipsize">end</property>
                         <style>
                             <class name="dim-label" />
                         </style>
@@ -46,6 +47,7 @@
                 <child>
                     <object class="GtkLabel" id="device_description">
                         <property name="halign">start</property>
+                        <property name="ellipsize">end</property>
                         <style>
                             <class name="dim-label" />
                         </style>
@@ -69,6 +71,7 @@
                 <child>
                     <object class="GtkLabel" id="device_profile">
                         <property name="halign">start</property>
+                        <property name="ellipsize">end</property>
                         <style>
                             <class name="dim-label" />
                         </style>
@@ -93,6 +96,7 @@
                 <child>
                     <object class="GtkLabel" id="preset_name">
                         <property name="halign">start</property>
+                        <property name="ellipsize">end</property>
                         <style>
                             <class name="dim-label" />
                         </style>

--- a/data/ui/blocklist_menu.ui
+++ b/data/ui/blocklist_menu.ui
@@ -39,7 +39,7 @@
                                     <class name="suggested-action" />
                                 </style>
                                 <accessibility>
-                                    <property name="label" translatable="yes">Add to Blocklist</property>
+                                    <property name="label" translatable="yes">Add to Excluded Applications</property>
                                 </accessibility>
                             </object>
                         </child>
@@ -83,7 +83,7 @@
                                             <class name="rich-list" />
                                         </style>
                                         <accessibility>
-                                            <property name="label" translatable="yes">Blocklisted Applications List</property>
+                                            <property name="label" translatable="yes">Excluded Applications List</property>
                                         </accessibility>
                                     </object>
                                 </child>

--- a/data/ui/blocklist_menu.ui
+++ b/data/ui/blocklist_menu.ui
@@ -93,25 +93,10 @@
                 </child>
 
                 <child>
-                    <object class="GtkBox">
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="show_blocklisted_apps_label">
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                                <property name="label" translatable="yes">Show Blocklisted Applications</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkSwitch" id="show_blocklisted_apps">
-                                <property name="halign">start</property>
-                                <property name="valign">center</property>
-                                <accessibility>
-                                    <relation name="labelled-by">show_blocklisted_apps_label</relation>
-                                </accessibility>
-                            </object>
-                        </child>
+                    <object class="GtkCheckButton" id="show_blocklisted_apps">
+                        <property name="halign">start</property>
+                        <property name="valign">center</property>
+                        <property name="label" translatable="yes">Show Excluded Applications</property>
                     </object>
                 </child>
             </object>

--- a/data/ui/effects_box.ui
+++ b/data/ui/effects_box.ui
@@ -111,7 +111,7 @@
                         <child>
                             <object class="GtkMenuButton" id="menubutton_blocklist">
                                 <property name="direction">up</property>
-                                <property name="label" translatable="yes">Blocklist</property>
+                                <property name="label" translatable="yes">Excluded Apps</property>
                             </object>
                         </child>
 

--- a/data/ui/plugins_box.ui
+++ b/data/ui/plugins_box.ui
@@ -16,7 +16,7 @@
                         <property name="halign">center</property>
                         <property name="valign">center</property>
                         <property name="direction">right</property>
-                        <property name="label" translatable="yes">Add Plugin</property>
+                        <property name="label" translatable="yes">Add Effect</property>
                     </object>
                 </child>
 

--- a/data/ui/presets_menu.ui
+++ b/data/ui/presets_menu.ui
@@ -10,7 +10,7 @@
                 <property name="margin-end">6</property>
                 <property name="margin-top">6</property>
                 <property name="margin-bottom">6</property>
-                <property name="spacing">6</property>
+                <property name="spacing">12</property>
                 <child>
                     <object class="AdwViewSwitcher" id="switcher_title">
                         <property name="stack">stack</property>
@@ -25,7 +25,7 @@
                         <child>
                             <object class="AdwViewStackPage">
                                 <property name="name">page_output</property>
-                                <property name="title" translatable="yes">Speakers</property>
+                                <property name="title" translatable="yes">Output</property>
                                 <property name="icon_name">audio-speakers-symbolic</property>
                                 <property name="child">
                                     <object class="GtkBox">
@@ -178,7 +178,7 @@
                         <child>
                             <object class="AdwViewStackPage">
                                 <property name="name">page_input</property>
-                                <property name="title" translatable="yes">Microphone</property>
+                                <property name="title" translatable="yes">Input</property>
                                 <property name="icon_name">audio-input-microphone-symbolic</property>
                                 <property name="child">
                                     <object class="GtkBox">

--- a/src/blocklist_menu.cpp
+++ b/src/blocklist_menu.cpp
@@ -78,6 +78,8 @@ void setup_listview(BlocklistMenu* self) {
 
         gtk_widget_set_halign(GTK_WIDGET(label), GTK_ALIGN_START);
         gtk_widget_set_hexpand(GTK_WIDGET(label), 1);
+        gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
+        gtk_label_set_max_width_chars(GTK_LABEL(label), 100);
 
         gtk_box_append(GTK_BOX(box), GTK_WIDGET(label));
         gtk_box_append(GTK_BOX(box), GTK_WIDGET(button));

--- a/src/blocklist_menu.cpp
+++ b/src/blocklist_menu.cpp
@@ -45,7 +45,7 @@ struct _BlocklistMenu {
 
   GtkText* app_name;
 
-  GtkSwitch* show_blocklisted_apps;
+  GtkCheckButton* show_blocklisted_apps;
 
   GtkStringList* string_list;
 

--- a/src/effects_box.cpp
+++ b/src/effects_box.cpp
@@ -303,7 +303,7 @@ void setup(EffectsBox* self, app::Application* application, PipelineType pipelin
   }
 
   self->plugins_box_page =
-      adw_view_stack_add_titled(self->stack, GTK_WIDGET(self->pluginsBox), "plugins", _("Plugins"));
+      adw_view_stack_add_titled(self->stack, GTK_WIDGET(self->pluginsBox), "plugins", _("Effects"));
 
   adw_view_stack_page_set_icon_name(self->plugins_box_page, "ee-plugins-symbolic");
 


### PR DESCRIPTION
Some fixes and improvements. Some of them trying to address what exposed [here](https://github.com/wwmm/easyeffects/issues/1316#issuecomment-1065931764).

- App Info: improved middle dot spacing and spacing between checkbuttons; text centered in volume spinbutton.
- App Info: app name and description are now selectable to be copied in the clipboard (thought it could be useful to the user and the app name could be pasted in the excluded list).
- App Info: `xalign` set to `0` is fixing the blur effect GTK bug on wrapped label and also improving the alignment on wrapped lines. 
- Plugin word replaced by Effect (more intuitive and follows the application name).
- Preset Autoload: labels of parameters have ellipsize property, so the delete button should not be hidden on low width window.
- Blocklist: The UI now exposes it like "Excluded Applications", no Blocklist anymore; we keep calling it as blocklist in the code.
- Excluded Apps Menu: the app name row now has ellipsize and max-width-char properties keeping the popover menu at reasonable width in case of extreme labels.
- Excluded Apps Menu: Show Exclude Applications changed as a checkbutton; The switch seems to big there. 
- Presets Menu: changed Microphone/Speakers in Input/Output, following Input/Output buttons in headerbar.

Edit: Tomorrow I should add the new translations.