### PR TITLE
Spectrum: add margin to labels

### DIFF
--- a/src/chart.cpp
+++ b/src/chart.cpp
@@ -269,14 +269,16 @@ auto draw_x_labels(Chart* self, GtkSnapshot* snapshot, const int& width, const i
     }
   }
 
-  draw_unit(self, snapshot, width, height, self->data->x_unit);
+  draw_unit(self, snapshot, width, height, " "s + self->data->x_unit + " "s);
 
   /*
-    There is no space left in the window to show the last label. So we skip it
+    There is no space left in the window to show the last label. So we skip it.
+    All labels are enclosed by whitespaces to not stick the first and the final
+    at window borders.
   */
 
   for (size_t n = 0U; n < labels.size() - 1; n++) {
-    const auto msg = fmt::format(self->data->user_locale, "{0:.{1}Lf}", labels[n], self->data->n_x_decimals);
+    const auto msg = fmt::format(self->data->user_locale, " {0:.{1}Lf} ", labels[n], self->data->n_x_decimals);
 
     auto* layout = gtk_widget_create_pango_layout(GTK_WIDGET(self), msg.c_str());
 
@@ -490,7 +492,8 @@ void snapshot(GtkWidget* widget, GtkSnapshot* snapshot) {
     }
 
     if (gtk_event_controller_motion_contains_pointer(GTK_EVENT_CONTROLLER_MOTION(self->controller_motion)) != 0) {
-      const auto msg = fmt::format(self->data->user_locale, "x = {0:.{1}Lf} {2} y = {3:.{4}Lf} {5}",
+      // We leave a withespace at the end to not stick the string at the window border.
+      const auto msg = fmt::format(self->data->user_locale, "x = {0:.{1}Lf} {2} y = {3:.{4}Lf} {5} ",
                                    self->data->mouse_x, self->data->n_x_decimals, self->data->x_unit,
                                    self->data->mouse_y, self->data->n_y_decimals, self->data->y_unit);
 


### PR DESCRIPTION
As I said in a previous post, since GTK widgets have a native padding, it would be better to not stick the spectrum labels to the window borders.

There's a `set_margin` method in the spectrum class, but I thought it would add the margin to the chart also while I want it only on the labels.

I simply ended up adding whitespaces. 