### PR TITLE
Default app icon and Effects adw status page

### DIFF
--- a/data/ui/app_info.ui
+++ b/data/ui/app_info.ui
@@ -28,7 +28,7 @@
                                     <object class="GtkImage" id="app_icon">
                                         <property name="halign">start</property>
                                         <property name="valign">center</property>
-                                        <property name="icon_size">large</property>
+                                        <property name="icon-size">large</property>
                                     </object>
                                 </child>
 
@@ -233,7 +233,7 @@
                                 <child>
                                     <object class="GtkToggleButton" id="mute">
                                         <property name="valign">center</property>
-                                        <property name="icon_name">audio-volume-high-symbolic</property>
+                                        <property name="icon-name">audio-volume-high-symbolic</property>
                                         <accessibility>
                                             <property name="label" translatable="yes">Mute Application</property>
                                         </accessibility>

--- a/data/ui/application_window.ui
+++ b/data/ui/application_window.ui
@@ -58,10 +58,10 @@
 
                         <child>
                             <object class="GtkToggleButton" id="bypass_button">
-                                <property name="tooltip_text" translatable="yes">Global Bypass</property>
+                                <property name="tooltip-text" translatable="yes">Global Bypass</property>
                                 <property name="halign">center</property>
                                 <property name="valign">center</property>
-                                <property name="icon_name">media-playlist-shuffle-symbolic</property>
+                                <property name="icon-name">media-playlist-shuffle-symbolic</property>
                                 <accessibility>
                                     <property name="label" translatable="yes">Global Bypass</property>
                                 </accessibility>

--- a/data/ui/autoload_row.ui
+++ b/data/ui/autoload_row.ui
@@ -111,10 +111,10 @@
 
         <child>
             <object class="GtkButton" id="remove">
-                <property name="tooltip_text" translatable="yes">Remove</property>
+                <property name="tooltip-text" translatable="yes">Remove</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="icon_name">user-trash-symbolic</property>
+                <property name="icon-name">user-trash-symbolic</property>
             </object>
         </child>
     </object>

--- a/data/ui/blocklist_menu.ui
+++ b/data/ui/blocklist_menu.ui
@@ -20,8 +20,8 @@
                             <object class="GtkText" id="app_name">
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
-                                <property name="placeholder_text" translatable="yes">Application Name</property>
-                                <property name="accessible_role">text-box</property>
+                                <property name="placeholder-text" translatable="yes">Application Name</property>
+                                <property name="accessible-role">text-box</property>
                                 <accessibility>
                                     <property name="label" translatable="yes">Application Name</property>
                                 </accessibility>
@@ -33,7 +33,7 @@
                                 <property name="margin-bottom">3</property>
                                 <property name="halign">center</property>
                                 <property name="valign">center</property>
-                                <property name="icon_name">list-add-symbolic</property>
+                                <property name="icon-name">list-add-symbolic</property>
                                 <signal name="clicked" handler="on_add_to_blocklist" object="BlocklistMenu" />
                                 <style>
                                     <class name="suggested-action" />
@@ -53,8 +53,8 @@
                     <object class="GtkFrame">
                         <child>
                             <object class="GtkScrolledWindow" id="scrolled_window">
-                                <property name="propagate_natural_width">1</property>
-                                <property name="propagate_natural_height">1</property>
+                                <property name="propagate-natural-width">1</property>
+                                <property name="propagate-natural-height">1</property>
                                 <child>
                                     <object class="GtkListView" id="listview">
                                         <property name="hexpand">1</property>

--- a/data/ui/compressor.ui
+++ b/data/ui/compressor.ui
@@ -29,8 +29,8 @@
                 <property name="hexpand">1</property>
                 <property name="hhomogeneous">0</property>
                 <property name="vhomogeneous">0</property>
-                <property name="transition_duration">250</property>
-                <property name="transition_type">slide-left-right</property>
+                <property name="transition-duration">250</property>
+                <property name="transition-type">slide-left-right</property>
 
                 <child>
                     <object class="GtkStackPage">

--- a/data/ui/convolver_menu_combine.ui
+++ b/data/ui/convolver_menu_combine.ui
@@ -88,9 +88,9 @@
                     <object class="GtkEntry" id="output_kernel_name">
                         <property name="valign">center</property>
                         <property name="hexpand">1</property>
-                        <property name="placeholder_text" translatable="yes">Output File Name</property>
-                        <property name="input_purpose">name</property>
-                        <property name="accessible_role">text-box</property>
+                        <property name="placeholder-text" translatable="yes">Output File Name</property>
+                        <property name="input-purpose">name</property>
+                        <property name="accessible-role">text-box</property>
                         <accessibility>
                             <property name="label" translatable="yes">Combined Kernel Name</property>
                         </accessibility>

--- a/data/ui/convolver_menu_impulses.ui
+++ b/data/ui/convolver_menu_impulses.ui
@@ -22,7 +22,7 @@
                     <object class="GtkSearchEntry" id="entry_search">
                         <property name="valign">start</property>
                         <property name="hexpand">1</property>
-                        <property name="placeholder_text" translatable="yes">Search</property>
+                        <property name="placeholder-text" translatable="yes">Search</property>
                         <accessibility>
                             <property name="label" translatable="yes">Search Impulse File</property>
                         </accessibility>
@@ -33,8 +33,8 @@
                     <object class="GtkFrame">
                         <child>
                             <object class="GtkScrolledWindow" id="scrolled_window">
-                                <property name="propagate_natural_width">1</property>
-                                <property name="propagate_natural_height">1</property>
+                                <property name="propagate-natural-width">1</property>
+                                <property name="propagate-natural-height">1</property>
                                 <child>
                                     <object class="GtkListView" id="listview">
                                         <property name="hexpand">1</property>

--- a/data/ui/effects_box.ui
+++ b/data/ui/effects_box.ui
@@ -64,7 +64,7 @@
                                     <object class="GtkLabel" id="label_global_output_level_left">
                                         <property name="halign">center</property>
                                         <property name="valign">center</property>
-                                        <property name="width_chars">4</property>
+                                        <property name="width-chars">4</property>
                                         <property name="label">0</property>
                                         <style>
                                             <class name="dim-label" />
@@ -75,7 +75,7 @@
                                     <object class="GtkLabel" id="label_global_output_level_right">
                                         <property name="halign">center</property>
                                         <property name="valign">center</property>
-                                        <property name="width_chars">4</property>
+                                        <property name="width-chars">4</property>
                                         <property name="label">0</property>
                                         <style>
                                             <class name="dim-label" />
@@ -98,7 +98,7 @@
                                         <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="opacity">0</property>
-                                        <property name="icon_name">dialog-warning-symbolic</property>
+                                        <property name="icon-name">dialog-warning-symbolic</property>
                                     </object>
                                 </child>
                             </object>

--- a/data/ui/equalizer.ui
+++ b/data/ui/equalizer.ui
@@ -29,8 +29,8 @@
                                 <child>
                                     <object class="GtkStack" id="stack">
                                         <property name="halign">center</property>
-                                        <property name="transition_duration">250</property>
-                                        <property name="transition_type">slide-left-right</property>
+                                        <property name="transition-duration">250</property>
+                                        <property name="transition-type">slide-left-right</property>
                                         <child>
                                             <object class="GtkStackPage">
                                                 <property name="name">page_left_channel</property>

--- a/data/ui/factory_input_device_dropdown.ui
+++ b/data/ui/factory_input_device_dropdown.ui
@@ -8,7 +8,7 @@
                     <object class="GtkImage">
                         <property name="halign">start</property>
                         <property name="valign">center</property>
-                        <property name="icon_name">audio-input-microphone-symbolic</property>
+                        <property name="icon-name">audio-input-microphone-symbolic</property>
                     </object>
                 </child>
 

--- a/data/ui/factory_output_device_dropdown.ui
+++ b/data/ui/factory_output_device_dropdown.ui
@@ -8,7 +8,7 @@
                     <object class="GtkImage">
                         <property name="halign">start</property>
                         <property name="valign">center</property>
-                        <property name="icon_name">audio-speakers-symbolic</property>
+                        <property name="icon-name">audio-speakers-symbolic</property>
                     </object>
                 </child>
 

--- a/data/ui/factory_presets_dropdown.ui
+++ b/data/ui/factory_presets_dropdown.ui
@@ -8,7 +8,7 @@
                     <object class="GtkImage">
                         <property name="halign">start</property>
                         <property name="valign">center</property>
-                        <property name="icon_name">emblem-system-symbolic</property>
+                        <property name="icon-name">emblem-system-symbolic</property>
                     </object>
                 </child>
 

--- a/data/ui/factory_rnnoise_listview.ui
+++ b/data/ui/factory_rnnoise_listview.ui
@@ -21,10 +21,10 @@
 
                 <child>
                     <object class="GtkButton" id="remove">
-                        <property name="tooltip_text" translatable="yes">Remove this model file</property>
+                        <property name="tooltip-text" translatable="yes">Remove this model file</property>
                         <property name="halign">center</property>
                         <property name="valign">center</property>
-                        <property name="icon_name">user-trash-symbolic</property>
+                        <property name="icon-name">user-trash-symbolic</property>
                         <signal name="clicked" handler="on_remove_model_file" object="GtkListItem" />
 
                         <binding name="visible">

--- a/data/ui/multiband_compressor.ui
+++ b/data/ui/multiband_compressor.ui
@@ -132,8 +132,8 @@
                                 <property name="valign">start</property>
                                 <property name="hhomogeneous">0</property>
                                 <property name="vhomogeneous">0</property>
-                                <property name="transition_duration">250</property>
-                                <property name="transition_type">slide-left-right</property>
+                                <property name="transition-duration">250</property>
+                                <property name="transition-type">slide-left-right</property>
                             </object>
                         </child>
                     </object>

--- a/data/ui/multiband_gate.ui
+++ b/data/ui/multiband_gate.ui
@@ -162,8 +162,8 @@
                 <property name="hexpand">1</property>
                 <property name="hhomogeneous">0</property>
                 <property name="vhomogeneous">0</property>
-                <property name="transition_duration">250</property>
-                <property name="transition_type">slide-left-right</property>
+                <property name="transition-duration">250</property>
+                <property name="transition-type">slide-left-right</property>
                 <child>
                     <object class="GtkStackPage">
                         <property name="name">page_sub_band</property>

--- a/data/ui/pipe_manager_box.ui
+++ b/data/ui/pipe_manager_box.ui
@@ -14,8 +14,8 @@
             <object class="GtkStack" id="stack">
                 <property name="hexpand">1</property>
                 <property name="vexpand">1</property>
-                <property name="transition_duration">250</property>
-                <property name="transition_type">slide-up-down</property>
+                <property name="transition-duration">250</property>
+                <property name="transition-type">slide-up-down</property>
                 <property name="margin-start">6</property>
                 <property name="margin-end">6</property>
                 <property name="margin-top">6</property>
@@ -35,7 +35,7 @@
                                                 <child>
                                                     <object class="AdwActionRow">
                                                         <property name="title" translatable="yes">Use Default</property>
-                                                        <property name="activatable_widget">use_default_input</property>
+                                                        <property name="activatable-widget">use_default_input</property>
                                                         <child>
                                                             <object class="GtkSwitch" id="use_default_input">
                                                                 <property name="valign">center</property>
@@ -76,7 +76,7 @@
                                                 <child>
                                                     <object class="AdwActionRow">
                                                         <property name="title" translatable="yes">Use Default</property>
-                                                        <property name="activatable_widget">use_default_output</property>
+                                                        <property name="activatable-widget">use_default_output</property>
                                                         <child>
                                                             <object class="GtkSwitch" id="use_default_output">
                                                                 <property name="valign">center</property>
@@ -201,8 +201,8 @@
                                     <object class="GtkStack" id="stack_presets_autoloading">
                                         <property name="hexpand">1</property>
                                         <property name="vexpand">1</property>
-                                        <property name="transition_duration">250</property>
-                                        <property name="transition_type">slide-left-right</property>
+                                        <property name="transition-duration">250</property>
+                                        <property name="transition-type">slide-left-right</property>
                                         <property name="margin-start">6</property>
                                         <property name="margin-end">6</property>
                                         <property name="margin-top">6</property>
@@ -257,10 +257,10 @@
 
                                                                 <child>
                                                                     <object class="GtkButton" id="autoloading_add_output_profile">
-                                                                        <property name="tooltip_text" translatable="yes">Create Association</property>
+                                                                        <property name="tooltip-text" translatable="yes">Create Association</property>
                                                                         <property name="halign">center</property>
                                                                         <property name="valign">center</property>
-                                                                        <property name="icon_name">list-add-symbolic</property>
+                                                                        <property name="icon-name">list-add-symbolic</property>
                                                                         <signal name="clicked" handler="on_autoloading_add_output_profile" object="PipeManagerBox" />
                                                                         <layout>
                                                                             <property name="column">1</property>
@@ -349,10 +349,10 @@
 
                                                                 <child>
                                                                     <object class="GtkButton" id="autoloading_add_input_profile">
-                                                                        <property name="tooltip_text" translatable="yes">Create Association</property>
+                                                                        <property name="tooltip-text" translatable="yes">Create Association</property>
                                                                         <property name="halign">center</property>
                                                                         <property name="valign">center</property>
-                                                                        <property name="icon_name">list-add-symbolic</property>
+                                                                        <property name="icon-name">list-add-symbolic</property>
                                                                         <signal name="clicked" handler="on_autoloading_add_input_profile" object="PipeManagerBox" />
                                                                         <layout>
                                                                             <property name="column">1</property>

--- a/data/ui/plugin_row.ui
+++ b/data/ui/plugin_row.ui
@@ -8,7 +8,7 @@
             <object class="GtkImage" id="plugin_icon">
                 <property name="halign">start</property>
                 <property name="valign">center</property>
-                <property name="icon_name">ee-arrow-down-symbolic</property>
+                <property name="icon-name">ee-arrow-down-symbolic</property>
             </object>
         </child>
 
@@ -23,10 +23,10 @@
 
         <child>
             <object class="GtkButton" id="remove">
-                <property name="tooltip_text" translatable="yes">Remove this plugin</property>
+                <property name="tooltip-text" translatable="yes">Remove this plugin</property>
                 <property name="valign">center</property>
                 <property name="opacity">0</property>
-                <property name="icon_name">user-trash-symbolic</property>
+                <property name="icon-name">user-trash-symbolic</property>
                 <style>
                     <class name="flat" />
                 </style>
@@ -38,7 +38,7 @@
                 <property name="halign">end</property>
                 <property name="valign">center</property>
                 <property name="opacity">0</property>
-                <property name="icon_name">ee-drag-handle-symbolic</property>
+                <property name="icon-name">ee-drag-handle-symbolic</property>
             </object>
         </child>
     </object>

--- a/data/ui/plugins_box.ui
+++ b/data/ui/plugins_box.ui
@@ -47,11 +47,25 @@
         </child>
 
         <child>
-            <object class="GtkScrolledWindow">
+            <object class="GtkOverlay" id="plugin_overlay">
+                <property name="hexpand">1</property>
+                <property name="vexpand">1</property>
                 <child>
-                    <object class="GtkStack" id="stack">
-                        <property name="hhomogeneous">0</property>
-                        <property name="vhomogeneous">0</property>
+                    <object class="GtkScrolledWindow">
+                        <child>
+                            <object class="GtkStack" id="stack">
+                                <property name="hhomogeneous">0</property>
+                                <property name="vhomogeneous">0</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+
+                <child type="overlay">
+                    <object class="AdwStatusPage" id="overlay_no_plugins">
+                        <property name="icon-name">emblem-music-symbolic</property>
+                        <property name="title" translatable="yes">No Effects</property>
+                        <property name="description" translatable="yes">Audio Stream Not Modified</property>
                     </object>
                 </child>
             </object>

--- a/data/ui/plugins_menu.ui
+++ b/data/ui/plugins_menu.ui
@@ -14,7 +14,7 @@
                     <object class="GtkSearchEntry" id="plugins_search">
                         <property name="valign">start</property>
                         <property name="hexpand">1</property>
-                        <property name="placeholder_text" translatable="yes">Search</property>
+                        <property name="placeholder-text" translatable="yes">Search</property>
                         <accessibility>
                             <property name="label" translatable="yes">Search Plugin</property>
                         </accessibility>
@@ -25,8 +25,8 @@
                     <object class="GtkFrame">
                         <child>
                             <object class="GtkScrolledWindow" id="scrolled_window">
-                                <property name="propagate_natural_width">1</property>
-                                <property name="propagate_natural_height">1</property>
+                                <property name="propagate-natural-width">1</property>
+                                <property name="propagate-natural-height">1</property>
                                 <child>
                                     <object class="GtkListView" id="listview">
                                         <property name="hexpand">1</property>

--- a/data/ui/preferences_general.ui
+++ b/data/ui/preferences_general.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface domain="easyeffects">
     <template class="PreferencesGeneral" parent="AdwPreferencesPage">
-        <property name="icon_name">preferences-system-symbolic</property>
+        <property name="icon-name">preferences-system-symbolic</property>
         <property name="title" translatable="yes">_General</property>
         <property name="use-underline">1</property>
 
@@ -11,7 +11,7 @@
                 <child>
                     <object class="AdwActionRow">
                         <property name="title" translatable="yes">Start Service at Login</property>
-                        <property name="activatable_widget">enable_autostart</property>
+                        <property name="activatable-widget">enable_autostart</property>
                         <child>
                             <object class="GtkSwitch" id="enable_autostart">
                                 <property name="valign">center</property>
@@ -24,7 +24,7 @@
                 <child>
                     <object class="AdwActionRow">
                         <property name="title" translatable="yes">Shutdown on Window Close</property>
-                        <property name="activatable_widget">shutdown_on_window_close</property>
+                        <property name="activatable-widget">shutdown_on_window_close</property>
                         <child>
                             <object class="GtkSwitch" id="shutdown_on_window_close">
                                 <property name="valign">center</property>
@@ -41,7 +41,7 @@
                 <child>
                     <object class="AdwActionRow">
                         <property name="title" translatable="yes">Process All Outputs</property>
-                        <property name="activatable_widget">process_all_outputs</property>
+                        <property name="activatable-widget">process_all_outputs</property>
                         <child>
                             <object class="GtkSwitch" id="process_all_outputs">
                                 <property name="valign">center</property>
@@ -53,7 +53,7 @@
                 <child>
                     <object class="AdwActionRow">
                         <property name="title" translatable="yes">Process All Inputs</property>
-                        <property name="activatable_widget">process_all_inputs</property>
+                        <property name="activatable-widget">process_all_inputs</property>
                         <child>
                             <object class="GtkSwitch" id="process_all_inputs">
                                 <property name="valign">center</property>
@@ -65,7 +65,7 @@
                 <child>
                     <object class="AdwActionRow">
                         <property name="title" translatable="yes">Use Cubic Volume</property>
-                        <property name="activatable_widget">use_cubic_volumes</property>
+                        <property name="activatable-widget">use_cubic_volumes</property>
                         <child>
                             <object class="GtkSwitch" id="use_cubic_volumes">
                                 <property name="valign">center</property>
@@ -77,7 +77,7 @@
                 <child>
                     <object class="AdwActionRow">
                         <property name="title" translatable="yes">Reset Our Devices Volume on Startup</property>
-                        <property name="activatable_widget">reset_volume_on_startup</property>
+                        <property name="activatable-widget">reset_volume_on_startup</property>
                         <child>
                             <object class="GtkSwitch" id="reset_volume_on_startup">
                                 <property name="valign">center</property>
@@ -116,7 +116,7 @@
                 <child>
                     <object class="AdwActionRow">
                         <property name="title" translatable="yes">Use Dark Theme</property>
-                        <property name="activatable_widget">theme_switch</property>
+                        <property name="activatable-widget">theme_switch</property>
                         <child>
                             <object class="GtkSwitch" id="theme_switch">
                                 <property name="valign">center</property>
@@ -128,7 +128,7 @@
                 <child>
                     <object class="AdwActionRow">
                         <property name="title" translatable="yes">Hide Menus on Outside Clicks</property>
-                        <property name="activatable_widget">autohide_popovers</property>
+                        <property name="activatable-widget">autohide_popovers</property>
                         <child>
                             <object class="GtkSwitch" id="autohide_popovers">
                                 <property name="valign">center</property>

--- a/data/ui/preferences_spectrum.ui
+++ b/data/ui/preferences_spectrum.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface domain="easyeffects">
     <template class="PreferencesSpectrum" parent="AdwPreferencesPage">
-        <property name="icon_name">ee-spectrum-symbolic</property>
+        <property name="icon-name">ee-spectrum-symbolic</property>
         <property name="title" translatable="yes">_Spectrum</property>
         <property name="use-underline">1</property>
         <child>
@@ -10,7 +10,7 @@
                 <child>
                     <object class="AdwActionRow">
                         <property name="title" translatable="yes">Enabled</property>
-                        <property name="activatable_widget">show</property>
+                        <property name="activatable-widget">show</property>
                         <child>
                             <object class="GtkSwitch" id="show">
                                 <property name="valign">center</property>
@@ -112,7 +112,7 @@
                 <child>
                     <object class="AdwActionRow">
                         <property name="title" translatable="yes">Fill</property>
-                        <property name="activatable_widget">fill</property>
+                        <property name="activatable-widget">fill</property>
                         <child>
                             <object class="GtkSwitch" id="fill">
                                 <property name="valign">center</property>
@@ -124,7 +124,7 @@
                 <child>
                     <object class="AdwActionRow">
                         <property name="title" translatable="yes">Show Bars Border</property>
-                        <property name="activatable_widget">show_bar_border</property>
+                        <property name="activatable-widget">show_bar_border</property>
                         <child>
                             <object class="GtkSwitch" id="show_bar_border">
                                 <property name="valign">center</property>
@@ -136,7 +136,7 @@
                 <child>
                     <object class="AdwActionRow">
                         <property name="title" translatable="yes">Rounded Corners</property>
-                        <property name="activatable_widget">rounded_corners</property>
+                        <property name="activatable-widget">rounded_corners</property>
                         <child>
                             <object class="GtkSwitch" id="rounded_corners">
                                 <property name="valign">center</property>

--- a/data/ui/preset_row.ui
+++ b/data/ui/preset_row.ui
@@ -26,10 +26,10 @@
 
         <child>
             <object class="GtkButton" id="save">
-                <property name="tooltip_text" translatable="yes">Save current settings to this preset file</property>
+                <property name="tooltip-text" translatable="yes">Save current settings to this preset file</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
-                <property name="icon_name">document-save-symbolic</property>
+                <property name="icon-name">document-save-symbolic</property>
                 <accessibility>
                     <relation name="labelled-by">name</relation>
                 </accessibility>
@@ -38,10 +38,10 @@
 
         <child>
             <object class="GtkButton" id="remove">
-                <property name="tooltip_text" translatable="yes">Remove this preset file</property>
+                <property name="tooltip-text" translatable="yes">Remove this preset file</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
-                <property name="icon_name">user-trash-symbolic</property>
+                <property name="icon-name">user-trash-symbolic</property>
                 <accessibility>
                     <relation name="labelled-by">name</relation>
                 </accessibility>

--- a/data/ui/presets_menu.ui
+++ b/data/ui/presets_menu.ui
@@ -26,7 +26,7 @@
                             <object class="AdwViewStackPage">
                                 <property name="name">page_output</property>
                                 <property name="title" translatable="yes">Output</property>
-                                <property name="icon_name">audio-speakers-symbolic</property>
+                                <property name="icon-name">audio-speakers-symbolic</property>
                                 <property name="child">
                                     <object class="GtkBox">
                                         <property name="hexpand">1</property>
@@ -47,9 +47,9 @@
                                                             <object class="GtkText" id="output_name">
                                                                 <property name="valign">center</property>
                                                                 <property name="hexpand">1</property>
-                                                                <property name="placeholder_text" translatable="yes">Name</property>
-                                                                <property name="input_purpose">name</property>
-                                                                <property name="accessible_role">text-box</property>
+                                                                <property name="placeholder-text" translatable="yes">Name</property>
+                                                                <property name="input-purpose">name</property>
+                                                                <property name="accessible-role">text-box</property>
                                                                 <accessibility>
                                                                     <property name="label" translatable="yes">New Output Preset Name</property>
                                                                 </accessibility>
@@ -59,10 +59,10 @@
                                                             <object class="GtkButton" id="add_output">
                                                                 <property name="margin-top">3</property>
                                                                 <property name="margin-bottom">3</property>
-                                                                <property name="tooltip_text" translatable="yes">Create Preset</property>
+                                                                <property name="tooltip-text" translatable="yes">Create Preset</property>
                                                                 <property name="halign">center</property>
                                                                 <property name="valign">center</property>
-                                                                <property name="icon_name">list-add-symbolic</property>
+                                                                <property name="icon-name">list-add-symbolic</property>
                                                                 <signal name="clicked" handler="create_output_preset" object="PresetsMenu" />
                                                                 <style>
                                                                     <class name="suggested-action" />
@@ -73,10 +73,10 @@
                                                             <object class="GtkButton" id="import_output">
                                                                 <property name="margin-top">3</property>
                                                                 <property name="margin-bottom">3</property>
-                                                                <property name="tooltip_text" translatable="yes">Import Presets</property>
+                                                                <property name="tooltip-text" translatable="yes">Import Presets</property>
                                                                 <property name="halign">center</property>
                                                                 <property name="valign">center</property>
-                                                                <property name="icon_name">document-open-symbolic</property>
+                                                                <property name="icon-name">document-open-symbolic</property>
                                                                 <signal name="clicked" handler="import_output_preset" object="PresetsMenu" />
                                                             </object>
                                                         </child>
@@ -89,7 +89,7 @@
                                             <object class="GtkSearchEntry" id="output_search">
                                                 <property name="valign">start</property>
                                                 <property name="hexpand">1</property>
-                                                <property name="placeholder_text" translatable="yes">Search</property>
+                                                <property name="placeholder-text" translatable="yes">Search</property>
                                                 <accessibility>
                                                     <property name="label" translatable="yes">Search Output Preset</property>
                                                 </accessibility>
@@ -104,8 +104,8 @@
                                                     <object class="GtkScrolledWindow" id="output_scrolled_window">
                                                         <property name="hexpand">1</property>
                                                         <property name="vexpand">1</property>
-                                                        <property name="propagate_natural_width">1</property>
-                                                        <property name="propagate_natural_height">1</property>
+                                                        <property name="propagate-natural-width">1</property>
+                                                        <property name="propagate-natural-height">1</property>
                                                         <child>
                                                             <object class="GtkListView" id="output_listview">
                                                                 <property name="hexpand">1</property>
@@ -179,7 +179,7 @@
                             <object class="AdwViewStackPage">
                                 <property name="name">page_input</property>
                                 <property name="title" translatable="yes">Input</property>
-                                <property name="icon_name">audio-input-microphone-symbolic</property>
+                                <property name="icon-name">audio-input-microphone-symbolic</property>
                                 <property name="child">
                                     <object class="GtkBox">
                                         <property name="hexpand">1</property>
@@ -200,9 +200,9 @@
                                                             <object class="GtkText" id="input_name">
                                                                 <property name="valign">center</property>
                                                                 <property name="hexpand">1</property>
-                                                                <property name="placeholder_text" translatable="yes">Name</property>
-                                                                <property name="input_purpose">name</property>
-                                                                <property name="accessible_role">text-box</property>
+                                                                <property name="placeholder-text" translatable="yes">Name</property>
+                                                                <property name="input-purpose">name</property>
+                                                                <property name="accessible-role">text-box</property>
                                                                 <accessibility>
                                                                     <property name="label" translatable="yes">New Input Preset Name</property>
                                                                 </accessibility>
@@ -212,10 +212,10 @@
                                                             <object class="GtkButton" id="add_input">
                                                                 <property name="margin-top">3</property>
                                                                 <property name="margin-bottom">3</property>
-                                                                <property name="tooltip_text" translatable="yes">Create Preset</property>
+                                                                <property name="tooltip-text" translatable="yes">Create Preset</property>
                                                                 <property name="halign">center</property>
                                                                 <property name="valign">center</property>
-                                                                <property name="icon_name">list-add-symbolic</property>
+                                                                <property name="icon-name">list-add-symbolic</property>
                                                                 <signal name="clicked" handler="create_input_preset" object="PresetsMenu" />
                                                                 <style>
                                                                     <class name="suggested-action" />
@@ -226,10 +226,10 @@
                                                             <object class="GtkButton" id="import_input">
                                                                 <property name="margin-top">3</property>
                                                                 <property name="margin-bottom">3</property>
-                                                                <property name="tooltip_text" translatable="yes">Import Presets</property>
+                                                                <property name="tooltip-text" translatable="yes">Import Presets</property>
                                                                 <property name="halign">center</property>
                                                                 <property name="valign">center</property>
-                                                                <property name="icon_name">document-open-symbolic</property>
+                                                                <property name="icon-name">document-open-symbolic</property>
                                                                 <signal name="clicked" handler="import_input_preset" object="PresetsMenu" />
                                                             </object>
                                                         </child>
@@ -242,7 +242,7 @@
                                             <object class="GtkSearchEntry" id="input_search">
                                                 <property name="valign">start</property>
                                                 <property name="hexpand">1</property>
-                                                <property name="placeholder_text" translatable="yes">Search</property>
+                                                <property name="placeholder-text" translatable="yes">Search</property>
                                                 <accessibility>
                                                     <property name="label" translatable="yes">Search Input Preset</property>
                                                 </accessibility>
@@ -257,8 +257,8 @@
                                                     <object class="GtkScrolledWindow" id="input_scrolled_window">
                                                         <property name="hexpand">1</property>
                                                         <property name="vexpand">1</property>
-                                                        <property name="propagate_natural_width">1</property>
-                                                        <property name="propagate_natural_height">1</property>
+                                                        <property name="propagate-natural-width">1</property>
+                                                        <property name="propagate-natural-height">1</property>
                                                         <child>
                                                             <object class="GtkListView" id="input_listview">
                                                                 <property name="hexpand">1</property>

--- a/data/ui/rnnoise.ui
+++ b/data/ui/rnnoise.ui
@@ -16,7 +16,7 @@
                     <object class="GtkButton" id="import_model">
                         <property name="halign">center</property>
                         <property name="valign">center</property>
-                        <property name="icon_name">document-open-symbolic</property>
+                        <property name="icon-name">document-open-symbolic</property>
                         <property name="label" translatable="yes">Import Model</property>
                         <signal name="clicked" handler="on_import_model_clicked" object="RNNoiseBox" />
                     </object>

--- a/data/ui/stereo_tools.ui
+++ b/data/ui/stereo_tools.ui
@@ -29,8 +29,8 @@
                 <property name="hexpand">1</property>
                 <property name="hhomogeneous">0</property>
                 <property name="vhomogeneous">0</property>
-                <property name="transition_duration">250</property>
-                <property name="transition_type">slide-left-right</property>
+                <property name="transition-duration">250</property>
+                <property name="transition-type">slide-left-right</property>
 
                 <child>
                     <object class="GtkStackPage">

--- a/src/app_info.cpp
+++ b/src/app_info.cpp
@@ -271,24 +271,14 @@ void update(AppInfo* self, const NodeInfo node_info) {
 
   // set the icon name
 
-  if (self->icon_theme != nullptr) {
-    if (const auto icon_name = get_app_icon_name(node_info); !icon_name.empty()) {
-      if (icon_available(self, icon_name)) {
-        gtk_widget_set_visible(GTK_WIDGET(self->app_icon), 1);
-
-        gtk_image_set_from_icon_name(self->app_icon, icon_name.c_str());
-      } else {
-        gtk_widget_set_visible(GTK_WIDGET(self->app_icon), 0);
-
-        util::debug(log_tag + icon_name + " icon name not installed in the " +
-                    gtk_icon_theme_get_theme_name(self->icon_theme) + " icon theme in use. " +
-                    "The application icon has been hidden.");
-      }
-    } else {
-      gtk_widget_set_visible(GTK_WIDGET(self->app_icon), 0);
-    }
+  if (const auto default_app_icon = "applications-multimedia-symbolic"s; self->icon_theme == nullptr) {
+    gtk_image_set_from_icon_name(self->app_icon, default_app_icon.c_str());
+  } else if (const auto icon_name = get_app_icon_name(node_info); icon_name.empty()) {
+    gtk_image_set_from_icon_name(self->app_icon, default_app_icon.c_str());
+  } else if (!icon_available(self, icon_name)) {
+    gtk_image_set_from_icon_name(self->app_icon, default_app_icon.c_str());
   } else {
-    gtk_widget_set_visible(GTK_WIDGET(self->app_icon), 0);
+    gtk_image_set_from_icon_name(self->app_icon, icon_name.c_str());
   }
 
   // updating the blocklist button state

--- a/src/plugins_box.cpp
+++ b/src/plugins_box.cpp
@@ -53,6 +53,10 @@ struct _PluginsBox {
 
   GtkMenuButton* menubutton_plugins;
 
+  GtkOverlay* plugin_overlay;
+
+  AdwStatusPage* overlay_no_plugins;
+
   GtkListView* listview;
 
   GtkStack* stack;
@@ -316,8 +320,14 @@ void add_plugins_to_stack(PluginsBox* self) {
     }
   }
 
-  if (std::ranges::find(plugins_list, visible_page_name) != plugins_list.end()) {
-    gtk_stack_set_visible_child_name(self->stack, visible_page_name.c_str());
+  if (plugins_list.empty()) {
+    gtk_widget_show(GTK_WIDGET(self->overlay_no_plugins));
+  } else {
+    gtk_widget_hide(GTK_WIDGET(self->overlay_no_plugins));
+
+    if (std::ranges::find(plugins_list, visible_page_name) != plugins_list.end()) {
+      gtk_stack_set_visible_child_name(self->stack, visible_page_name.c_str());
+    }
   }
 }
 
@@ -591,6 +601,8 @@ void plugins_box_class_init(PluginsBoxClass* klass) {
   gtk_widget_class_set_template_from_resource(widget_class, "/com/github/wwmm/easyeffects/ui/plugins_box.ui");
 
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, menubutton_plugins);
+  gtk_widget_class_bind_template_child(widget_class, PluginsBox, plugin_overlay);
+  gtk_widget_class_bind_template_child(widget_class, PluginsBox, overlay_no_plugins);
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, listview);
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, stack);
 }
@@ -605,6 +617,8 @@ void plugins_box_init(PluginsBox* self) {
   self->plugins_menu = ui::plugins_menu::create();
 
   gtk_menu_button_set_popover(self->menubutton_plugins, GTK_WIDGET(self->plugins_menu));
+
+  gtk_overlay_set_clip_overlay(self->plugin_overlay, GTK_WIDGET(self->overlay_no_plugins), 1);
 }
 
 auto create() -> PluginsBox* {


### PR DESCRIPTION
- `applications-multimedia-symbolic` set as default visible app icon if the provided icon is not available in the system icon theme.
- `AdwStatusPage` added into plugin box ui to show the empty status when no plugins are placed in the list.

With these two I think a new release could be prepared, but first the translations have to be updated and the default app icon has to be tested on Flatpak because my icon theme does not show it.

@wwmm Regarding the status page for plugins, I tried to reproduce what you did for app ui, but I may forget something, so please check it out.
