### PR TITLE
Plugin stack: Start/endpoint labels

### DIFF
--- a/data/easyeffects.gresource.xml
+++ b/data/easyeffects.gresource.xml
@@ -54,7 +54,6 @@
         <file>ui/shortcuts.ui</file>
         <file>ui/stereo_tools.ui</file>
         <file>icons/scalable/emblems/ee-arrow-down-symbolic.svg</file>
-        <file>icons/scalable/emblems/ee-square-symbolic.svg</file>
         <file>icons/scalable/emblems/ee-spectrum-symbolic.svg</file>
         <file>icons/scalable/emblems/ee-drag-handle-symbolic.svg</file>
     </gresource>

--- a/data/icons/scalable/emblems/ee-square-symbolic.svg
+++ b/data/icons/scalable/emblems/ee-square-symbolic.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M4.002 4h8v8h-8z" style="marker:none" color="#000" overflow="visible" fill="#474747"/></svg>

--- a/data/ui/plugin_row.ui
+++ b/data/ui/plugin_row.ui
@@ -44,6 +44,11 @@
                 <property name="valign">center</property>
                 <property name="opacity">0</property>
                 <property name="icon-name">ee-drag-handle-symbolic</property>
+                <property name="cursor">
+                    <object class="GdkCursor">
+                        <property name="name">grab</property>
+                    </object>
+                </property>
             </object>
         </child>
     </object>

--- a/data/ui/plugin_row.ui
+++ b/data/ui/plugin_row.ui
@@ -4,6 +4,11 @@
         <property name="spacing">6</property>
         <property name="margin-start">6</property>
         <property name="margin-end">6</property>
+        <property name="cursor">
+            <object class="GdkCursor">
+                <property name="name">pointer</property>
+            </object>
+        </property>
         <child>
             <object class="GtkImage" id="plugin_icon">
                 <property name="halign">start</property>

--- a/data/ui/plugins_box.ui
+++ b/data/ui/plugins_box.ui
@@ -38,6 +38,7 @@
                                             <object class="GtkImage" id="startpoint_icon">
                                                 <property name="halign">start</property>
                                                 <property name="valign">center</property>
+                                                <property name="opacity">0.5</property>
                                             </object>
                                         </child>
 
@@ -45,6 +46,7 @@
                                             <object class="GtkLabel" id="startpoint_name">
                                                 <property name="halign">start</property>
                                                 <property name="valign">center</property>
+                                                <property name="opacity">0.5</property>
                                                 <property name="label">Source</property>
                                             </object>
                                         </child>
@@ -74,6 +76,7 @@
                                             <object class="GtkImage" id="endpoint_icon">
                                                 <property name="halign">start</property>
                                                 <property name="valign">center</property>
+                                                <property name="opacity">0.5</property>
                                             </object>
                                         </child>
 
@@ -81,6 +84,7 @@
                                             <object class="GtkLabel" id="endpoint_name">
                                                 <property name="halign">start</property>
                                                 <property name="valign">center</property>
+                                                <property name="opacity">0.5</property>
                                                 <property name="label">Endpoint</property>
                                             </object>
                                         </child>

--- a/data/ui/plugins_box.ui
+++ b/data/ui/plugins_box.ui
@@ -17,6 +17,11 @@
                         <property name="valign">center</property>
                         <property name="direction">right</property>
                         <property name="label" translatable="yes">Add Effect</property>
+                        <property name="cursor">
+                            <object class="GdkCursor">
+                                <property name="name">pointer</property>
+                            </object>
+                        </property>
                     </object>
                 </child>
 

--- a/data/ui/plugins_box.ui
+++ b/data/ui/plugins_box.ui
@@ -28,7 +28,7 @@
                             <object class="GtkBox">
                                 <property name="orientation">vertical</property>
                                 <child>
-                                    <object class="GtkBox">
+                                    <object class="GtkBox" id="startpoint_box">
                                         <property name="spacing">6</property>
                                         <property name="margin-start">21</property>
                                         <property name="margin-end">21</property>
@@ -64,7 +64,7 @@
                                 </child>
 
                                 <child>
-                                    <object class="GtkBox">
+                                    <object class="GtkBox" id="endpoint_box">
                                         <property name="spacing">6</property>
                                         <property name="margin-start">21</property>
                                         <property name="margin-end">21</property>

--- a/data/ui/plugins_box.ui
+++ b/data/ui/plugins_box.ui
@@ -23,16 +23,71 @@
                 <child>
                     <object class="GtkScrolledWindow">
                         <property name="propagate-natural-width">1</property>
+                        <property name="propagate-natural-height">1</property>
                         <child>
-                            <object class="GtkListView" id="listview">
-                                <property name="vexpand">1</property>
-                                <property name="model" bind-source="stack" bind-property="pages" bind-flags="sync-create" />
-                                <style>
-                                    <class name="navigation-sidebar" />
-                                </style>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Used Plugins List</property>
-                                </accessibility>
+                            <object class="GtkBox">
+                                <property name="orientation">vertical</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="spacing">6</property>
+                                        <property name="margin-start">21</property>
+                                        <property name="margin-end">21</property>
+                                        <property name="margin-top">9</property>
+                                        <property name="margin-bottom">3</property>
+                                        <child>
+                                            <object class="GtkImage" id="startpoint_icon">
+                                                <property name="halign">start</property>
+                                                <property name="valign">center</property>
+                                                <property name="icon-name">ee-square-symbolic</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="startpoint_name">
+                                                <property name="halign">start</property>
+                                                <property name="valign">center</property>
+                                                <property name="label">Source</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkListView" id="listview">
+                                        <property name="model" bind-source="stack" bind-property="pages" bind-flags="sync-create" />
+                                        <style>
+                                            <class name="navigation-sidebar" />
+                                        </style>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">Used Plugins List</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="spacing">6</property>
+                                        <property name="margin-start">21</property>
+                                        <property name="margin-end">21</property>
+                                        <property name="margin-top">3</property>
+                                        <property name="margin-bottom">9</property>
+                                        <child>
+                                            <object class="GtkImage" id="endpoint_icon">
+                                                <property name="halign">start</property>
+                                                <property name="valign">center</property>
+                                                <property name="icon-name">ee-square-symbolic</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="endpoint_name">
+                                                <property name="halign">start</property>
+                                                <property name="valign">center</property>
+                                                <property name="label">Endpoint</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
                             </object>
                         </child>
                     </object>

--- a/data/ui/plugins_box.ui
+++ b/data/ui/plugins_box.ui
@@ -38,7 +38,6 @@
                                             <object class="GtkImage" id="startpoint_icon">
                                                 <property name="halign">start</property>
                                                 <property name="valign">center</property>
-                                                <property name="icon-name">ee-square-symbolic</property>
                                             </object>
                                         </child>
 
@@ -75,7 +74,6 @@
                                             <object class="GtkImage" id="endpoint_icon">
                                                 <property name="halign">start</property>
                                                 <property name="valign">center</property>
-                                                <property name="icon-name">ee-square-symbolic</property>
                                             </object>
                                         </child>
 

--- a/src/plugins_box.cpp
+++ b/src/plugins_box.cpp
@@ -365,10 +365,6 @@ void setup_listview(PluginsBox* self) {
         g_object_set_data(G_OBJECT(item), "remove", remove);
         g_object_set_data(G_OBJECT(item), "drag_handle", drag_handle);
 
-        // pointer cursor when the mouse is over the plugin row
-
-        gtk_widget_set_cursor_from_name(GTK_WIDGET(top_box), "pointer");
-
         gtk_list_item_set_child(item, GTK_WIDGET(top_box));
 
         g_object_unref(builder);
@@ -644,8 +640,6 @@ void plugins_box_init(PluginsBox* self) {
   self->data->schedule_signal_idle = false;
 
   self->plugins_menu = ui::plugins_menu::create();
-
-  gtk_widget_set_cursor_from_name(GTK_WIDGET(self->menubutton_plugins), "pointer");
 
   gtk_menu_button_set_popover(self->menubutton_plugins, GTK_WIDGET(self->plugins_menu));
 

--- a/src/plugins_box.cpp
+++ b/src/plugins_box.cpp
@@ -61,6 +61,8 @@ struct _PluginsBox {
 
   GtkStack* stack;
 
+  GtkBox *startpoint_box, *endpoint_box;
+
   GtkImage *startpoint_icon, *endpoint_icon;
 
   GtkLabel *startpoint_name, *endpoint_name;
@@ -326,8 +328,16 @@ void add_plugins_to_stack(PluginsBox* self) {
 
   if (plugins_list.empty()) {
     gtk_widget_show(GTK_WIDGET(self->overlay_no_plugins));
+
+    gtk_widget_hide(GTK_WIDGET(self->startpoint_box));
+
+    gtk_widget_hide(GTK_WIDGET(self->endpoint_box));
   } else {
     gtk_widget_hide(GTK_WIDGET(self->overlay_no_plugins));
+
+    gtk_widget_show(GTK_WIDGET(self->startpoint_box));
+
+    gtk_widget_show(GTK_WIDGET(self->endpoint_box));
 
     if (std::ranges::find(plugins_list, visible_page_name) != plugins_list.end()) {
       gtk_stack_set_visible_child_name(self->stack, visible_page_name.c_str());
@@ -354,6 +364,10 @@ void setup_listview(PluginsBox* self) {
         g_object_set_data(G_OBJECT(item), "name", gtk_builder_get_object(builder, "name"));
         g_object_set_data(G_OBJECT(item), "remove", remove);
         g_object_set_data(G_OBJECT(item), "drag_handle", drag_handle);
+
+        // pointer cursor when the mouse is over the plugin row
+
+        gtk_widget_set_cursor_from_name(GTK_WIDGET(top_box), "pointer");
 
         gtk_list_item_set_child(item, GTK_WIDGET(top_box));
 
@@ -614,8 +628,10 @@ void plugins_box_class_init(PluginsBoxClass* klass) {
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, overlay_no_plugins);
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, listview);
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, stack);
+  gtk_widget_class_bind_template_child(widget_class, PluginsBox, startpoint_box);
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, startpoint_icon);
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, startpoint_name);
+  gtk_widget_class_bind_template_child(widget_class, PluginsBox, endpoint_box);
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, endpoint_icon);
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, endpoint_name);
 }
@@ -628,6 +644,8 @@ void plugins_box_init(PluginsBox* self) {
   self->data->schedule_signal_idle = false;
 
   self->plugins_menu = ui::plugins_menu::create();
+
+  gtk_widget_set_cursor_from_name(GTK_WIDGET(self->menubutton_plugins), "pointer");
 
   gtk_menu_button_set_popover(self->menubutton_plugins, GTK_WIDGET(self->plugins_menu));
 

--- a/src/plugins_box.cpp
+++ b/src/plugins_box.cpp
@@ -61,6 +61,10 @@ struct _PluginsBox {
 
   GtkStack* stack;
 
+  GtkImage *startpoint_icon, *endpoint_icon;
+
+  GtkLabel *startpoint_name, *endpoint_name;
+
   ui::plugins_menu::PluginsMenu* plugins_menu;
 
   GSettings* settings;
@@ -487,14 +491,7 @@ void setup_listview(PluginsBox* self) {
                      gtk_accessible_update_property(GTK_ACCESSIBLE(remove), GTK_ACCESSIBLE_PROPERTY_LABEL,
                                                     (_("Remove") + " "s + self->data->translated[name]).c_str(), -1);
 
-                     const auto list = util::gchar_array_to_vector(g_settings_get_strv(self->settings, "plugins"));
-
-                     if (const auto iter_name = std::ranges::find(list, name);
-                         (iter_name == list.begin() && iter_name != list.end() - 2) || iter_name == list.end() - 1) {
-                       gtk_image_set_from_icon_name(plugin_icon, "ee-square-symbolic");
-                     } else {
-                       gtk_image_set_from_icon_name(plugin_icon, "ee-arrow-down-symbolic");
-                     }
+                     gtk_image_set_from_icon_name(plugin_icon, "ee-arrow-down-symbolic");
                    }),
                    self);
 
@@ -519,6 +516,12 @@ void setup(PluginsBox* self, app::Application* application, PipelineType pipelin
           }),
           self));
 
+      gtk_image_set_from_icon_name(self->startpoint_icon, "audio-input-microphone-symbolic");
+      gtk_image_set_from_icon_name(self->endpoint_icon, "applications-multimedia-symbolic");
+
+      gtk_label_set_text(self->startpoint_name, _("Input Device"));
+      gtk_label_set_text(self->endpoint_name, _("Recording Apps"));
+
       break;
     }
     case PipelineType::output: {
@@ -531,6 +534,12 @@ void setup(PluginsBox* self, app::Application* application, PipelineType pipelin
             add_plugins_to_stack<PipelineType::output>(self);
           }),
           self));
+
+      gtk_image_set_from_icon_name(self->startpoint_icon, "applications-multimedia-symbolic");
+      gtk_image_set_from_icon_name(self->endpoint_icon, "audio-speakers-symbolic");
+
+      gtk_label_set_text(self->startpoint_name, _("Playing Apps"));
+      gtk_label_set_text(self->endpoint_name, _("Output Device"));
 
       break;
     }
@@ -605,6 +614,10 @@ void plugins_box_class_init(PluginsBoxClass* klass) {
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, overlay_no_plugins);
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, listview);
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, stack);
+  gtk_widget_class_bind_template_child(widget_class, PluginsBox, startpoint_icon);
+  gtk_widget_class_bind_template_child(widget_class, PluginsBox, startpoint_name);
+  gtk_widget_class_bind_template_child(widget_class, PluginsBox, endpoint_icon);
+  gtk_widget_class_bind_template_child(widget_class, PluginsBox, endpoint_name);
 }
 
 void plugins_box_init(PluginsBox* self) {


### PR DESCRIPTION
This will be more user friendly and will resolve the longstanding issue of not understanding where the stream comes from and where it ends up.

Maybe it has to be refined since `navigation-sidebar` class isn't useful on GtkBox, so we have to set manual margins to align the labels to the effects. On my system it's quite aligned, but I don't know if on other systems with different resolutions it's the same.

It can be work out, but it's a good starting point anyway.