### PR TITLE
Add capture node blocklist

### DIFF
--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -228,6 +228,8 @@ class PipeManager {
 
   std::array<std::string, 2U> blocklist_media_role = {"event", "Notification"};
 
+  std::array<std::string, 1U> blocklist_capture_node = {"OBS"};
+
   std::string header_version, library_version, core_name;
   std::string default_clock_rate = "0";
   std::string default_min_quantum = "0";


### PR DESCRIPTION
Related to #1541 

I think this is a more elegant way to exclude OBS.

But it has to be tested against a localized OBS. The hack for pavucontrol is done in `on_info_node` not only because `PW_KEY_STREAM_MONITOR` is not set in `on_registry_global`, but mainly because pavucontrol app name is localized and different between languages set at system level.

@wwmm Can you run and test OBS in Portuguese? I don't have OBS installed on my system.

Anyway, If this is not working or you think it's better to do it inside `on_node_info`, you can reject the merge request.