### PR TITLE
build: Declare required fmt version

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -136,7 +136,7 @@ easyeffects_deps = [
 	dependency('rubberband'),
 	dependency('speexdsp'),
 	dependency('nlohmann_json'),
-	dependency('fmt'),
+	dependency('fmt', version: '>=8.0.0'),
 	dependency('threads'),
 	tbb,
 	zita_convolver,


### PR DESCRIPTION
Since https://github.com/wwmm/easyeffects/commit/755595e0e98d35c03558cb19c1950e1c5ecefb75, the build was failing with:

    error: no matching function for call to 'format(std::locale, const char [14], double&, int&, std::__cxx11::basic_string<char>)'