### PR TITLE
Toggle convolver autogain

### DIFF
--- a/data/schemas/com.github.wwmm.easyeffects.convolver.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.convolver.gschema.xml
@@ -16,5 +16,8 @@
             <range min="0" max="200" />
             <default>100</default>
         </key>
+        <key name="autogain" type="b">
+            <default>false</default>
+        </key>
     </schema>
 </schemalist>

--- a/data/ui/convolver.ui
+++ b/data/ui/convolver.ui
@@ -131,6 +131,7 @@
                                 <property name="halign">center</property>
                                 <property name="valign">center</property>
                                 <property name="label" translatable="yes">Autogain</property>
+                                <signal name="toggled" handler="on_autogain" object="ConvolverBox" />
                             </object>
                         </child>
                     </object>

--- a/data/ui/convolver.ui
+++ b/data/ui/convolver.ui
@@ -125,6 +125,14 @@
                                 <signal name="toggled" handler="on_enable_log_scale" object="ConvolverBox" />
                             </object>
                         </child>
+
+                        <child>
+                            <object class="GtkToggleButton" id="autogain">
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="label" translatable="yes">Autogain</property>
+                            </object>
+                        </child>
                     </object>
                 </child>
             </object>

--- a/include/convolver.hpp
+++ b/include/convolver.hpp
@@ -50,6 +50,8 @@ class Convolver : public PluginBase {
 
   sigc::signal<void(const float&)> latency;
 
+  bool do_autogain = false;
+
  private:
   bool kernel_is_initialized = false;
   bool n_samples_is_power_of_2 = true;

--- a/src/convolver.cpp
+++ b/src/convolver.cpp
@@ -389,7 +389,7 @@ void Convolver::read_kernel_file() {
 }
 
 void Convolver::apply_kernel_autogain() {
-  if (g_settings_get_boolean(settings, "autogain") == 0) {
+  if (!do_autogain) {
     return;
   }
   if (kernel_L.empty() || kernel_R.empty()) {

--- a/src/convolver.cpp
+++ b/src/convolver.cpp
@@ -84,6 +84,40 @@ Convolver::Convolver(const std::string& tag,
                                           }),
                                           this));
 
+  gconnections.push_back(g_signal_connect(settings, "changed::autogain",
+                                          G_CALLBACK(+[](GSettings* settings, char* key, gpointer user_data) {
+                                            auto self = static_cast<Convolver*>(user_data);
+
+                                            if (self->n_samples == 0U || self->rate == 0U) {
+                                              return;
+                                            }
+
+                                            self->data_mutex.lock();
+
+                                            self->ready = false;
+
+                                            self->data_mutex.unlock();
+
+                                            self->read_kernel_file();
+
+                                            if (self->kernel_is_initialized) {
+                                              self->kernel_L = self->original_kernel_L;
+                                              self->kernel_R = self->original_kernel_R;
+
+                                              self->set_kernel_stereo_width();
+                                              self->apply_kernel_autogain();
+
+                                              self->setup_zita();
+
+                                              self->data_mutex.lock();
+
+                                              self->ready = self->kernel_is_initialized && self->zita_ready;
+
+                                              self->data_mutex.unlock();
+                                            }
+                                          }),
+                                          this));
+
   setup_input_output_gain();
 }
 
@@ -355,6 +389,9 @@ void Convolver::read_kernel_file() {
 }
 
 void Convolver::apply_kernel_autogain() {
+  if (g_settings_get_boolean(settings, "autogain") == 0) {
+    return;
+  }
   if (kernel_L.empty() || kernel_R.empty()) {
     return;
   }

--- a/src/convolver_preset.cpp
+++ b/src/convolver_preset.cpp
@@ -33,6 +33,8 @@ void ConvolverPreset::save(nlohmann::json& json, const std::string& section, GSe
   json[section]["convolver"]["kernel-path"] = util::gsettings_get_string(settings, "kernel-path");
 
   json[section]["convolver"]["ir-width"] = g_settings_get_int(settings, "ir-width");
+
+  json[section]["convolver"]["autogain"] = g_settings_get_boolean(settings, "autogain") != 0;
 }
 
 void ConvolverPreset::load(const nlohmann::json& json, const std::string& section, GSettings* settings) {
@@ -43,4 +45,6 @@ void ConvolverPreset::load(const nlohmann::json& json, const std::string& sectio
   update_key<gchar*>(json.at(section).at("convolver"), settings, "kernel-path", "kernel-path");
 
   update_key<int>(json.at(section).at("convolver"), settings, "ir-width", "ir-width");
+
+  update_key<bool>(json.at(section).at("convolver"), settings, "autogain", "autogain");
 }

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -81,6 +81,8 @@ struct _ConvolverBox {
   GFileMonitor* folder_monitor;
 
   Data* data;
+
+  GtkToggleButton *autogain;
 };
 
 G_DEFINE_TYPE(ConvolverBox, convolver_box, GTK_TYPE_BOX)
@@ -91,6 +93,7 @@ void on_bypass(ConvolverBox* self, GtkToggleButton* btn) {
 
 void on_reset(ConvolverBox* self, GtkButton* btn) {
   gtk_toggle_button_set_active(self->bypass, 0);
+  gtk_toggle_button_set_active(self->autogain, 0);
 
   util::reset_all_keys(self->settings);
 }
@@ -479,7 +482,7 @@ void setup(ConvolverBox* self,
       }),
       self));
 
-  gsettings_bind_widgets<"input-gain", "output-gain">(self->settings, self->input_gain, self->output_gain);
+  gsettings_bind_widgets<"input-gain", "output-gain", "autogain">(self->settings, self->input_gain, self->output_gain, self->autogain);
 
   g_settings_bind(self->settings, "ir-width", gtk_spin_button_get_adjustment(self->ir_width), "value",
                   G_SETTINGS_BIND_DEFAULT);
@@ -566,6 +569,7 @@ void convolver_box_class_init(ConvolverBoxClass* klass) {
   gtk_widget_class_bind_template_child(widget_class, ConvolverBox, show_fft);
   gtk_widget_class_bind_template_child(widget_class, ConvolverBox, enable_log_scale);
   gtk_widget_class_bind_template_child(widget_class, ConvolverBox, chart_box);
+  gtk_widget_class_bind_template_child(widget_class, ConvolverBox, autogain);
 
   gtk_widget_class_bind_template_callback(widget_class, on_bypass);
   gtk_widget_class_bind_template_callback(widget_class, on_reset);

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -91,6 +91,10 @@ void on_bypass(ConvolverBox* self, GtkToggleButton* btn) {
   self->data->convolver->bypass = gtk_toggle_button_get_active(btn);
 }
 
+void on_autogain(ConvolverBox* self, GtkToggleButton* btn) {
+  self->data->convolver->do_autogain = gtk_toggle_button_get_active(btn);
+}
+
 void on_reset(ConvolverBox* self, GtkButton* btn) {
   gtk_toggle_button_set_active(self->bypass, 0);
   gtk_toggle_button_set_active(self->autogain, 0);
@@ -576,6 +580,7 @@ void convolver_box_class_init(ConvolverBoxClass* klass) {
   gtk_widget_class_bind_template_callback(widget_class, on_show_fft);
   gtk_widget_class_bind_template_callback(widget_class, on_show_channel);
   gtk_widget_class_bind_template_callback(widget_class, on_enable_log_scale);
+  gtk_widget_class_bind_template_callback(widget_class, on_autogain);
 }
 
 void convolver_box_init(ConvolverBox* self) {


### PR DESCRIPTION
This is related to the issue #1309.
It is an implementation of a simple button in the Convolver plugin that allows to enable or disable the autogain.

I tested my convolution equalization `.wav` file under several applications and OS, in general the gain is not altered.
I find this feature weird for my use case but I guess some people prefer it as is, so I implemented a way to quickly turn it off/on.