### PR TITLE
src/rnnoise.cpp: Fix typo in ifdef logic

### DIFF
--- a/src/rnnoise.cpp
+++ b/src/rnnoise.cpp
@@ -64,7 +64,7 @@ RNNoise::RNNoise(const std::string& tag,
   state_right = rnnoise_create(model);
 
   rnnoise_ready = true;
-#elif
+#else
   util::warning("The RNNoise library was not available at compilation time. The noise reduction filter won't work");
 #endif
 }


### PR DESCRIPTION
This commit fixes a typo in `#ifdef` logic that caused build failure.