### PR TITLE
Fix/changelog typos: fix EasyEffe[e]cts to EasyEffects typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and #1427
 - Many translation updates
 
 ### Bugfixes:
-- Fixed a bug where EasyEffeects crashed when the number of points displayed in the spectrum was changed while 
+- Fixed a bug where EasyEffects crashed when the number of points displayed in the spectrum was changed while 
 our pipeline was active and the spectrum widget was visible
 - The pipeline latency value displayed in our window could be wrong in some situations. This was fixed.
 

--- a/data/com.github.wwmm.easyeffects.metainfo.xml.in
+++ b/data/com.github.wwmm.easyeffects.metainfo.xml.in
@@ -70,7 +70,7 @@
         </ul>
         <p>This release fixes the following bugs:</p>
         <ul>
-          <li>Fixed a bug where EasyEffeects crashed when the number of points displayed in the spectrum was changed while</li>
+          <li>Fixed a bug where EasyEffects crashed when the number of points displayed in the spectrum was changed while</li>
           <li>our pipeline was active and the spectrum widget was visible</li>
           <li>The pipeline latency value displayed in our window could be wrong in some situations. This was fixed.</li>
         </ul>

--- a/po/easyeffects.pot
+++ b/po/easyeffects.pot
@@ -143,7 +143,7 @@ msgstr ""
 
 #: data/com.github.wwmm.easyeffects.metainfo.xml.in:51
 msgid ""
-"Fixed a bug where EasyEffeects crashed when the number of points displayed "
+"Fixed a bug where EasyEffects crashed when the number of points displayed "
 "in the spectrum was changed while"
 msgstr ""
 

--- a/util/NEWS
+++ b/util/NEWS
@@ -48,7 +48,7 @@ and #1427
 - Many translation updates
 
 Bugfixes:
-- Fixed a bug where EasyEffeects crashed when the number of points displayed in the spectrum was changed while 
+- Fixed a bug where EasyEffects crashed when the number of points displayed in the spectrum was changed while 
 our pipeline was active and the spectrum widget was visible
 - The pipeline latency value displayed in our window could be wrong in some situations. This was fixed.
 


### PR DESCRIPTION
The typo messes with the translation glossar matching.