### PR TITLE
Autogain: fix display of `Internal output gain`

### DIFF
--- a/src/autogain_ui.cpp
+++ b/src/autogain_ui.cpp
@@ -93,8 +93,9 @@ void setup(AutogainBox* self, std::shared_ptr<AutoGain> autogain, const std::str
         gtk_level_bar_set_value(self->l_level, util::db_to_linear(loudness));
         gtk_label_set_text(self->l_label, fmt::format("{0:.0f}", loudness).c_str());
 
-        gtk_level_bar_set_value(self->g_level, util::db_to_linear(gain));
-        gtk_label_set_text(self->g_label, fmt::format(self->data->user_locale, "{0:.2Lf}", gain).c_str());
+        gtk_level_bar_set_value(self->g_level, gain);
+        gtk_label_set_text(self->g_label,
+                           fmt::format(self->data->user_locale, "{0:.2Lf}", util::linear_to_db(gain)).c_str());
 
         gtk_level_bar_set_value(self->m_level, util::db_to_linear(momentary));
         gtk_label_set_text(self->m_label, fmt::format("{0:.0f}", momentary).c_str());


### PR DESCRIPTION
The `AutoGain::process()` is treating `internal_output_gain` as
a linear gain:
https://github.com/wwmm/easyeffects/blob/28d1172819424b16b8df4f274387cf6604ca95da/src/autogain.cpp#L322-L324
... yet the display code thought that it was in dB's:
https://github.com/wwmm/easyeffects/blob/28d1172819424b16b8df4f274387cf6604ca95da/src/autogain_ui.cpp#L96-L97

I don't know which of the two need to be adjusted, i fixed this one.