### PR TITLE
Test Message Dialogs

### DIFF
--- a/include/presets_manager.hpp
+++ b/include/presets_manager.hpp
@@ -71,6 +71,9 @@ class PresetsManager {
     plugin_generic
   };
 
+  // signal sending title and description strings
+  sigc::signal<void(const std::string, const std::string)> preset_load_error;
+
   auto get_names(const PresetType& preset_type) -> std::vector<std::string>;
 
   auto search_names(std::filesystem::directory_iterator& it) -> std::vector<std::string>;
@@ -166,5 +169,5 @@ class PresetsManager {
 
   auto load_blocklist(const PresetType& preset_type, const nlohmann::json& json) -> bool;
 
-  void notify_error(const PresetError& preset_error);
+  void notify_error(const PresetError& preset_error, const std::string& plugin_name = "");
 };

--- a/include/presets_manager.hpp
+++ b/include/presets_manager.hpp
@@ -62,6 +62,15 @@ class PresetsManager {
   auto operator=(const PresetsManager&&) -> PresetsManager& = delete;
   ~PresetsManager();
 
+  enum class PresetError {
+    blocklist_format,
+    blocklist_generic,
+    pipeline_format,
+    pipeline_generic,
+    plugin_format,
+    plugin_generic
+  };
+
   auto get_names(const PresetType& preset_type) -> std::vector<std::string>;
 
   auto search_names(std::filesystem::directory_iterator& it) -> std::vector<std::string>;
@@ -156,4 +165,6 @@ class PresetsManager {
   void save_blocklist(const PresetType& preset_type, nlohmann::json& json);
 
   auto load_blocklist(const PresetType& preset_type, const nlohmann::json& json) -> bool;
+
+  void notify_error(const PresetError& preset_error);
 };

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -326,17 +326,15 @@ auto PresetsManager::load_blocklist(const PresetType& preset_type, const nlohman
       } catch (const nlohmann::json::exception& e) {
         g_settings_reset(sie_settings, "blocklist");
 
-        util::warning(e.what());
+        notify_error(PresetError::blocklist_format);
 
-        util::warning(
-            "A parsing error occurred while trying to load the blocklist inside the preset. The file could be invalid "
-            "or corrupted. Please check its content.");
+        util::warning(e.what());
 
         return false;
       } catch (...) {
         g_settings_reset(sie_settings, "blocklist");
 
-        util::warning("A generic error occurred while trying to load the blocklist inside the preset.");
+        notify_error(PresetError::blocklist_generic);
 
         return false;
       }
@@ -351,17 +349,15 @@ auto PresetsManager::load_blocklist(const PresetType& preset_type, const nlohman
       } catch (const nlohmann::json::exception& e) {
         g_settings_reset(soe_settings, "blocklist");
 
-        util::warning(e.what());
+        notify_error(PresetError::blocklist_format);
 
-        util::warning(
-            "A parsing error occurred while trying to load the blocklist inside the preset. The file could be invalid "
-            "or corrupted. Please check its content.");
+        util::warning(e.what());
 
         return false;
       } catch (...) {
         g_settings_reset(soe_settings, "blocklist");
 
-        util::warning("A generic error occurred while trying to load the blocklist inside the preset.");
+        notify_error(PresetError::blocklist_generic);
 
         return false;
       }
@@ -542,14 +538,13 @@ auto PresetsManager::load_preset_file(const PresetType& preset_type, const std::
           }
 
         } catch (const nlohmann::json::exception& e) {
-          util::warning(e.what());
+          notify_error(PresetError::pipeline_format);
 
-          util::warning("A parsing error occurred while trying to load the effects list inside " + name +
-                        " preset. The file could be invalid or corrupted. Please check its content.");
+          util::warning(e.what());
 
           return false;
         } catch (...) {
-          util::warning("A generic error occurred while trying to load the effects list inside " + name + " preset.");
+          notify_error(PresetError::pipeline_generic);
 
           return false;
         }
@@ -595,14 +590,13 @@ auto PresetsManager::load_preset_file(const PresetType& preset_type, const std::
           }
 
         } catch (const nlohmann::json::exception& e) {
-          util::warning(e.what());
+          notify_error(PresetError::pipeline_format);
 
-          util::warning("A parsing error occurred while trying to load the effects list inside " + name +
-                        " preset. The file could be invalid or corrupted. Please check its content.");
+          util::warning(e.what());
 
           return false;
         } catch (...) {
-          util::warning("A generic error occurred while trying to load the effects list inside " + name + " preset.");
+          notify_error(PresetError::pipeline_generic);
 
           return false;
         }
@@ -680,14 +674,13 @@ auto PresetsManager::read_plugins_preset(const PresetType& preset_type,
         stereo_tools->read(preset_type, json);
       }
     } catch (const nlohmann::json::exception& e) {
-      util::warning(e.what());
+      notify_error(PresetError::plugin_format);
 
-      util::warning("A parsing error occurred while reading the parameters for " + name +
-                    " effect. The preset file could be invalid or corrupted. Please check its content.");
+      util::warning(e.what());
 
       return false;
     } catch (...) {
-      util::warning("A generic error occurred while parsing the preset file for " + name + " effect.");
+      notify_error(PresetError::plugin_generic);
 
       return false;
     }
@@ -900,4 +893,47 @@ auto PresetsManager::preset_file_exists(const PresetType& preset_type, const std
   }
 
   return false;
+}
+
+void PresetsManager::notify_error(const PresetError& preset_error) {
+  switch (preset_error) {
+    case PresetError::blocklist_format: {
+      util::warning(
+          "A parsing error occurred while trying to load the blocklist inside the preset. The file could be invalid "
+          "or corrupted. Please check its content.");
+
+      break;
+    }
+    case PresetError::blocklist_generic: {
+      util::warning("A generic error occurred while trying to load the blocklist inside the preset.");
+
+      break;
+    }
+    case PresetError::pipeline_format: {
+      util::warning(
+          "A parsing error occurred while trying to load the pipeline inside the preset. The file could be invalid "
+          "or corrupted. Please check its content.");
+
+      break;
+    }
+    case PresetError::pipeline_generic: {
+      util::warning("A generic error occurred while trying to load the pipeline inside the preset.");
+
+      break;
+    }
+    case PresetError::plugin_format: {
+      util::warning(
+          "A parsing error occurred while trying to load a plugin inside the preset. The file file could be invalid or "
+          "corrupted. Please check its content.");
+
+      break;
+    }
+    case PresetError::plugin_generic: {
+      util::warning("A generic error occurred while trying to load a plugin inside the preset.");
+
+      break;
+    }
+    default:
+      break;
+  }
 }

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -674,13 +674,13 @@ auto PresetsManager::read_plugins_preset(const PresetType& preset_type,
         stereo_tools->read(preset_type, json);
       }
     } catch (const nlohmann::json::exception& e) {
-      notify_error(PresetError::plugin_format);
+      notify_error(PresetError::plugin_format, name);
 
       util::warning(e.what());
 
       return false;
     } catch (...) {
-      notify_error(PresetError::plugin_generic);
+      notify_error(PresetError::plugin_generic, name);
 
       return false;
     }
@@ -895,41 +895,54 @@ auto PresetsManager::preset_file_exists(const PresetType& preset_type, const std
   return false;
 }
 
-void PresetsManager::notify_error(const PresetError& preset_error) {
+void PresetsManager::notify_error(const PresetError& preset_error, const std::string& plugin_name) {
   switch (preset_error) {
     case PresetError::blocklist_format: {
       util::warning(
-          "A parsing error occurred while trying to load the blocklist inside the preset. The file could be invalid "
+          "A parsing error occurred while trying to load the blocklist from the preset. The file could be invalid "
           "or corrupted. Please check its content.");
+
+      preset_load_error.emit(_("Preset Not Loaded Correctly"), _("Wrong Format in Excluded Apps List"));
 
       break;
     }
     case PresetError::blocklist_generic: {
-      util::warning("A generic error occurred while trying to load the blocklist inside the preset.");
+      util::warning("A generic error occurred while trying to load the blocklist from the preset.");
+
+      preset_load_error.emit(_("Preset Not Loaded Correctly"), _("Generic Error While Loading Excluded Apps List"));
 
       break;
     }
     case PresetError::pipeline_format: {
       util::warning(
-          "A parsing error occurred while trying to load the pipeline inside the preset. The file could be invalid "
+          "A parsing error occurred while trying to load the pipeline from the preset. The file could be invalid "
           "or corrupted. Please check its content.");
+
+      preset_load_error.emit(_("Preset Not Loaded Correctly"), _("Wrong Format in Effects List"));
 
       break;
     }
     case PresetError::pipeline_generic: {
-      util::warning("A generic error occurred while trying to load the pipeline inside the preset.");
+      util::warning("A generic error occurred while trying to load the pipeline from the preset.");
+
+      preset_load_error.emit(_("Preset Not Loaded Correctly"), _("Generic Error While Loading Effects List"));
 
       break;
     }
     case PresetError::plugin_format: {
-      util::warning(
-          "A parsing error occurred while trying to load a plugin inside the preset. The file file could be invalid or "
-          "corrupted. Please check its content.");
+      util::warning("A parsing error occurred while trying to load the " + plugin_name +
+                    " plugin from the preset. The file could be invalid or "
+                    "corrupted. Please check its content.");
+
+      preset_load_error.emit(_("Preset Not Loaded Correctly"), plugin_name + ": " + _("The Effect Has a Wrong Format"));
 
       break;
     }
     case PresetError::plugin_generic: {
-      util::warning("A generic error occurred while trying to load a plugin inside the preset.");
+      util::warning("A generic error occurred while trying to load the " + plugin_name + " plugin from the preset.");
+
+      preset_load_error.emit(_("Preset Not Loaded Correctly"),
+                             plugin_name + ": " + _("Generic Error While Loading The Effect"));
 
       break;
     }


### PR DESCRIPTION
Related to #1607 

I wanted to show the Toasts on preset loading error, but looking at their implementation I found out that they need a GTkOverlay like the AdwStatusPage, but this way they would be covered by the Preset Menu widget because that widget is on top of the main window where we are supposed to show the toast.

So I though we need something that stays on top of everything even if it's constructed from the main window which could be covered by other widgets (preset menu, blocklist menu, etc...).

So I chose the AdwMessageDialog, but only during compilation I found out it is available from libAdwaita 1.2 (we're at 1.1 I think). Anyway I implemented the GtkMessageDialog. It's not bad. I tested it. It's working and it appears on top of everything. As suggested by the docs, I set the modal and transient property.

Initially I had issues in getting the signal from the preset manager, but I managed to use the realize function in application_ui. If there is a better and safe method, @wwmm you can refine it. In the message dialog setup I added a null check on the parent widget: maybe it's useless, you can remove it.

In preset manager notify_error I pass the preset name, but unfortunately it's the tag for the json preset. Can it be translated somehow to a user friendly name like in the Effects List? In the message dialog it's shown `multiband_compressor: Wrong Format`, it's not the best, `Multiband Compressor: Wrong Format` is more appropriate.

I forgot to test while the window is hided. You can do it, I will try tomorrow. The preset autoload on the device switch is the only way to trigger the change while the window is hided?