### PR TITLE
Multiband gate: fix annoying schema bug

### DIFF
--- a/data/schemas/com.github.wwmm.easyeffects.multibandgate.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.multibandgate.gschema.xml
@@ -63,7 +63,7 @@
             <range min="0" max="18" />
             <default>9</default>
         </key>
-        <key name="detection0" enum="com.github.wwmm.easyeffects.gate.detection.enum">
+        <key name="detection0" enum="com.github.wwmm.easyeffects.multibandgate.detection.enum">
             <default>"RMS"</default>
         </key>
         <key name="bypass0" type="b">
@@ -100,7 +100,7 @@
             <range min="0" max="18" />
             <default>9</default>
         </key>
-        <key name="detection1" enum="com.github.wwmm.easyeffects.gate.detection.enum">
+        <key name="detection1" enum="com.github.wwmm.easyeffects.multibandgate.detection.enum">
             <default>"RMS"</default>
         </key>
         <key name="bypass1" type="b">
@@ -137,7 +137,7 @@
             <range min="0" max="18" />
             <default>9</default>
         </key>
-        <key name="detection2" enum="com.github.wwmm.easyeffects.gate.detection.enum">
+        <key name="detection2" enum="com.github.wwmm.easyeffects.multibandgate.detection.enum">
             <default>"RMS"</default>
         </key>
         <key name="bypass2" type="b">
@@ -174,7 +174,7 @@
             <range min="0" max="18" />
             <default>9</default>
         </key>
-        <key name="detection3" enum="com.github.wwmm.easyeffects.gate.detection.enum">
+        <key name="detection3" enum="com.github.wwmm.easyeffects.multibandgate.detection.enum">
             <default>"RMS"</default>
         </key>
         <key name="bypass3" type="b">


### PR DESCRIPTION
The enum `com.github.wwmm.easyeffects.multibandgate.detection.enum`
is defined in this schema, but the enum `com.github.wwmm.easyeffects.gate.detection.enum`
is being used instead :) Thus, the schema is not hermetic,
and leads to really hard-to-diagnose bugs (if you don't know where to look)
when changing the plain gate scheme.

This took me way too long to understand...