### PR TITLE
`LSP Gate` implementation (Fixes #1596)

### DIFF
--- a/data/schemas/com.github.wwmm.easyeffects.gate.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.gate.gschema.xml
@@ -1,12 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-    <enum id="com.github.wwmm.easyeffects.gate.detection.enum">
-        <value nick="RMS" value="0" />
-        <value nick="Peak" value="1" />
+    <enum id="com.github.wwmm.easyeffects.gate.sidechain.input.enum">
+        <value nick="Internal" value="0" />
+        <value nick="External" value="1" />
     </enum>
-    <enum id="com.github.wwmm.easyeffects.gate.stereo.link.enum">
-        <value nick="Average" value="0" />
-        <value nick="Maximum" value="1" />
+    <enum id="com.github.wwmm.easyeffects.gate.sidechain.mode.enum">
+        <value nick="Peak" value="0" />
+        <value nick="RMS" value="1" />
+        <value nick="Low-Pass" value="2" />
+        <value nick="Uniform" value="3" />
+    </enum>
+    <enum id="com.github.wwmm.easyeffects.gate.sidechain.source.enum">
+        <value nick="Middle" value="0" />
+        <value nick="Side" value="1" />
+        <value nick="Left" value="2" />
+        <value nick="Right" value="3" />
+    </enum>
+    <enum id="com.github.wwmm.easyeffects.gate.filter.mode.enum">
+        <value nick="off" value="0" />
+        <value nick="12 dB/oct" value="1" />
+        <value nick="24 dB/oct" value="2" />
+        <value nick="36 dB/oct" value="3" />
     </enum>
     <schema id="com.github.wwmm.easyeffects.gate">
         <key name="bypass" type="b">
@@ -20,39 +34,81 @@
             <range min="-36" max="36" />
             <default>0</default>
         </key>
-        <key name="detection" enum="com.github.wwmm.easyeffects.gate.detection.enum">
-            <default>"RMS"</default>
-        </key>
-        <key name="stereo-link" enum="com.github.wwmm.easyeffects.gate.stereo.link.enum">
-            <default>"Average"</default>
-        </key>
-        <key name="range" type="d">
-            <range min="-95" max="0" />
-            <default>-24</default>
-        </key>
         <key name="attack" type="d">
-            <range min="0.01" max="2000" />
+            <range min="0" max="2000" />
             <default>20</default>
         </key>
         <key name="release" type="d">
-            <range min="0.01" max="2000" />
-            <default>250</default>
+            <range min="0" max="5000" />
+            <default>100</default>
         </key>
-        <key name="threshold" type="d">
+        <key name="curve-threshold" type="d">
             <range min="-60" max="0" />
-            <default>-18</default>
+            <default>-24</default>
         </key>
-        <key name="ratio" type="d">
-            <range min="1" max="20" />
-            <default>2</default>
+        <key name="curve-zone" type="d">
+            <range min="-60" max="0" />
+            <default>-6</default>
         </key>
-        <key name="knee" type="d">
-            <range min="0" max="18" />
-            <default>9</default>
+        <key name="hysteresis" type="b">
+            <default>false</default>
+        </key>
+        <key name="hysteresis-threshold" type="d">
+            <range min="-60" max="0" />
+            <default>-12</default>
+        </key>
+        <key name="hysteresis-zone" type="d">
+            <range min="-60" max="0" />
+            <default>-6</default>
+        </key>
+        <key name="reduction" type="d">
+            <range min="-72" max="0" />
+            <default>-24</default>
         </key>
         <key name="makeup" type="d">
-            <range min="0" max="36" />
+            <range min="-60" max="60" />
             <default>0</default>
+        </key>
+        <key name="sidechain-listen" type="b">
+            <default>false</default>
+        </key>
+        <key name="sidechain-input" enum="com.github.wwmm.easyeffects.gate.sidechain.input.enum">
+            <default>"Internal"</default>
+        </key>
+        <key name="sidechain-mode" enum="com.github.wwmm.easyeffects.gate.sidechain.mode.enum">
+            <default>"RMS"</default>
+        </key>
+        <key name="sidechain-source" enum="com.github.wwmm.easyeffects.gate.sidechain.source.enum">
+            <default>"Middle"</default>
+        </key>
+        <key name="sidechain-preamp" type="d">
+            <range min="-120" max="40" />
+            <default>0</default>
+        </key>
+        <key name="sidechain-reactivity" type="d">
+            <range min="0" max="250" />
+            <default>10</default>
+        </key>
+        <key name="sidechain-lookahead" type="d">
+            <range min="0" max="20" />
+            <default>0</default>
+        </key>
+        <key name="hpf-mode" enum="com.github.wwmm.easyeffects.gate.filter.mode.enum">
+            <default>"off"</default>
+        </key>
+        <key name="hpf-frequency" type="d">
+            <range min="10" max="20000" />
+            <default>10</default>
+        </key>
+        <key name="lpf-mode" enum="com.github.wwmm.easyeffects.gate.filter.mode.enum">
+            <default>"off"</default>
+        </key>
+        <key name="lpf-frequency" type="d">
+            <range min="10" max="20000" />
+            <default>20000</default>
+        </key>
+        <key name="sidechain-input-device" type="s">
+            <default>""</default>
         </key>
     </schema>
 </schemalist>

--- a/data/ui/gate.ui
+++ b/data/ui/gate.ui
@@ -9,301 +9,914 @@
         <property name="orientation">vertical</property>
 
         <child>
-            <object class="GtkBox" id="box_reduction_option">
+            <object class="GtkStackSwitcher" id="stack_switcher">
                 <property name="halign">center</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">48</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="spacing">6</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkLabel" id="detection_label">
-                                <property name="label" translatable="yes">Detection</property>
-                            </object>
-                        </child>
+                <property name="stack">stack</property>
+            </object>
+        </child>
 
-                        <child>
-                            <object class="GtkComboBoxText" id="detection">
-                                <items>
-                                    <item translatable="yes" id="RMS">RMS</item>
-                                    <item translatable="yes" id="Peak">Peak</item>
-                                </items>
-                                <accessibility>
-                                    <relation name="labelled-by">detection_label</relation>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
+        <child>
+            <object class="GtkStack" id="stack">
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">6</property>
+                <property name="hexpand">1</property>
+                <property name="hhomogeneous">0</property>
+                <property name="vhomogeneous">0</property>
+                <property name="transition-duration">250</property>
+                <property name="transition-type">slide-left-right</property>
 
                 <child>
-                    <object class="GtkBox">
-                        <property name="spacing">6</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkLabel" id="range_label">
-                                <property name="label" translatable="yes">Max Reduction</property>
-                            </object>
-                        </child>
+                    <object class="GtkStackPage">
+                        <property name="name">page_gate</property>
+                        <property name="title" translatable="yes">Gate</property>
+                        <property name="child">
+                            <object class="GtkBox">
+                                <property name="spacing">24</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                    <object class="GtkGrid">
+                                        <property name="halign">center</property>
+                                        <property name="row-spacing">6</property>
+                                        <property name="column-spacing">12</property>
 
-                        <child>
-                            <object class="GtkSpinButton" id="range">
-                                <property name="width-chars">10</property>
-                                <property name="digits">1</property>
-                                <property name="update-policy">if-valid</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-95</property>
-                                        <property name="value">-24</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                        <child>
+                                            <object class="GtkLabel" id="attack_time_label">
+                                                <property name="label" translatable="yes">Attack</property>
+                                                <layout>
+                                                    <property name="column">0</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="attack">
+                                                <property name="margin-end">6</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="digits">2</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="upper">2000</property>
+                                                        <property name="value">20</property>
+                                                        <property name="step-increment">0.01</property>
+                                                        <property name="page-increment">0.1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">0</property>
+                                                    <property name="row">1</property>
+                                                    <property name="row-span">2</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <relation name="labelled-by">attack_time_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="release_time_label">
+                                                <property name="label" translatable="yes">Release</property>
+                                                <layout>
+                                                    <property name="column">1</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="release">
+                                                <property name="margin-start">6</property>
+                                                <property name="margin-end">6</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="digits">2</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="upper">5000</property>
+                                                        <property name="value">100</property>
+                                                        <property name="step-increment">0.01</property>
+                                                        <property name="page-increment">0.1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">1</property>
+                                                    <property name="row">1</property>
+                                                    <property name="row-span">2</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <relation name="labelled-by">release_time_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="label" translatable="yes">Curve</property>
+                                                <layout>
+                                                    <property name="column">2</property>
+                                                    <property name="row">0</property>
+                                                    <property name="column-span">2</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="curve_threshold_label">
+                                                <property name="label" translatable="yes">Threshold</property>
+                                                <layout>
+                                                    <property name="column">2</property>
+                                                    <property name="row">1</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="curve_threshold">
+                                                <property name="margin-start">6</property>
+                                                <property name="margin-end">3</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="digits">1</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-60</property>
+                                                        <property name="upper">0</property>
+                                                        <property name="value">-24</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">2</property>
+                                                    <property name="row">2</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <relation name="labelled-by">curve_threshold_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="curve_zone_label">
+                                                <property name="label" translatable="yes">Zone</property>
+                                                <layout>
+                                                    <property name="column">3</property>
+                                                    <property name="row">1</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="curve_zone">
+                                                <property name="margin-start">3</property>
+                                                <property name="margin-end">6</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="digits">1</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-60</property>
+                                                        <property name="upper">0</property>
+                                                        <property name="value">-6</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">3</property>
+                                                    <property name="row">2</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <relation name="labelled-by">curve_zone_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkToggleButton" id="hysteresis">
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="label" translatable="yes">Hysteresis</property>
+                                                <layout>
+                                                    <property name="column">4</property>
+                                                    <property name="row">0</property>
+                                                    <property name="column-span">2</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="hysteresis_threshold_label">
+                                                <property name="label" translatable="yes">Threshold</property>
+                                                <layout>
+                                                    <property name="column">4</property>
+                                                    <property name="row">1</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="hysteresis_threshold">
+                                                <property name="margin-start">6</property>
+                                                <property name="margin-end">3</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="digits">1</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="sensitive" bind-source="hysteresis" bind-property="active" bind-flags="sync-create" />
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-60</property>
+                                                        <property name="upper">0</property>
+                                                        <property name="value">-12</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">4</property>
+                                                    <property name="row">2</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <relation name="labelled-by">hysteresis_threshold_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="hysteresis_zone_label">
+                                                <property name="label" translatable="yes">Zone</property>
+                                                <layout>
+                                                    <property name="column">5</property>
+                                                    <property name="row">1</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="hysteresis_zone">
+                                                <property name="margin-start">3</property>
+                                                <property name="margin-end">6</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="digits">1</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="sensitive" bind-source="hysteresis" bind-property="active" bind-flags="sync-create" />
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-60</property>
+                                                        <property name="upper">0</property>
+                                                        <property name="value">-6</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">5</property>
+                                                    <property name="row">2</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <relation name="labelled-by">hysteresis_zone_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="reduction_label">
+                                                <property name="label" translatable="yes">Reduction</property>
+                                                <layout>
+                                                    <property name="column">6</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="reduction">
+                                                <property name="margin-start">6</property>
+                                                <property name="margin-end">6</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">1</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-72</property>
+                                                        <property name="upper">0</property>
+                                                        <property name="value">-24</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">6</property>
+                                                    <property name="row">1</property>
+                                                    <property name="row-span">2</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <relation name="labelled-by">reduction_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="makeup_label">
+                                                <property name="label" translatable="yes">Makeup</property>
+                                                <layout>
+                                                    <property name="column">7</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="makeup">
+                                                <property name="margin-start">6</property>
+                                                <property name="margin-end">6</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">1</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-60</property>
+                                                        <property name="upper">60</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">7</property>
+                                                    <property name="row">1</property>
+                                                    <property name="row-span">2</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <relation name="labelled-by">makeup_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
-                                </property>
-                                <accessibility>
-                                    <relation name="labelled-by">range_label</relation>
-                                </accessibility>
+                                </child>
                             </object>
-                        </child>
+                        </property>
                     </object>
                 </child>
 
                 <child>
-                    <object class="GtkBox">
-                        <property name="spacing">6</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkLabel" id="stereo_link_label">
-                                <property name="label" translatable="yes">Stereo Link</property>
-                            </object>
-                        </child>
+                    <object class="GtkStackPage">
+                        <property name="name">page_sidechain</property>
+                        <property name="title" translatable="yes">Sidechain</property>
+                        <property name="child">
+                            <object class="GtkBox">
+                                <property name="halign">center</property>
+                                <property name="spacing">24</property>
+                                <property name="orientation">vertical</property>
 
-                        <child>
-                            <object class="GtkComboBoxText" id="stereo_link">
-                                <items>
-                                    <item translatable="yes" id="Average">Average</item>
-                                    <item translatable="yes" id="Maximum">Maximum</item>
-                                </items>
-                                <accessibility>
-                                    <relation name="labelled-by">stereo_link_label</relation>
-                                </accessibility>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <property name="homogeneous">1</property>
+                                        <property name="spacing">24</property>
+                                        <child>
+                                            <object class="GtkGrid">
+                                                <property name="row-spacing">6</property>
+                                                <property name="column-spacing">18</property>
+                                                <property name="column-homogeneous">1</property>
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="label" translatable="yes">Mode</property>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkComboBoxText" id="sidechain_mode">
+                                                        <items>
+                                                            <item translatable="yes" id="Peak">Peak</item>
+                                                            <item translatable="yes" id="RMS">RMS</item>
+                                                            <item translatable="yes" id="Low-Pass">Low-Pass</item>
+                                                            <item translatable="yes" id="Uniform">Uniform</item>
+                                                        </items>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <property name="label" translatable="yes">Sidechain Mode</property>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkToggleButton" id="listen">
+                                                        <property name="halign">center</property>
+                                                        <property name="label" translatable="yes">Listen</property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="label" translatable="yes">Source</property>
+                                                        <layout>
+                                                            <property name="column">2</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkComboBoxText" id="sidechain_source">
+                                                        <items>
+                                                            <item translatable="yes" id="Middle">Middle</item>
+                                                            <item translatable="yes" id="Side">Side</item>
+                                                            <item translatable="yes" id="Left">Left</item>
+                                                            <item translatable="yes" id="Right">Right</item>
+                                                        </items>
+                                                        <layout>
+                                                            <property name="column">2</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <property name="label" translatable="yes">Sidechain Source</property>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkGrid">
+                                        <property name="halign">center</property>
+                                        <property name="row-spacing">6</property>
+                                        <property name="column-spacing">12</property>
+
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="label" translatable="yes">Input</property>
+                                                <layout>
+                                                    <property name="column">1</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="valign">center</property>
+                                                <property name="label" translatable="yes">Type</property>
+                                                <layout>
+                                                    <property name="column">0</property>
+                                                    <property name="row">1</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="valign">center</property>
+                                                <property name="label" translatable="yes">Device</property>
+                                                <layout>
+                                                    <property name="column">0</property>
+                                                    <property name="row">2</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkComboBoxText" id="sidechain_input">
+                                                <property name="valign">center</property>
+                                                <property name="margin-end">6</property>
+                                                <items>
+                                                    <item id="Internal" translatable="yes">Internal</item>
+                                                    <item id="External" translatable="yes">External</item>
+                                                </items>
+                                                <layout>
+                                                    <property name="column">1</property>
+                                                    <property name="row">1</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Sidechain Type</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkDropDown" id="dropdown_input_devices">
+                                                <property name="valign">center</property>
+                                                <property name="margin-end">6</property>
+
+                                                <binding name="sensitive">
+                                                    <closure type="gboolean" function="set_dropdown_sensitive">
+                                                        <lookup name="active-id">sidechain_input</lookup>
+                                                    </closure>
+                                                </binding>
+
+                                                <property name="factory">
+                                                    <object class="GtkBuilderListItemFactory">
+                                                        <property name="resource">/com/github/wwmm/easyeffects/ui/factory_input_device_dropdown.ui</property>
+                                                    </object>
+                                                </property>
+
+                                                <layout>
+                                                    <property name="column">1</property>
+                                                    <property name="row">2</property>
+                                                </layout>
+
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Input Device</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+
+                                        <child>
+                                            <object class="GtkLabel" id="preamp_label">
+                                                <property name="label" translatable="yes">PreAmplification</property>
+                                                <layout>
+                                                    <property name="column">2</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="preamp">
+                                                <property name="halign">center</property>
+                                                <property name="margin-start">6</property>
+                                                <property name="margin-end">6</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">1</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-120</property>
+                                                        <property name="upper">40</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">2</property>
+                                                    <property name="row">1</property>
+                                                    <property name="row-span">2</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <relation name="labelled-by">preamp_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="reactivity_label">
+                                                <property name="label" translatable="yes">Reactivity</property>
+                                                <layout>
+                                                    <property name="column">3</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="reactivity">
+                                                <property name="halign">center</property>
+                                                <property name="margin-start">6</property>
+                                                <property name="margin-end">6</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">2</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="upper">250</property>
+                                                        <property name="value">10</property>
+                                                        <property name="step-increment">0.01</property>
+                                                        <property name="page-increment">0.1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">3</property>
+                                                    <property name="row">1</property>
+                                                    <property name="row-span">2</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <relation name="labelled-by">reactivity_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="lookahead_label">
+                                                <property name="label" translatable="yes">Lookahead</property>
+                                                <layout>
+                                                    <property name="column">4</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="lookahead">
+                                                <property name="halign">center</property>
+                                                <property name="margin-start">6</property>
+                                                <property name="margin-end">6</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">2</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="upper">20</property>
+                                                        <property name="step-increment">0.01</property>
+                                                        <property name="page-increment">0.1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">4</property>
+                                                    <property name="row">1</property>
+                                                    <property name="row-span">2</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <relation name="labelled-by">lookahead_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
                             </object>
-                        </child>
+                        </property>
+                    </object>
+                </child>
+
+                <child>
+                    <object class="GtkStackPage">
+                        <property name="name">page_sidechain_filters</property>
+                        <property name="title" translatable="yes">Sidechain Filters</property>
+                        <property name="child">
+                            <object class="GtkGrid">
+                                <property name="halign">center</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">12</property>
+                                <property name="margin-top">12</property>
+                                <property name="margin-bottom">12</property>
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="label" translatable="yes">High-Pass</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">end</property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-bottom">6</property>
+                                        <property name="label" translatable="yes">Mode</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">end</property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-top">6</property>
+                                        <property name="label" translatable="yes">Frequency</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">2</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkComboBoxText" id="hpf_mode">
+                                        <property name="margin-bottom">6</property>
+                                        <property name="margin-end">6</property>
+                                        <items>
+                                            <item translatable="yes" id="off">Off</item>
+                                            <item translatable="yes" id="12 dB/oct">12 dB/oct</item>
+                                            <item translatable="yes" id="24 dB/oct">24 dB/oct</item>
+                                            <item translatable="yes" id="36 dB/oct">36 dB/oct</item>
+                                        </items>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">High-Pass Filter Mode</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkSpinButton" id="hpf_freq">
+                                        <property name="margin-top">6</property>
+                                        <property name="margin-end">6</property>
+                                        <property name="digits">0</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">10</property>
+                                                <property name="upper">20000</property>
+                                                <property name="value">10</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">100</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">2</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">High-Pass Filter Frequency</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="label" translatable="yes">Low-Pass</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkComboBoxText" id="lpf_mode">
+                                        <property name="margin-bottom">6</property>
+                                        <property name="margin-start">6</property>
+                                        <items>
+                                            <item translatable="yes" id="off">Off</item>
+                                            <item translatable="yes" id="12 dB/oct">12 dB/oct</item>
+                                            <item translatable="yes" id="24 dB/oct">24 dB/oct</item>
+                                            <item translatable="yes" id="36 dB/oct">36 dB/oct</item>
+                                        </items>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">Low-Pass Filter Mode</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkSpinButton" id="lpf_freq">
+                                        <property name="margin-top">6</property>
+                                        <property name="margin-start">6</property>
+                                        <property name="digits">0</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">10</property>
+                                                <property name="upper">20000</property>
+                                                <property name="value">20000</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">100</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">2</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">High-Pass Filter Frequency</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
+                            </object>
+                        </property>
                     </object>
                 </child>
             </object>
         </child>
 
         <child>
-            <object class="GtkGrid" id="grid_spinbox">
-                <property name="margin-bottom">12</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">24</property>
+            <object class="GtkBox">
+                <property name="hexpand">1</property>
+                <property name="vexpand">0</property>
+                <property name="homogeneous">1</property>
+                <property name="margin-top">4</property>
+                <property name="margin-bottom">4</property>
+
                 <child>
-                    <object class="GtkLabel" id="attack_label">
-                        <property name="label" translatable="yes">Attack</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="attack">
+                    <object class="GtkBox">
                         <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">11</property>
-                        <property name="digits">2</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">0.01</property>
-                                <property name="upper">2000</property>
-                                <property name="value">20</property>
-                                <property name="step-increment">0.01</property>
-                                <property name="page-increment">0.1</property>
+                        <child>
+                            <object class="GtkLabel" id="gain_title">
+                                <property name="halign">end</property>
+                                <property name="xalign">1</property>
+                                <property name="label" translatable="yes">Gain</property>
                             </object>
-                        </property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">attack_label</relation>
-                        </accessibility>
+                        </child>
+
+                        <child>
+                            <object class="GtkLabel" id="gain_label">
+                                <property name="width-chars">6</property>
+                                <property name="label">0</property>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkLabel">
+                                <property name="halign">start</property>
+                                <property name="label">db</property>
+                            </object>
+                        </child>
                     </object>
                 </child>
 
                 <child>
-                    <object class="GtkLabel" id="release_label">
-                        <property name="label" translatable="yes">Release</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="release">
+                    <object class="GtkBox">
                         <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">11</property>
-                        <property name="digits">2</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">0.01</property>
-                                <property name="upper">2000</property>
-                                <property name="value">250</property>
-                                <property name="step-increment">0.01</property>
-                                <property name="page-increment">0.1</property>
+                        <child>
+                            <object class="GtkLabel" id="envelope_title">
+                                <property name="halign">end</property>
+                                <property name="xalign">1</property>
+                                <property name="label" translatable="yes">Envelope</property>
                             </object>
-                        </property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">release_label</relation>
-                        </accessibility>
+                        </child>
+
+                        <child>
+                            <object class="GtkLabel" id="envelope_label">
+                                <property name="width-chars">6</property>
+                                <property name="label">0</property>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkLabel">
+                                <property name="halign">start</property>
+                                <property name="label">db</property>
+                            </object>
+                        </child>
                     </object>
                 </child>
 
                 <child>
-                    <object class="GtkLabel" id="threshold_label">
-                        <property name="label" translatable="yes">Threshold</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="threshold">
+                    <object class="GtkBox">
                         <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-60</property>
-                                <property name="value">-18</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
+                        <child>
+                            <object class="GtkLabel" id="sidechain_title">
+                                <property name="halign">end</property>
+                                <property name="xalign">1</property>
+                                <property name="label" translatable="yes">Sidechain</property>
                             </object>
-                        </property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">threshold_label</relation>
-                        </accessibility>
+                        </child>
+
+                        <child>
+                            <object class="GtkLabel" id="sidechain_label">
+                                <property name="width-chars">6</property>
+                                <property name="label">0</property>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkLabel">
+                                <property name="halign">start</property>
+                                <property name="label">db</property>
+                            </object>
+                        </child>
                     </object>
                 </child>
 
                 <child>
-                    <object class="GtkLabel" id="ratio_label">
-                        <property name="label" translatable="yes">Ratio</property>
-                        <layout>
-                            <property name="column">3</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="ratio">
+                    <object class="GtkBox">
                         <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">2</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">1</property>
-                                <property name="upper">20</property>
-                                <property name="value">2</property>
-                                <property name="step-increment">0.01</property>
-                                <property name="page-increment">0.1</property>
+                        <child>
+                            <object class="GtkLabel" id="curve_title">
+                                <property name="halign">end</property>
+                                <property name="xalign">1</property>
+                                <property name="label" translatable="yes">Curve</property>
                             </object>
-                        </property>
-                        <layout>
-                            <property name="column">3</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">ratio_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
+                        </child>
 
-                <child>
-                    <object class="GtkLabel" id="knee_label">
-                        <property name="label" translatable="yes">Knee</property>
-                        <layout>
-                            <property name="column">4</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="knee">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="upper">18</property>
-                                <property name="value">9</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
+                        <child>
+                            <object class="GtkLabel" id="curve_label">
+                                <property name="width-chars">6</property>
+                                <property name="label">0</property>
                             </object>
-                        </property>
-                        <layout>
-                            <property name="column">4</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">knee_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
+                        </child>
 
-                <child>
-                    <object class="GtkLabel" id="makeup_label">
-                        <property name="label" translatable="yes">Makeup</property>
-                        <layout>
-                            <property name="column">5</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="makeup">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="upper">36</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
+                        <child>
+                            <object class="GtkLabel">
+                                <property name="halign">start</property>
+                                <property name="label">db</property>
                             </object>
-                        </property>
-                        <layout>
-                            <property name="column">5</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">makeup_label</relation>
-                        </accessibility>
+                        </child>
                     </object>
                 </child>
             </object>
@@ -481,36 +1094,6 @@
             <object class="GtkBox">
                 <property name="hexpand">1</property>
                 <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="gating_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Gating</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="gating">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="gating_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">4</property>
-                        <property name="label">0</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
                 <property name="layout-manager">
                     <object class="GtkBinLayout"></object>
                 </property>
@@ -540,7 +1123,7 @@
                         <child>
                             <object class="GtkLabel">
                                 <property name="halign">end</property>
-                                <property name="label">Calf Studio Gear</property>
+                                <property name="label">Linux Studio Plugins</property>
                                 <attributes>
                                     <attribute name="weight" value="bold" />
                                 </attributes>
@@ -557,15 +1140,10 @@
         <widgets>
             <widget name="input_level_title" />
             <widget name="output_level_title" />
-            <widget name="gating_title" />
-        </widgets>
-    </object>
-
-    <object class="GtkSizeGroup">
-        <property name="mode">horizontal</property>
-        <widgets>
-            <widget name="box_reduction_option" />
-            <widget name="grid_spinbox" />
+            <widget name="curve_title" />
+            <widget name="sidechain_title" />
+            <widget name="gain_title" />
+            <widget name="envelope_title" />
         </widgets>
     </object>
 

--- a/help/C/gate.page
+++ b/help/C/gate.page
@@ -5,98 +5,227 @@
         <link type="guide" xref="index#plugins" />
     </info>
     <title>Gate</title>
-    <p>The Gate attenuates signals that register below a Threshold. This kind of signal processing is used to reduce disturbing noise between useful signals. EasyEffects uses the Gate developed by Calf Studio Gear.</p>
-    <terms>
-        <item>
-            <title>
-                <em style="strong" its:withinText="nested">Max Reduction</em>
-            </title>
-            <p>The maximum level of gain reduction to apply when the signal is below the Threshold.</p>
-        </item>
-        <item>
-            <title>
-                <em style="strong" its:withinText="nested">Detection</em>
-            </title>
-            <p>Determines how the signal is evaluated for the gain reduction.</p>
-            <list>
-                <item>
-                    <p>
-                        <em style="strong">Peak</em>
-                        - The Gate reacts according to the peaks.
-                    </p>
-                </item>
-                <item>
-                    <p>
-                        <em style="strong">RMS</em>
-                        - The Gate reacts according to the average level measured by the root mean square.
-                    </p>
-                </item>
-            </list>
-        </item>
-        <item>
-            <title>
-                <em style="strong" its:withinText="nested">Stereo Link</em>
-            </title>
-            <p>Determines which part of the signal is taken into account for the gain reduction.</p>
-            <list>
-                <item>
-                    <p>
-                        <em style="strong">Average</em>
-                        - The average level between both channels.
-                    </p>
-                </item>
-                <item>
-                    <p>
-                        <em style="strong">Maximum</em>
-                        - The loudest channel.
-                    </p>
-                </item>
-            </list>
-        </item>
-        <item>
-            <title>
-                <em style="strong" its:withinText="nested">Release</em>
-            </title>
-            <p>The length of time it takes to apply roughly two-thirds of the targeted amount of reduction ratio.</p>
-        </item>
-        <item>
-            <title>
-                <em style="strong" its:withinText="nested">Attack</em>
-            </title>
-            <p>The length of time it takes to restore roughly two-thirds of the reduced gain.</p>
-        </item>
-        <item>
-            <title>
-                <em style="strong" its:withinText="nested">Threshold</em>
-            </title>
-            <p>The target level around which the reduction is applied (the range depends by the Knee).</p>
-        </item>
-        <item>
-            <title>
-                <em style="strong" its:withinText="nested">Ratio</em>
-            </title>
-            <p>The amount of reduction that will be applied to the signal.</p>
-            <p>For example, when the Ratio is 2 and the signal falls below the Threshold by 5 dB, it would be ideally reduced by 10 dB (5x2 dB, or less if the Maximum Gain Reduction is greater than -10 dB). In practice this behavior mostly depends on how the Gate is designed and configured.</p>
-        </item>
-        <item>
-            <title>
-                <em style="strong" its:withinText="nested">Knee</em>
-            </title>
-            <p>The range over which the Gate switches from no reduction to almost the full ratio reduction (the Threshold usually sits at the center of this transition zone).</p>
-        </item>
-        <item>
-            <title>
-                <em style="strong" its:withinText="nested">Makeup</em>
-            </title>
-            <p>The gain to apply after the gating stage.</p>
-        </item>
-    </terms>
+    <p>The Gate attenuates signals that register below a Threshold. This kind of signal processing is used to reduce disturbing noise between useful signals. EasyEffects uses the Stereo Sidechain Gate from Linux Studio Plugins.</p>
+    <section>
+        <title>Gate Options</title>
+        <terms>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Attack Time</em>
+                </title>
+                <p>The length of time it takes to restore roughly two-thirds of the gain reduction.</p>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Release Time</em>
+                </title>
+                <p>The length of time it takes to apply roughly two-thirds of the gain reduction.</p>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Curve Threshold</em>
+                </title>
+                <p>The Gate fully opens upon the Sidechain level becoming above Curve Threshold.</p>
+                <p>If Hysteresis is not enabled, the Gate begins to close upon the Sidechain level becoming below Curve Threshold.</p>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Curve Zone Size</em>
+                </title>
+                <p>The Gate begins to open upon the Sidechain level becoming above the Curve Threshold + Curve Zone.</p>
+                <p>If Hysteresis is not enabled, the Gate fully closes upon the Sidechain level becoming below the Curve Threshold + Curve Zone.</p>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Hysteresis</em>
+                </title>
+                <p>When enabled, Curve Threshold and Curve Zone apply only to the opening Gate, and separate parameters can be configured for closing Gate.</p>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Hysteresis Threshold</em>
+                </title>
+                <p>If Hysteresis is enabled, the Gate begins to close upon the Sidechain level becoming below Curve Threshold + Hysteresis Threshold.</p>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Hysteresis Zone Size</em>
+                </title>
+                <p>If Hysteresis is enabled, the Gate fully closes upon the Sidechain level becoming below the Curve Threshold + Hysteresis Threshold + Hysteresis Zone.</p>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Reduction</em>
+                </title>
+                <p>The amount of gain reduction to apply when the Gate is fully closed.</p>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Makeup</em>
+                </title>
+                <p>The gain to apply after the gating stage.</p>
+            </item>
+        </terms>
+    </section>
+    <section>
+        <title>Sidechain</title>
+        <terms>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Listen</em>
+                </title>
+                <p>Allows to listen the processed Sidechain signal.</p>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Input Type</em>
+                </title>
+                <p>Determines which signal is the Sidechain or, in other words, the signal that controls the gating stage.</p>
+                <list>
+                    <item>
+                        <p>
+                            <em style="strong">Internal</em>
+                            - The Sidechain is the Gate input signal (taken after applying the plugin input gain).
+                        </p>
+                    </item>
+                    <item>
+                        <p>
+                            <em style="strong">External</em>
+                            - The Sidechain is an external source took by a specific input device (typically a microphone).
+                        </p>
+                    </item>
+                </list>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Input Device</em>
+                </title>
+                <p>Select the device for the External Sidechain.</p>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Mode</em>
+                </title>
+                <p>Determines how the Sidechain is evaluated for the gating stage.</p>
+                <list>
+                    <item>
+                        <p>
+                            <em style="strong">Peak</em>
+                            - The Gate reacts according to the peaks.
+                        </p>
+                    </item>
+                    <item>
+                        <p>
+                            <em style="strong">RMS</em>
+                            - The Gate reacts according to the average loudness measured by the root mean square.
+                        </p>
+                    </item>
+                    <item>
+                        <p>
+                            <em style="strong">Low-Pass</em>
+                            - The Gate reacts according to the signal processed by a Low-Pass filter.
+                        </p>
+                    </item>
+                    <item>
+                        <p>
+                            <em style="strong">Uniform</em>
+                            - The Gate reacts according to the loudness measured by the average of the absolute amplitude.
+                        </p>
+                    </item>
+                </list>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Source</em>
+                </title>
+                <p>Determines which part of the Sidechain is taken into account for the gating stage.</p>
+                <list>
+                    <item>
+                        <p>
+                            <em style="strong">Middle</em>
+                            - The sum of left and right channels.
+                        </p>
+                    </item>
+                    <item>
+                        <p>
+                            <em style="strong">Side</em>
+                            - The difference between left and right channels.
+                        </p>
+                    </item>
+                    <item>
+                        <p>
+                            <em style="strong">Left</em>
+                            - Only left channel is used.
+                        </p>
+                    </item>
+                    <item>
+                        <p>
+                            <em style="strong">Right</em>
+                            - Only right channel is used.
+                        </p>
+                    </item>
+                </list>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">PreAmplification</em>
+                </title>
+                <p>Gain applied to the Sidechain signal.</p>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Reactivity</em>
+                </title>
+                <p>The time that defines the number of samples used to process the Sidechain in RMS, Uniform and Low-Pass modes. Higher the value, more smooth the gating.</p>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Lookahead</em>
+                </title>
+                <p>The signal to gate is delayed by this amount of time, so that the gating will be applied earlier than it would be otherwise. The corresponding delay is reproduced on the output signal.</p>
+            </item>
+        </terms>
+    </section>
+    <section>
+        <title>Sidechain Filters</title>
+        <terms>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">High-Pass Filter Mode</em>
+                </title>
+                <p>Sets the type of the High-Pass filter applied to Sidechain signal.</p>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">High-Pass Frequency</em>
+                </title>
+                <p>Sets the cut-off frequency of the High-Pass filter.</p>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Low-Pass Filter Mode</em>
+                </title>
+                <p>Sets the type of the Low-Pass filter applied to Sidechain signal.</p>
+            </item>
+            <item>
+                <title>
+                    <em style="strong" its:withinText="nested">Low-Pass Frequency</em>
+                </title>
+                <p>Sets the cut-off frequency of the Low-Pass filter.</p>
+            </item>
+        </terms>
+    </section>
     <section>
         <title>References</title>
         <list>
             <item>
                 <p>
-                    <link href="https://calf-studio-gear.org/doc/Gate.html" its:translate="no">Calf Gate</link>
+                    <link href="https://en.wikipedia.org/wiki/Dynamic_range_compression" its:translate="no">Wikipedia Dynamic Range Compression</link>
+                </p>
+            </item>
+            <item>
+                <p>
+                    <link href="https://lsp-plug.in/?page=manuals&amp;section=sc_gate_stereo" its:translate="no">LSP Sidechain Gate Stereo</link>
                 </p>
             </item>
             <item>

--- a/include/gate.hpp
+++ b/include/gate.hpp
@@ -36,14 +36,28 @@ class Gate : public PluginBase {
   void process(std::span<float>& left_in,
                std::span<float>& right_in,
                std::span<float>& left_out,
-               std::span<float>& right_out) override;
+               std::span<float>& right_out,
+               std::span<float>& probe_left,
+               std::span<float>& probe_right) override;
 
   auto get_latency_seconds() -> float override;
 
-  sigc::signal<void(const double)> gating;
+  void update_probe_links() override;
 
-  double gating_port_value = 0.0;
+  sigc::signal<void(const float)> reduction, sidechain, curve, envelope, latency;
+
+  float reduction_port_value = 0.0F;
+  float sidechain_port_value = 0.0F;
+  float curve_port_value = 0.0F;
+  float envelope_port_value = 0.0F;
+  float latency_port_value = 0.0F;
 
  private:
+  uint latency_n_frames = 0U;
+
   std::unique_ptr<lv2::Lv2Wrapper> lv2_wrapper;
+
+  std::vector<pw_proxy*> list_proxies;
+
+  void update_sidechain_links(const std::string& key);
 };

--- a/include/gate_ui.hpp
+++ b/include/gate_ui.hpp
@@ -21,6 +21,7 @@
 
 #include <adwaita.h>
 #include "effects_base.hpp"
+#include "node_info_holder.hpp"
 #include "tags_resources.hpp"
 #include "ui_helpers.hpp"
 
@@ -36,6 +37,6 @@ G_END_DECLS
 
 auto create() -> GateBox*;
 
-void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_path);
+void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_path, PipeManager* pm);
 
 }  // namespace ui::gate_box

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -20,29 +20,67 @@
 #include "gate.hpp"
 
 Gate::Gate(const std::string& tag, const std::string& schema, const std::string& schema_path, PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::gate, schema, schema_path, pipe_manager),
-      lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://calf.sourceforge.net/plugins/Gate")) {
+    : PluginBase(tag, tags::plugin_name::gate, schema, schema_path, pipe_manager, true),
+      lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/sc_gate_stereo")) {
   if (!lv2_wrapper->found_plugin) {
-    util::debug(log_tag + "http://calf.sourceforge.net/plugins/Gate is not installed");
+    util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/sc_gate_stereo is not installed");
   }
 
-  lv2_wrapper->bind_key_enum<"detection", "detection">(settings);
+  gconnections.push_back(g_signal_connect(settings, "changed::sidechain-input",
+                                          G_CALLBACK(+[](GSettings* settings, char* key, gpointer user_data) {
+                                            auto self = static_cast<Gate*>(user_data);
 
-  lv2_wrapper->bind_key_enum<"stereo_link", "stereo-link">(settings);
+                                            self->update_sidechain_links(key);
+                                          }),
+                                          this));
 
-  lv2_wrapper->bind_key_double<"attack", "attack">(settings);
+  gconnections.push_back(g_signal_connect(settings, "changed::sidechain-input-device",
+                                          G_CALLBACK(+[](GSettings* settings, char* key, gpointer user_data) {
+                                            auto self = static_cast<Gate*>(user_data);
 
-  lv2_wrapper->bind_key_double<"release", "release">(settings);
+                                            self->update_sidechain_links(key);
+                                          }),
+                                          this));
 
-  lv2_wrapper->bind_key_double<"ratio", "ratio">(settings);
+  lv2_wrapper->bind_key_enum<"sci", "sidechain-input">(settings);
 
-  lv2_wrapper->bind_key_double_db<"range", "range">(settings);
+  lv2_wrapper->bind_key_enum<"scm", "sidechain-mode">(settings);
 
-  lv2_wrapper->bind_key_double_db<"threshold", "threshold">(settings);
+  lv2_wrapper->bind_key_enum<"scs", "sidechain-source">(settings);
 
-  lv2_wrapper->bind_key_double_db<"knee", "knee">(settings);
+  lv2_wrapper->bind_key_enum<"shpm", "hpf-mode">(settings);
 
-  lv2_wrapper->bind_key_double_db<"makeup", "makeup">(settings);
+  lv2_wrapper->bind_key_enum<"slpm", "lpf-mode">(settings);
+
+  lv2_wrapper->bind_key_bool<"scl", "sidechain-listen">(settings);
+
+  lv2_wrapper->bind_key_double<"at", "attack">(settings);
+
+  lv2_wrapper->bind_key_double<"rt", "release">(settings);
+
+  lv2_wrapper->bind_key_double<"scr", "sidechain-reactivity">(settings);
+
+  lv2_wrapper->bind_key_double<"sla", "sidechain-lookahead">(settings);
+
+  lv2_wrapper->bind_key_double<"shpf", "hpf-frequency">(settings);
+
+  lv2_wrapper->bind_key_double<"slpf", "lpf-frequency">(settings);
+
+  lv2_wrapper->bind_key_double_db<"gt", "curve-threshold">(settings);
+
+  lv2_wrapper->bind_key_double_db<"gz", "curve-zone">(settings);
+
+  lv2_wrapper->bind_key_bool<"gh", "hysteresis">(settings);
+
+  lv2_wrapper->bind_key_double_db<"ht", "hysteresis-threshold">(settings);
+
+  lv2_wrapper->bind_key_double_db<"hz", "hysteresis-zone">(settings);
+
+  lv2_wrapper->bind_key_double_db<"gr", "reduction">(settings);
+
+  lv2_wrapper->bind_key_double_db<"mk", "makeup">(settings);
+
+  lv2_wrapper->bind_key_double_db<"scp", "sidechain-preamp">(settings);
 
   setup_input_output_gain();
 }
@@ -70,7 +108,9 @@ void Gate::setup() {
 void Gate::process(std::span<float>& left_in,
                    std::span<float>& right_in,
                    std::span<float>& left_out,
-                   std::span<float>& right_out) {
+                   std::span<float>& right_out,
+                   std::span<float>& probe_left,
+                   std::span<float>& probe_right) {
   if (!lv2_wrapper->found_plugin || !lv2_wrapper->has_instance() || bypass) {
     std::copy(left_in.begin(), left_in.end(), left_out.begin());
     std::copy(right_in.begin(), right_in.end(), right_out.begin());
@@ -82,11 +122,57 @@ void Gate::process(std::span<float>& left_in,
     apply_gain(left_in, right_in, input_gain);
   }
 
-  lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
+  lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out, probe_left, probe_right);
   lv2_wrapper->run();
 
   if (output_gain != 1.0F) {
     apply_gain(left_out, right_out, output_gain);
+  }
+
+  /*
+   This plugin gives the latency in number of samples
+ */
+
+  const auto lv = static_cast<uint>(lv2_wrapper->get_control_port_value("out_latency"));
+
+  if (latency_n_frames != lv) {
+    latency_n_frames = lv;
+
+    latency_port_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+
+    util::debug(log_tag + name + " latency: " + util::to_string(latency_port_value, "") + " s");
+
+    g_idle_add((GSourceFunc) +
+                   [](gpointer user_data) {
+                     auto* self = static_cast<Gate*>(user_data);
+
+                     if (!self->post_messages) {
+                       return G_SOURCE_REMOVE;
+                     }
+
+                     if (self->latency.empty()) {
+                       return G_SOURCE_REMOVE;
+                     }
+
+                     self->latency.emit(self->latency_port_value);
+
+                     return G_SOURCE_REMOVE;
+                   },
+               this);
+
+    spa_process_latency_info latency_info{};
+
+    latency_info.ns = static_cast<uint64_t>(latency_port_value * 1000000000.0F);
+
+    std::array<char, 1024U> buffer{};
+
+    spa_pod_builder b{};
+
+    spa_pod_builder_init(&b, buffer.data(), sizeof(buffer));
+
+    const spa_pod* param = spa_process_latency_build(&b, SPA_PARAM_ProcessLatency, &latency_info);
+
+    pw_filter_update_params(filter, nullptr, &param, 1);
   }
 
   if (post_messages) {
@@ -95,11 +181,15 @@ void Gate::process(std::span<float>& left_in,
     notification_dt += buffer_duration;
 
     if (notification_dt >= notification_time_window) {
-      // gating needed as double for levelbar widget ui, so we convert it here
+      reduction_port_value = lv2_wrapper->get_control_port_value("rlm");
+      sidechain_port_value = lv2_wrapper->get_control_port_value("slm");
+      curve_port_value = lv2_wrapper->get_control_port_value("clm");
+      envelope_port_value = lv2_wrapper->get_control_port_value("elm");
 
-      gating_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("gating"));
-
-      gating.emit(gating_port_value);
+      reduction.emit(reduction_port_value);
+      sidechain.emit(sidechain_port_value);
+      curve.emit(curve_port_value);
+      envelope.emit(envelope_port_value);
 
       notify();
 
@@ -108,6 +198,38 @@ void Gate::process(std::span<float>& left_in,
   }
 }
 
+void Gate::update_sidechain_links(const std::string& key) {
+  if (util::gsettings_get_string(settings, "sidechain-input") == "External") {
+    const auto device_name = util::gsettings_get_string(settings, "sidechain-input-device");
+
+    NodeInfo input_device = pm->ee_source_node;
+
+    for (const auto& [serial, node] : pm->node_map) {
+      if (node.name == device_name) {
+        input_device = node;
+
+        break;
+      }
+    }
+
+    pm->destroy_links(list_proxies);
+
+    list_proxies.clear();
+
+    for (const auto& link : pm->link_nodes(input_device.id, get_node_id(), true)) {
+      list_proxies.push_back(link);
+    }
+  } else {
+    pm->destroy_links(list_proxies);
+
+    list_proxies.clear();
+  }
+}
+
+void Gate::update_probe_links() {
+  update_sidechain_links("");
+}
+
 auto Gate::get_latency_seconds() -> float {
-  return 0.0F;
+  return this->latency_port_value;
 }

--- a/src/gate_preset.cpp
+++ b/src/gate_preset.cpp
@@ -32,23 +32,43 @@ void GatePreset::save(nlohmann::json& json, const std::string& section, GSetting
 
   json[section]["gate"]["output-gain"] = g_settings_get_double(settings, "output-gain");
 
-  json[section]["gate"]["detection"] = util::gsettings_get_string(settings, "detection");
-
-  json[section]["gate"]["stereo-link"] = util::gsettings_get_string(settings, "stereo-link");
-
-  json[section]["gate"]["range"] = g_settings_get_double(settings, "range");
-
   json[section]["gate"]["attack"] = g_settings_get_double(settings, "attack");
 
   json[section]["gate"]["release"] = g_settings_get_double(settings, "release");
 
-  json[section]["gate"]["threshold"] = g_settings_get_double(settings, "threshold");
+  json[section]["gate"]["curve_threshold"] = g_settings_get_double(settings, "curve-threshold");
 
-  json[section]["gate"]["ratio"] = g_settings_get_double(settings, "ratio");
+  json[section]["gate"]["curve_zone"] = g_settings_get_double(settings, "curve-zone");
 
-  json[section]["gate"]["knee"] = g_settings_get_double(settings, "knee");
+  json[section]["gate"]["hysteresis"] = g_settings_get_boolean(settings, "hysteresis");
+
+  json[section]["gate"]["hysteresis_threshold"] = g_settings_get_double(settings, "hysteresis-threshold");
+
+  json[section]["gate"]["hysteresis_zone"] = g_settings_get_double(settings, "hysteresis-zone");
+
+  json[section]["gate"]["reduction"] = g_settings_get_double(settings, "reduction");
 
   json[section]["gate"]["makeup"] = g_settings_get_double(settings, "makeup");
+
+  json[section]["gate"]["sidechain"]["input"] = util::gsettings_get_string(settings, "sidechain-input");
+
+  json[section]["gate"]["sidechain"]["mode"] = util::gsettings_get_string(settings, "sidechain-mode");
+
+  json[section]["gate"]["sidechain"]["source"] = util::gsettings_get_string(settings, "sidechain-source");
+
+  json[section]["gate"]["sidechain"]["preamp"] = g_settings_get_double(settings, "sidechain-preamp");
+
+  json[section]["gate"]["sidechain"]["reactivity"] = g_settings_get_double(settings, "sidechain-reactivity");
+
+  json[section]["gate"]["sidechain"]["lookahead"] = g_settings_get_double(settings, "sidechain-lookahead");
+
+  json[section]["gate"]["hpf-mode"] = util::gsettings_get_string(settings, "hpf-mode");
+
+  json[section]["gate"]["hpf-frequency"] = g_settings_get_double(settings, "hpf-frequency");
+
+  json[section]["gate"]["lpf-mode"] = util::gsettings_get_string(settings, "lpf-mode");
+
+  json[section]["gate"]["lpf-frequency"] = g_settings_get_double(settings, "lpf-frequency");
 }
 
 void GatePreset::load(const nlohmann::json& json, const std::string& section, GSettings* settings) {
@@ -58,21 +78,41 @@ void GatePreset::load(const nlohmann::json& json, const std::string& section, GS
 
   update_key<double>(json.at(section).at("gate"), settings, "output-gain", "output-gain");
 
-  update_key<gchar*>(json.at(section).at("gate"), settings, "detection", "detection");
-
-  update_key<gchar*>(json.at(section).at("gate"), settings, "stereo-link", "stereo-link");
-
-  update_key<double>(json.at(section).at("gate"), settings, "range", "range");
-
   update_key<double>(json.at(section).at("gate"), settings, "attack", "attack");
 
   update_key<double>(json.at(section).at("gate"), settings, "release", "release");
 
-  update_key<double>(json.at(section).at("gate"), settings, "threshold", "threshold");
+  update_key<double>(json.at(section).at("gate"), settings, "curve_threshold", "curve-threshold");
 
-  update_key<double>(json.at(section).at("gate"), settings, "ratio", "ratio");
+  update_key<double>(json.at(section).at("gate"), settings, "curve_zone", "curve-zone");
 
-  update_key<double>(json.at(section).at("gate"), settings, "knee", "knee");
+  update_key<bool>(json.at(section).at("gate"), settings, "hysteresis", "hysteresis");
+
+  update_key<double>(json.at(section).at("gate"), settings, "hysteresis_threshold", "hysteresis-threshold");
+
+  update_key<double>(json.at(section).at("gate"), settings, "hysteresis_zone", "hysteresis-zone");
+
+  update_key<double>(json.at(section).at("gate"), settings, "reduction", "reduction");
 
   update_key<double>(json.at(section).at("gate"), settings, "makeup", "makeup");
+
+  update_key<gchar*>(json.at(section).at("gate").at("sidechain"), settings, "sidechain-input", "input");
+
+  update_key<gchar*>(json.at(section).at("gate").at("sidechain"), settings, "sidechain-mode", "mode");
+
+  update_key<gchar*>(json.at(section).at("gate").at("sidechain"), settings, "sidechain-source", "source");
+
+  update_key<double>(json.at(section).at("gate").at("sidechain"), settings, "sidechain-preamp", "preamp");
+
+  update_key<double>(json.at(section).at("gate").at("sidechain"), settings, "sidechain-reactivity", "reactivity");
+
+  update_key<double>(json.at(section).at("gate").at("sidechain"), settings, "sidechain-lookahead", "lookahead");
+
+  update_key<gchar*>(json.at(section).at("gate"), settings, "hpf-mode", "hpf-mode");
+
+  update_key<double>(json.at(section).at("gate"), settings, "hpf-frequency", "hpf-frequency");
+
+  update_key<gchar*>(json.at(section).at("gate"), settings, "lpf-mode", "lpf-mode");
+
+  update_key<double>(json.at(section).at("gate"), settings, "lpf-frequency", "lpf-frequency");
 }

--- a/src/plugins_box.cpp
+++ b/src/plugins_box.cpp
@@ -229,7 +229,7 @@ void add_plugins_to_stack(PluginsBox* self) {
 
       auto plugin_ptr = effects_base->get_plugin_instance<Gate>(name);
 
-      ui::gate_box::setup(box, plugin_ptr, self->data->schema_path + name + "/");
+      ui::gate_box::setup(box, plugin_ptr, self->data->schema_path + name + "/", self->data->application->pm);
 
       gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
     } else if (name.rfind(tags::plugin_name::limiter, 0) == 0) {


### PR DESCRIPTION
This ended up being rather boringly straight-forward
after figuring out https://github.com/wwmm/easyeffects/pull/1622.
I started by fully copying the `Compressor` effect,
which is also LSP-based, and is pretty modern,
and then changed things.

The `Sidechain`/`Sidechain Filters` tabs are exactly identical
as they are in the `Compressor`, and in general most of the code
is rather exactly identical to `Compressor`.
Seems like some common boilerplate could/should be extracted.

I'm sure i've missed something, but this is basically it.
![image](https://user-images.githubusercontent.com/88600/177223954-0cadbe35-c2ee-4a3c-8b84-59a4c8e96b77.png)

Fixes https://github.com/wwmm/easyeffects/issues/1596