### PR TITLE
LSP Gate: display more meters

### DIFF
--- a/data/ui/gate.ui
+++ b/data/ui/gate.ui
@@ -354,6 +354,98 @@
                                         </child>
                                     </object>
                                 </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="homogeneous">1</property>
+                                        <property name="margin-top">4</property>
+                                        <property name="margin-bottom">4</property>
+
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="halign">center</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="zone_start_title">
+                                                        <property name="halign">end</property>
+                                                        <property name="xalign">1</property>
+                                                        <property name="label" translatable="yes">Zone start</property>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="zone_start_label">
+                                                        <property name="width-chars">6</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="halign">start</property>
+                                                        <property name="label">db</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="halign">center</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="hysteresis_threshold_start_title">
+                                                        <property name="halign">end</property>
+                                                        <property name="xalign">1</property>
+                                                        <property name="label" translatable="yes">Hysteresis threshold start</property>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="hysteresis_threshold_start_label">
+                                                        <property name="width-chars">6</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="halign">start</property>
+                                                        <property name="label">db</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="halign">center</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="hysteresis_zone_start_title">
+                                                        <property name="halign">end</property>
+                                                        <property name="xalign">1</property>
+                                                        <property name="label" translatable="yes">Hysteresis zone start</property>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="hysteresis_zone_start_label">
+                                                        <property name="width-chars">6</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="halign">start</property>
+                                                        <property name="label">db</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
                             </object>
                         </property>
                     </object>

--- a/data/ui/gate.ui
+++ b/data/ui/gate.ui
@@ -377,7 +377,7 @@
                                                 <child>
                                                     <object class="GtkLabel" id="attack_zone_start_label">
                                                         <property name="width-chars">6</property>
-                                                        <property name="label">0</property>
+                                                        <property name="label">0.0</property>
                                                     </object>
                                                 </child>
 
@@ -404,7 +404,7 @@
                                                 <child>
                                                     <object class="GtkLabel" id="attack_threshold_label">
                                                         <property name="width-chars">6</property>
-                                                        <property name="label">0</property>
+                                                        <property name="label">0.0</property>
                                                     </object>
                                                 </child>
 
@@ -431,7 +431,7 @@
                                                 <child>
                                                     <object class="GtkLabel" id="release_zone_start_label">
                                                         <property name="width-chars">6</property>
-                                                        <property name="label">0</property>
+                                                        <property name="label">0.0</property>
                                                     </object>
                                                 </child>
 
@@ -458,7 +458,7 @@
                                                 <child>
                                                     <object class="GtkLabel" id="release_threshold_label">
                                                         <property name="width-chars">6</property>
-                                                        <property name="label">0</property>
+                                                        <property name="label">0.0</property>
                                                     </object>
                                                 </child>
 

--- a/data/ui/gate.ui
+++ b/data/ui/gate.ui
@@ -370,7 +370,7 @@
                                                     <object class="GtkLabel" id="attack_zone_start_title">
                                                         <property name="halign">end</property>
                                                         <property name="xalign">1</property>
-                                                        <property name="label" translatable="yes">Attack zone start</property>
+                                                        <property name="label" translatable="yes">Attack Zone Start</property>
                                                     </object>
                                                 </child>
 
@@ -397,7 +397,7 @@
                                                     <object class="GtkLabel" id="attack_threshold_title">
                                                         <property name="halign">end</property>
                                                         <property name="xalign">1</property>
-                                                        <property name="label" translatable="yes">Attack threshold</property>
+                                                        <property name="label" translatable="yes">Attack Threshold</property>
                                                     </object>
                                                 </child>
 
@@ -424,7 +424,7 @@
                                                     <object class="GtkLabel" id="release_zone_start_title">
                                                         <property name="halign">end</property>
                                                         <property name="xalign">1</property>
-                                                        <property name="label" translatable="yes">Release zone start</property>
+                                                        <property name="label" translatable="yes">Release Zone Start</property>
                                                     </object>
                                                 </child>
 
@@ -451,7 +451,7 @@
                                                     <object class="GtkLabel" id="release_threshold_title">
                                                         <property name="halign">end</property>
                                                         <property name="xalign">1</property>
-                                                        <property name="label" translatable="yes">Release threshold</property>
+                                                        <property name="label" translatable="yes">Release Threshold</property>
                                                     </object>
                                                 </child>
 

--- a/data/ui/gate.ui
+++ b/data/ui/gate.ui
@@ -367,15 +367,15 @@
                                             <object class="GtkBox">
                                                 <property name="halign">center</property>
                                                 <child>
-                                                    <object class="GtkLabel" id="zone_start_title">
+                                                    <object class="GtkLabel" id="attack_zone_start_title">
                                                         <property name="halign">end</property>
                                                         <property name="xalign">1</property>
-                                                        <property name="label" translatable="yes">Zone start</property>
+                                                        <property name="label" translatable="yes">Attack zone start</property>
                                                     </object>
                                                 </child>
 
                                                 <child>
-                                                    <object class="GtkLabel" id="zone_start_label">
+                                                    <object class="GtkLabel" id="attack_zone_start_label">
                                                         <property name="width-chars">6</property>
                                                         <property name="label">0</property>
                                                     </object>
@@ -394,15 +394,15 @@
                                             <object class="GtkBox">
                                                 <property name="halign">center</property>
                                                 <child>
-                                                    <object class="GtkLabel" id="hysteresis_threshold_start_title">
+                                                    <object class="GtkLabel" id="attack_threshold_title">
                                                         <property name="halign">end</property>
                                                         <property name="xalign">1</property>
-                                                        <property name="label" translatable="yes">Hysteresis threshold start</property>
+                                                        <property name="label" translatable="yes">Attack threshold</property>
                                                     </object>
                                                 </child>
 
                                                 <child>
-                                                    <object class="GtkLabel" id="hysteresis_threshold_start_label">
+                                                    <object class="GtkLabel" id="attack_threshold_label">
                                                         <property name="width-chars">6</property>
                                                         <property name="label">0</property>
                                                     </object>
@@ -421,15 +421,42 @@
                                             <object class="GtkBox">
                                                 <property name="halign">center</property>
                                                 <child>
-                                                    <object class="GtkLabel" id="hysteresis_zone_start_title">
+                                                    <object class="GtkLabel" id="release_zone_start_title">
                                                         <property name="halign">end</property>
                                                         <property name="xalign">1</property>
-                                                        <property name="label" translatable="yes">Hysteresis zone start</property>
+                                                        <property name="label" translatable="yes">Release zone start</property>
                                                     </object>
                                                 </child>
 
                                                 <child>
-                                                    <object class="GtkLabel" id="hysteresis_zone_start_label">
+                                                    <object class="GtkLabel" id="release_zone_start_label">
+                                                        <property name="width-chars">6</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="halign">start</property>
+                                                        <property name="label">db</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="halign">center</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="release_threshold_title">
+                                                        <property name="halign">end</property>
+                                                        <property name="xalign">1</property>
+                                                        <property name="label" translatable="yes">Release threshold</property>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="release_threshold_label">
                                                         <property name="width-chars">6</property>
                                                         <property name="label">0</property>
                                                     </object>

--- a/help/C/gate.page
+++ b/help/C/gate.page
@@ -8,10 +8,10 @@
     <p>The Gate attenuates signals that register below a Threshold. This kind of signal processing is used to reduce disturbing noise between useful signals. EasyEffects uses the Stereo Sidechain Gate from Linux Studio Plugins.</p>
     <section>
         <title>Gate Workflow</title>
-        <p>The Gate begins to open when the Sidechain level becomes above the Attack zone start level.</p>
-        <p>The Gate fully opens when the Sidechain level becomes above the Attack threshold level.</p>
-        <p>The Gate begins to close when the Sidechain level becomes below the Release zone start level.</p>
-        <p>The Gate fully closes when the Sidechain level becomes below the Release threshold level.</p>
+        <p>The Gate begins to open when the Sidechain level becomes above the Attack Zone Start level.</p>
+        <p>The Gate fully opens when the Sidechain level becomes above the Attack Threshold level.</p>
+        <p>The Gate begins to close when the Sidechain level becomes below the Release Zone Start level.</p>
+        <p>The Gate fully closes when the Sidechain level becomes below the Release Threshold level.</p>
     </section>
     <section>
         <title>Gate Options</title>
@@ -32,15 +32,15 @@
                 <title>
                     <em style="strong" its:withinText="nested">Curve Threshold</em>
                 </title>
-                <p>The Gate fully opens upon the Sidechain level becoming above Curve Threshold (displayed as Attack threshold).</p>
-                <p>If Hysteresis is not enabled, the Gate begins to close upon the Sidechain level becoming below Curve Threshold (displayed as Release zone start).</p>
+                <p>The Gate fully opens upon the Sidechain level becoming above Curve Threshold (displayed as Attack Threshold level).</p>
+                <p>If Hysteresis is not enabled, the Gate begins to close upon the Sidechain level becoming below Curve Threshold (displayed as Release Zone Start level).</p>
             </item>
             <item>
                 <title>
                     <em style="strong" its:withinText="nested">Curve Zone Size</em>
                 </title>
-                <p>The Gate begins to open upon the Sidechain level becoming above the Curve Threshold + Curve Zone (displayed as Attack zone start).</p>
-                <p>If Hysteresis is not enabled, the Gate fully closes upon the Sidechain level becoming below the Curve Threshold + Curve Zone (displayed as Release threshold).</p>
+                <p>The Gate begins to open upon the Sidechain level becoming above the Curve Threshold + Curve Zone (displayed as Attack Zone Start level).</p>
+                <p>If Hysteresis is not enabled, the Gate fully closes upon the Sidechain level becoming below the Curve Threshold + Curve Zone (displayed as Release Threshold level).</p>
             </item>
             <item>
                 <title>
@@ -52,13 +52,13 @@
                 <title>
                     <em style="strong" its:withinText="nested">Hysteresis Threshold</em>
                 </title>
-                <p>If Hysteresis is enabled, the Gate begins to close upon the Sidechain level becoming below Curve Threshold + Hysteresis Threshold (displayed as Release zone start).</p>
+                <p>If Hysteresis is enabled, the Gate begins to close upon the Sidechain level becoming below Curve Threshold + Hysteresis Threshold (displayed as Release Zone Start level).</p>
             </item>
             <item>
                 <title>
                     <em style="strong" its:withinText="nested">Hysteresis Zone Size</em>
                 </title>
-                <p>If Hysteresis is enabled, the Gate fully closes upon the Sidechain level becoming below the Curve Threshold + Hysteresis Threshold + Hysteresis Zone (displayed as Release threshold).</p>
+                <p>If Hysteresis is enabled, the Gate fully closes upon the Sidechain level becoming below the Curve Threshold + Hysteresis Threshold + Hysteresis Zone (displayed as Release Threshold level).</p>
             </item>
             <item>
                 <title>

--- a/help/C/gate.page
+++ b/help/C/gate.page
@@ -32,8 +32,8 @@
                 <title>
                     <em style="strong" its:withinText="nested">Curve Zone Size</em>
                 </title>
-                <p>The Gate begins to open upon the Sidechain level becoming above the Curve Threshold + Curve Zone.</p>
-                <p>If Hysteresis is not enabled, the Gate fully closes upon the Sidechain level becoming below the Curve Threshold + Curve Zone.</p>
+                <p>The Gate begins to open upon the Sidechain level becoming above the Curve Threshold + Curve Zone (displayed as Zone start).</p>
+                <p>If Hysteresis is not enabled, the Gate fully closes upon the Sidechain level becoming below the Curve Threshold + Curve Zone (displayed as Zone start).</p>
             </item>
             <item>
                 <title>
@@ -45,13 +45,13 @@
                 <title>
                     <em style="strong" its:withinText="nested">Hysteresis Threshold</em>
                 </title>
-                <p>If Hysteresis is enabled, the Gate begins to close upon the Sidechain level becoming below Curve Threshold + Hysteresis Threshold.</p>
+                <p>If Hysteresis is enabled, the Gate begins to close upon the Sidechain level becoming below Curve Threshold + Hysteresis Threshold (displayed as Hysteresis threshold start).</p>
             </item>
             <item>
                 <title>
                     <em style="strong" its:withinText="nested">Hysteresis Zone Size</em>
                 </title>
-                <p>If Hysteresis is enabled, the Gate fully closes upon the Sidechain level becoming below the Curve Threshold + Hysteresis Threshold + Hysteresis Zone.</p>
+                <p>If Hysteresis is enabled, the Gate fully closes upon the Sidechain level becoming below the Curve Threshold + Hysteresis Threshold + Hysteresis Zone (displayed as Hysteresis zone start).</p>
             </item>
             <item>
                 <title>

--- a/help/C/gate.page
+++ b/help/C/gate.page
@@ -7,6 +7,13 @@
     <title>Gate</title>
     <p>The Gate attenuates signals that register below a Threshold. This kind of signal processing is used to reduce disturbing noise between useful signals. EasyEffects uses the Stereo Sidechain Gate from Linux Studio Plugins.</p>
     <section>
+        <title>Gate Workflow</title>
+        <p>The Gate begins to open when the Sidechain level becomes above the Attack zone start level.</p>
+        <p>The Gate fully opens when the Sidechain level becomes above the Attack threshold level.</p>
+        <p>The Gate begins to close when the Sidechain level becomes below the Release zone start level.</p>
+        <p>The Gate fully closes when the Sidechain level becomes below the Release threshold level.</p>
+    </section>
+    <section>
         <title>Gate Options</title>
         <terms>
             <item>
@@ -25,15 +32,15 @@
                 <title>
                     <em style="strong" its:withinText="nested">Curve Threshold</em>
                 </title>
-                <p>The Gate fully opens upon the Sidechain level becoming above Curve Threshold.</p>
-                <p>If Hysteresis is not enabled, the Gate begins to close upon the Sidechain level becoming below Curve Threshold.</p>
+                <p>The Gate fully opens upon the Sidechain level becoming above Curve Threshold (displayed as Attack threshold).</p>
+                <p>If Hysteresis is not enabled, the Gate begins to close upon the Sidechain level becoming below Curve Threshold (displayed as Release zone start).</p>
             </item>
             <item>
                 <title>
                     <em style="strong" its:withinText="nested">Curve Zone Size</em>
                 </title>
-                <p>The Gate begins to open upon the Sidechain level becoming above the Curve Threshold + Curve Zone (displayed as Zone start).</p>
-                <p>If Hysteresis is not enabled, the Gate fully closes upon the Sidechain level becoming below the Curve Threshold + Curve Zone (displayed as Zone start).</p>
+                <p>The Gate begins to open upon the Sidechain level becoming above the Curve Threshold + Curve Zone (displayed as Attack zone start).</p>
+                <p>If Hysteresis is not enabled, the Gate fully closes upon the Sidechain level becoming below the Curve Threshold + Curve Zone (displayed as Release threshold).</p>
             </item>
             <item>
                 <title>
@@ -45,19 +52,19 @@
                 <title>
                     <em style="strong" its:withinText="nested">Hysteresis Threshold</em>
                 </title>
-                <p>If Hysteresis is enabled, the Gate begins to close upon the Sidechain level becoming below Curve Threshold + Hysteresis Threshold (displayed as Hysteresis threshold start).</p>
+                <p>If Hysteresis is enabled, the Gate begins to close upon the Sidechain level becoming below Curve Threshold + Hysteresis Threshold (displayed as Release zone start).</p>
             </item>
             <item>
                 <title>
                     <em style="strong" its:withinText="nested">Hysteresis Zone Size</em>
                 </title>
-                <p>If Hysteresis is enabled, the Gate fully closes upon the Sidechain level becoming below the Curve Threshold + Hysteresis Threshold + Hysteresis Zone (displayed as Hysteresis zone start).</p>
+                <p>If Hysteresis is enabled, the Gate fully closes upon the Sidechain level becoming below the Curve Threshold + Hysteresis Threshold + Hysteresis Zone (displayed as Release threshold).</p>
             </item>
             <item>
                 <title>
                     <em style="strong" its:withinText="nested">Reduction</em>
                 </title>
-                <p>The amount of gain reduction to apply when the Gate is fully closed.</p>
+                <p>The amount of gain reduction to apply to the input signal when the Gate is fully closed.</p>
             </item>
             <item>
                 <title>

--- a/include/gate.hpp
+++ b/include/gate.hpp
@@ -44,8 +44,12 @@ class Gate : public PluginBase {
 
   void update_probe_links() override;
 
-  sigc::signal<void(const float)> reduction, sidechain, curve, envelope, latency;
+  sigc::signal<void(const float)> zone_start, hysteresis_threshold_start, hysteresis_zone_start, reduction, sidechain,
+      curve, envelope, latency;
 
+  float zone_start_port_value = 0.0F;
+  float hysteresis_threshold_start_port_value = 0.0F;
+  float hysteresis_zone_start_port_value = 0.0F;
   float reduction_port_value = 0.0F;
   float sidechain_port_value = 0.0F;
   float curve_port_value = 0.0F;

--- a/include/gate.hpp
+++ b/include/gate.hpp
@@ -44,12 +44,13 @@ class Gate : public PluginBase {
 
   void update_probe_links() override;
 
-  sigc::signal<void(const float)> zone_start, hysteresis_threshold_start, hysteresis_zone_start, reduction, sidechain,
-      curve, envelope, latency;
+  sigc::signal<void(const float)> attack_zone_start, attack_threshold, release_zone_start, release_threshold, reduction,
+      sidechain, curve, envelope, latency;
 
-  float zone_start_port_value = 0.0F;
-  float hysteresis_threshold_start_port_value = 0.0F;
-  float hysteresis_zone_start_port_value = 0.0F;
+  float attack_zone_start_port_value = 0.0F;
+  float attack_threshold_port_value = 0.0F;
+  float release_zone_start_port_value = 0.0F;
+  float release_threshold_port_value = 0.0F;
   float reduction_port_value = 0.0F;
   float sidechain_port_value = 0.0F;
   float curve_port_value = 0.0F;

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -181,17 +181,19 @@ void Gate::process(std::span<float>& left_in,
     notification_dt += buffer_duration;
 
     if (notification_dt >= notification_time_window) {
-      zone_start_port_value = lv2_wrapper->get_control_port_value("gzs");
-      hysteresis_threshold_start_port_value = lv2_wrapper->get_control_port_value("hts");
-      hysteresis_zone_start_port_value = lv2_wrapper->get_control_port_value("hzs");
+      attack_zone_start_port_value = lv2_wrapper->get_control_port_value("gzs");
+      attack_threshold_port_value = lv2_wrapper->get_control_port_value("gt");
+      release_zone_start_port_value = lv2_wrapper->get_control_port_value("hts");
+      release_threshold_port_value = lv2_wrapper->get_control_port_value("hzs");
       reduction_port_value = lv2_wrapper->get_control_port_value("rlm");
       sidechain_port_value = lv2_wrapper->get_control_port_value("slm");
       curve_port_value = lv2_wrapper->get_control_port_value("clm");
       envelope_port_value = lv2_wrapper->get_control_port_value("elm");
 
-      zone_start.emit(zone_start_port_value);
-      hysteresis_threshold_start.emit(hysteresis_threshold_start_port_value);
-      hysteresis_zone_start.emit(hysteresis_zone_start_port_value);
+      attack_zone_start.emit(attack_zone_start_port_value);
+      attack_threshold.emit(attack_threshold_port_value);
+      release_zone_start.emit(release_zone_start_port_value);
+      release_threshold.emit(release_threshold_port_value);
       reduction.emit(reduction_port_value);
       sidechain.emit(sidechain_port_value);
       curve.emit(curve_port_value);

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -181,11 +181,17 @@ void Gate::process(std::span<float>& left_in,
     notification_dt += buffer_duration;
 
     if (notification_dt >= notification_time_window) {
+      zone_start_port_value = lv2_wrapper->get_control_port_value("gzs");
+      hysteresis_threshold_start_port_value = lv2_wrapper->get_control_port_value("hts");
+      hysteresis_zone_start_port_value = lv2_wrapper->get_control_port_value("hzs");
       reduction_port_value = lv2_wrapper->get_control_port_value("rlm");
       sidechain_port_value = lv2_wrapper->get_control_port_value("slm");
       curve_port_value = lv2_wrapper->get_control_port_value("clm");
       envelope_port_value = lv2_wrapper->get_control_port_value("elm");
 
+      zone_start.emit(zone_start_port_value);
+      hysteresis_threshold_start.emit(hysteresis_threshold_start_port_value);
+      hysteresis_zone_start.emit(hysteresis_zone_start_port_value);
       reduction.emit(reduction_port_value);
       sidechain.emit(sidechain_port_value);
       curve.emit(curve_port_value);

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -43,7 +43,7 @@ struct _GateBox {
 
   GtkLabel *input_level_left_label, *input_level_right_label, *output_level_left_label, *output_level_right_label;
 
-  GtkLabel *zone_start_label, *hysteresis_threshold_start_label, *hysteresis_zone_start_label;
+  GtkLabel *attack_zone_start_label, *attack_threshold_label, *release_zone_start_label, *release_threshold_label;
 
   GtkLabel *gain_label, *sidechain_label, *curve_label, *envelope_label;
 
@@ -151,46 +151,59 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
     });
   }));
 
-  self->data->connections.push_back(gate->zone_start.connect([=](const double& value) {
+  self->data->connections.push_back(gate->attack_zone_start.connect([=](const double& value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
       }
 
-      if (!GTK_IS_LABEL(self->zone_start_label)) {
+      if (!GTK_IS_LABEL(self->attack_zone_start_label)) {
         return;
       }
 
-      gtk_label_set_text(self->zone_start_label, fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
+      gtk_label_set_text(self->attack_zone_start_label, fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
     });
   }));
 
-  self->data->connections.push_back(gate->hysteresis_threshold_start.connect([=](const double& value) {
+  self->data->connections.push_back(gate->attack_threshold.connect([=](const double& value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
       }
 
-      if (!GTK_IS_LABEL(self->hysteresis_threshold_start_label)) {
+      if (!GTK_IS_LABEL(self->attack_threshold_label)) {
         return;
       }
 
-      gtk_label_set_text(self->hysteresis_threshold_start_label,
-                         fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
+      gtk_label_set_text(self->attack_threshold_label, fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
     });
   }));
 
-  self->data->connections.push_back(gate->hysteresis_zone_start.connect([=](const double& value) {
+  self->data->connections.push_back(gate->release_zone_start.connect([=](const double& value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
       }
 
-      if (!GTK_IS_LABEL(self->hysteresis_zone_start_label)) {
+      if (!GTK_IS_LABEL(self->release_zone_start_label)) {
         return;
       }
 
-      gtk_label_set_text(self->hysteresis_zone_start_label, fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
+      gtk_label_set_text(self->release_zone_start_label, fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
+    });
+  }));
+
+  self->data->connections.push_back(gate->release_threshold.connect([=](const double& value) {
+    util::idle_add([=]() {
+      if (get_ignore_filter_idle_add(serial)) {
+        return;
+      }
+
+      if (!GTK_IS_LABEL(self->release_threshold_label)) {
+        return;
+      }
+
+      gtk_label_set_text(self->release_threshold_label, fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
     });
   }));
 
@@ -399,9 +412,10 @@ void gate_box_class_init(GateBoxClass* klass) {
   gtk_widget_class_bind_template_child(widget_class, GateBox, output_level_left_label);
   gtk_widget_class_bind_template_child(widget_class, GateBox, output_level_right_label);
 
-  gtk_widget_class_bind_template_child(widget_class, GateBox, zone_start_label);
-  gtk_widget_class_bind_template_child(widget_class, GateBox, hysteresis_threshold_start_label);
-  gtk_widget_class_bind_template_child(widget_class, GateBox, hysteresis_zone_start_label);
+  gtk_widget_class_bind_template_child(widget_class, GateBox, attack_zone_start_label);
+  gtk_widget_class_bind_template_child(widget_class, GateBox, attack_threshold_label);
+  gtk_widget_class_bind_template_child(widget_class, GateBox, release_zone_start_label);
+  gtk_widget_class_bind_template_child(widget_class, GateBox, release_threshold_label);
   gtk_widget_class_bind_template_child(widget_class, GateBox, gain_label);
   gtk_widget_class_bind_template_child(widget_class, GateBox, sidechain_label);
   gtk_widget_class_bind_template_child(widget_class, GateBox, curve_label);

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -161,7 +161,7 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
         return;
       }
 
-      gtk_label_set_text(self->attack_zone_start_label, fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
+      gtk_label_set_text(self->attack_zone_start_label, fmt::format("{0:.1f}", util::linear_to_db(value)).c_str());
     });
   }));
 
@@ -175,7 +175,7 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
         return;
       }
 
-      gtk_label_set_text(self->attack_threshold_label, fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
+      gtk_label_set_text(self->attack_threshold_label, fmt::format("{0:.1f}", util::linear_to_db(value)).c_str());
     });
   }));
 
@@ -189,7 +189,7 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
         return;
       }
 
-      gtk_label_set_text(self->release_zone_start_label, fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
+      gtk_label_set_text(self->release_zone_start_label, fmt::format("{0:.1f}", util::linear_to_db(value)).c_str());
     });
   }));
 
@@ -203,7 +203,7 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
         return;
       }
 
-      gtk_label_set_text(self->release_threshold_label, fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
+      gtk_label_set_text(self->release_threshold_label, fmt::format("{0:.1f}", util::linear_to_db(value)).c_str());
     });
   }));
 

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -43,6 +43,8 @@ struct _GateBox {
 
   GtkLabel *input_level_left_label, *input_level_right_label, *output_level_left_label, *output_level_right_label;
 
+  GtkLabel *zone_start_label, *hysteresis_threshold_start_label, *hysteresis_zone_start_label;
+
   GtkLabel *gain_label, *sidechain_label, *curve_label, *envelope_label;
 
   GtkToggleButton* hysteresis;
@@ -146,6 +148,49 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
 
       update_level(self->output_level_left, self->output_level_left_label, self->output_level_right,
                    self->output_level_right_label, left, right);
+    });
+  }));
+
+  self->data->connections.push_back(gate->zone_start.connect([=](const double& value) {
+    util::idle_add([=]() {
+      if (get_ignore_filter_idle_add(serial)) {
+        return;
+      }
+
+      if (!GTK_IS_LABEL(self->zone_start_label)) {
+        return;
+      }
+
+      gtk_label_set_text(self->zone_start_label, fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
+    });
+  }));
+
+  self->data->connections.push_back(gate->hysteresis_threshold_start.connect([=](const double& value) {
+    util::idle_add([=]() {
+      if (get_ignore_filter_idle_add(serial)) {
+        return;
+      }
+
+      if (!GTK_IS_LABEL(self->hysteresis_threshold_start_label)) {
+        return;
+      }
+
+      gtk_label_set_text(self->hysteresis_threshold_start_label,
+                         fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
+    });
+  }));
+
+  self->data->connections.push_back(gate->hysteresis_zone_start.connect([=](const double& value) {
+    util::idle_add([=]() {
+      if (get_ignore_filter_idle_add(serial)) {
+        return;
+      }
+
+      if (!GTK_IS_LABEL(self->hysteresis_zone_start_label)) {
+        return;
+      }
+
+      gtk_label_set_text(self->hysteresis_zone_start_label, fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
     });
   }));
 
@@ -354,6 +399,9 @@ void gate_box_class_init(GateBoxClass* klass) {
   gtk_widget_class_bind_template_child(widget_class, GateBox, output_level_left_label);
   gtk_widget_class_bind_template_child(widget_class, GateBox, output_level_right_label);
 
+  gtk_widget_class_bind_template_child(widget_class, GateBox, zone_start_label);
+  gtk_widget_class_bind_template_child(widget_class, GateBox, hysteresis_threshold_start_label);
+  gtk_widget_class_bind_template_child(widget_class, GateBox, hysteresis_zone_start_label);
   gtk_widget_class_bind_template_child(widget_class, GateBox, gain_label);
   gtk_widget_class_bind_template_child(widget_class, GateBox, sidechain_label);
   gtk_widget_class_bind_template_child(widget_class, GateBox, curve_label);


### PR DESCRIPTION
I believe, exposing these labels leads to more understandable UI.
* `Attack Zone Start` (which is `Curve Threshold` + `Curve Zone`)
  The Gate begins to open when the `Sidechain` level becomes above the `Attack Zone Start` level.
* `Attack Threshold` (which is just `Curve Threshold`)
  The Gate fully opens when the `Sidechain` level becomes above the `Attack Threshold` level.
* `Release Zone Start` (which is either just `Curve Threshold` or `Curve Threshold` + `Hysteresis Threshold`)
  The Gate begins to close when the `Sidechain` level becomes below the `Release Zone Start` level.
* `Release Threshold` (which is either `Curve Threshold` + `Curve Zone`, or  `Curve Threshold` + `Hysteresis Threshold` + `Hysteresis Zone`)
  The Gate fully closes when the `Sidechain` level becomes below the `Release Threshold` level.

https://github.com/lsp-plugins/lsp-plugins-gate/blob/d4b1df23d5b49bb7272f9eb5cd1122ff1cf23d78/src/main/meta/gate.cpp#L134-L136

![image](https://user-images.githubusercontent.com/88600/177388138-124e9381-cf9a-4b70-bea1-5bd6bc14d931.png)
