### PR TITLE
Various fixes

### DIFF
--- a/data/ui/gate.ui
+++ b/data/ui/gate.ui
@@ -53,7 +53,7 @@
                                                 <property name="margin-end">6</property>
                                                 <property name="orientation">vertical</property>
                                                 <property name="digits">2</property>
-                                                <property name="width-chars">10</property>
+                                                <property name="width-chars">11</property>
                                                 <property name="update-policy">if-valid</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
@@ -89,7 +89,7 @@
                                                 <property name="margin-end">6</property>
                                                 <property name="orientation">vertical</property>
                                                 <property name="digits">2</property>
-                                                <property name="width-chars">10</property>
+                                                <property name="width-chars">11</property>
                                                 <property name="update-policy">if-valid</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -215,7 +215,7 @@ auto parse_apo_quality(const std::string& line, struct APO_Band& filter) -> bool
 }
 
 auto parse_apo_config_line(const std::string& line, struct APO_Band& filter) -> bool {
-  std::string filter_type = parse_apo_filter(line, filter);
+  auto filter_type = parse_apo_filter(line, filter);
 
   if (filter_type.empty()) {
     return false;


### PR DESCRIPTION
Just as I made for https://github.com/wwmm/easyeffects/commit/c88db8f016a3cb3443a51116d11c69330ac86425

Have more space for some locales to show the text properly:

![Schermata del 2022-07-05 22-41-35](https://user-images.githubusercontent.com/25790525/177417195-92f60d6b-b1b2-41f9-8f9f-bb04c71e4a03.png)
