### PR TITLE
Improve Gate UI and implement Toast for Equalizer UI

### DIFF
--- a/data/ui/equalizer.ui
+++ b/data/ui/equalizer.ui
@@ -5,377 +5,392 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
         <child>
-            <object class="GtkBox">
-                <property name="spacing">12</property>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
+                    </object>
+                </child>
+
                 <child>
                     <object class="GtkBox">
-                        <property name="spacing">6</property>
-                        <property name="hexpand">1</property>
+                        <property name="spacing">12</property>
                         <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkStackSwitcher" id="stack_switcher">
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                                <property name="stack">stack</property>
-                                <property name="visible" bind-source="split_channels" bind-property="active" bind-flags="sync-create" />
+                            <object class="GtkBox">
+                                <property name="spacing">12</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="spacing">6</property>
+                                        <property name="hexpand">1</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkStackSwitcher" id="stack_switcher">
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="stack">stack</property>
+                                                <property name="visible" bind-source="split_channels" bind-property="active" bind-flags="sync-create" />
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkScrolledWindow">
+                                                <child>
+                                                    <object class="GtkStack" id="stack">
+                                                        <property name="halign">center</property>
+                                                        <property name="transition-duration">250</property>
+                                                        <property name="transition-type">slide-left-right</property>
+                                                        <child>
+                                                            <object class="GtkStackPage">
+                                                                <property name="name">page_left_channel</property>
+                                                                <property name="title" translatable="yes">Left</property>
+                                                                <property name="child">
+                                                                    <object class="GtkBox" id="bands_box_left">
+                                                                        <property name="spacing">6</property>
+                                                                    </object>
+                                                                </property>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkStackPage">
+                                                                <property name="name">page_right_channel</property>
+                                                                <property name="title" translatable="yes">Right</property>
+                                                                <property name="child">
+                                                                    <object class="GtkBox" id="bands_box_right">
+                                                                        <property name="spacing">6</property>
+                                                                    </object>
+                                                                </property>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="spacing">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="valign">center</property>
+                                        <child>
+                                            <object class="GtkGrid">
+                                                <property name="row-spacing">6</property>
+                                                <property name="column-spacing">6</property>
+                                                <property name="hexpand">0</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="nbands_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="label" translatable="yes">Bands</property>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkSpinButton" id="nbands">
+                                                        <property name="hexpand">1</property>
+                                                        <property name="digits">0</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">1</property>
+                                                                <property name="upper">32</property>
+                                                                <property name="value">32</property>
+                                                                <property name="step-increment">1</property>
+                                                                <property name="page-increment">3</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">nbands_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="mode_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="label" translatable="yes">Mode</property>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkComboBoxText" id="mode">
+                                                        <property name="hexpand">1</property>
+                                                        <items>
+                                                            <item translatable="yes" id="IIR">IIR</item>
+                                                            <item translatable="yes" id="FIR">FIR</item>
+                                                            <item translatable="yes" id="FFT">FFT</item>
+                                                            <item translatable="yes" id="SPM">SPM</item>
+                                                        </items>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">mode_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkToggleButton" id="split_channels">
+                                                <property name="valign">center</property>
+                                                <property name="label" translatable="yes">Split Channels</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkButton" id="flat_response">
+                                                <property name="label" translatable="yes">Flat Response</property>
+                                                <property name="valign">center</property>
+                                                <signal name="clicked" handler="on_flat_response" object="EqualizerBox" />
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkButton" id="calculate_freqs">
+                                                <property name="label" translatable="yes">Calculate Frequencies</property>
+                                                <property name="valign">center</property>
+                                                <signal name="clicked" handler="on_calculate_frequencies" object="EqualizerBox" />
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkButton" id="import_apo">
+                                                <property name="label" translatable="yes">Load APO Preset</property>
+                                                <property name="valign">center</property>
+                                                <signal name="clicked" handler="on_import_apo_preset_clicked" object="EqualizerBox" />
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
                             </object>
                         </child>
 
                         <child>
-                            <object class="GtkScrolledWindow">
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
                                 <child>
-                                    <object class="GtkStack" id="stack">
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
+                                </property>
+
+                                <child>
+                                    <object class="GtkButton" id="reset_button">
                                         <property name="halign">center</property>
-                                        <property name="transition-duration">250</property>
-                                        <property name="transition-type">slide-left-right</property>
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="EqualizerBox" />
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">end</property>
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
                                         <child>
-                                            <object class="GtkStackPage">
-                                                <property name="name">page_left_channel</property>
-                                                <property name="title" translatable="yes">Left</property>
-                                                <property name="child">
-                                                    <object class="GtkBox" id="bands_box_left">
-                                                        <property name="spacing">6</property>
-                                                    </object>
-                                                </property>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
                                             </object>
                                         </child>
-
                                         <child>
-                                            <object class="GtkStackPage">
-                                                <property name="name">page_right_channel</property>
-                                                <property name="title" translatable="yes">Right</property>
-                                                <property name="child">
-                                                    <object class="GtkBox" id="bands_box_right">
-                                                        <property name="spacing">6</property>
-                                                    </object>
-                                                </property>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Linux Studio Plugins</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
                                             </object>
                                         </child>
                                     </object>
                                 </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="spacing">6</property>
-                        <property name="orientation">vertical</property>
-                        <property name="valign">center</property>
-                        <child>
-                            <object class="GtkGrid">
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">6</property>
-                                <property name="hexpand">0</property>
-                                <child>
-                                    <object class="GtkLabel" id="nbands_label">
-                                        <property name="halign">end</property>
-                                        <property name="label" translatable="yes">Bands</property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkSpinButton" id="nbands">
-                                        <property name="hexpand">1</property>
-                                        <property name="digits">0</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">1</property>
-                                                <property name="upper">32</property>
-                                                <property name="value">32</property>
-                                                <property name="step-increment">1</property>
-                                                <property name="page-increment">3</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">nbands_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel" id="mode_label">
-                                        <property name="halign">end</property>
-                                        <property name="label" translatable="yes">Mode</property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkComboBoxText" id="mode">
-                                        <property name="hexpand">1</property>
-                                        <items>
-                                            <item translatable="yes" id="IIR">IIR</item>
-                                            <item translatable="yes" id="FIR">FIR</item>
-                                            <item translatable="yes" id="FFT">FFT</item>
-                                            <item translatable="yes" id="SPM">SPM</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">mode_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkToggleButton" id="split_channels">
-                                <property name="valign">center</property>
-                                <property name="label" translatable="yes">Split Channels</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkButton" id="flat_response">
-                                <property name="label" translatable="yes">Flat Response</property>
-                                <property name="valign">center</property>
-                                <signal name="clicked" handler="on_flat_response" object="EqualizerBox" />
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkButton" id="calculate_freqs">
-                                <property name="label" translatable="yes">Calculate Frequencies</property>
-                                <property name="valign">center</property>
-                                <signal name="clicked" handler="on_calculate_frequencies" object="EqualizerBox" />
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkButton" id="import_apo">
-                                <property name="label" translatable="yes">Load APO Preset</property>
-                                <property name="valign">center</property>
-                                <signal name="clicked" handler="on_import_apo_preset_clicked" object="EqualizerBox" />
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
-                                <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="output_gain">
-                                <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="EqualizerBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">Linux Studio Plugins</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/gate.ui
+++ b/data/ui/gate.ui
@@ -1229,6 +1229,36 @@
             <object class="GtkBox">
                 <property name="hexpand">1</property>
                 <property name="vexpand">0</property>
+                <property name="spacing">6</property>
+                <child>
+                    <object class="GtkLabel" id="gating_title">
+                        <property name="halign">end</property>
+                        <property name="xalign">1</property>
+                        <property name="label" translatable="yes">Gating</property>
+                    </object>
+                </child>
+
+                <child>
+                    <object class="GtkLevelBar" id="gating">
+                        <property name="valign">center</property>
+                        <property name="hexpand">1</property>
+                    </object>
+                </child>
+
+                <child>
+                    <object class="GtkLabel" id="gating_label">
+                        <property name="halign">end</property>
+                        <property name="width-chars">4</property>
+                        <property name="label">0</property>
+                    </object>
+                </child>
+            </object>
+        </child>
+
+        <child>
+            <object class="GtkBox">
+                <property name="hexpand">1</property>
+                <property name="vexpand">0</property>
                 <property name="layout-manager">
                     <object class="GtkBinLayout"></object>
                 </property>
@@ -1279,6 +1309,7 @@
             <widget name="sidechain_title" />
             <widget name="gain_title" />
             <widget name="envelope_title" />
+            <widget name="gating_title" />
         </widgets>
     </object>
 

--- a/data/ui/gate.ui
+++ b/data/ui/gate.ui
@@ -36,8 +36,7 @@
                                 <child>
                                     <object class="GtkGrid">
                                         <property name="halign">center</property>
-                                        <property name="row-spacing">6</property>
-                                        <property name="column-spacing">12</property>
+                                        <property name="column-spacing">18</property>
 
                                         <child>
                                             <object class="GtkLabel" id="attack_time_label">
@@ -50,7 +49,7 @@
                                         </child>
                                         <child>
                                             <object class="GtkSpinButton" id="attack">
-                                                <property name="margin-end">6</property>
+                                                <property name="margin-top">4</property>
                                                 <property name="orientation">vertical</property>
                                                 <property name="digits">2</property>
                                                 <property name="width-chars">11</property>
@@ -85,8 +84,7 @@
                                         </child>
                                         <child>
                                             <object class="GtkSpinButton" id="release">
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">6</property>
+                                                <property name="margin-top">4</property>
                                                 <property name="orientation">vertical</property>
                                                 <property name="digits">2</property>
                                                 <property name="width-chars">11</property>
@@ -122,74 +120,85 @@
                                         </child>
 
                                         <child>
-                                            <object class="GtkLabel" id="curve_threshold_label">
-                                                <property name="label" translatable="yes">Threshold</property>
+                                            <object class="GtkBox">
+                                                <property name="halign">fill</property>
+                                                <property name="homogeneous">1</property>
+                                                <property name="margin-bottom">6</property>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="curve_threshold_label">
+                                                        <property name="label" translatable="yes">Threshold</property>
+
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="curve_zone_label">
+                                                        <property name="label" translatable="yes">Zone</property>
+                                                    </object>
+                                                </child>
+
                                                 <layout>
                                                     <property name="column">2</property>
                                                     <property name="row">1</property>
+                                                    <property name="column-span">2</property>
                                                 </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="curve_threshold">
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">3</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="digits">1</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">-60</property>
-                                                        <property name="upper">0</property>
-                                                        <property name="value">-24</property>
-                                                        <property name="step-increment">0.1</property>
-                                                        <property name="page-increment">1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">2</property>
-                                                    <property name="row">2</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">curve_threshold_label</relation>
-                                                </accessibility>
                                             </object>
                                         </child>
 
                                         <child>
-                                            <object class="GtkLabel" id="curve_zone_label">
-                                                <property name="label" translatable="yes">Zone</property>
-                                                <layout>
-                                                    <property name="column">3</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="curve_zone">
-                                                <property name="margin-start">3</property>
-                                                <property name="margin-end">6</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="digits">1</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">-60</property>
-                                                        <property name="upper">0</property>
-                                                        <property name="value">-6</property>
-                                                        <property name="step-increment">0.1</property>
-                                                        <property name="page-increment">1</property>
+                                            <object class="GtkBox">
+                                                <property name="margin-top">4</property>
+                                                <property name="halign">center</property>
+                                                <style>
+                                                    <class name="linked" />
+                                                </style>
+
+                                                <child>
+                                                    <object class="GtkSpinButton" id="curve_threshold">
+                                                        <property name="orientation">vertical</property>
+                                                        <property name="digits">1</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">-60</property>
+                                                                <property name="upper">0</property>
+                                                                <property name="value">-24</property>
+                                                                <property name="step-increment">0.1</property>
+                                                                <property name="page-increment">1</property>
+                                                            </object>
+                                                        </property>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">curve_threshold_label</relation>
+                                                        </accessibility>
                                                     </object>
-                                                </property>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkSpinButton" id="curve_zone">
+                                                        <property name="orientation">vertical</property>
+                                                        <property name="digits">1</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">-60</property>
+                                                                <property name="upper">0</property>
+                                                                <property name="value">-6</property>
+                                                                <property name="step-increment">0.1</property>
+                                                                <property name="page-increment">1</property>
+                                                            </object>
+                                                        </property>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">curve_zone_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
                                                 <layout>
-                                                    <property name="column">3</property>
+                                                    <property name="column">2</property>
                                                     <property name="row">2</property>
+                                                    <property name="column-span">2</property>
                                                 </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">curve_zone_label</relation>
-                                                </accessibility>
                                             </object>
                                         </child>
 
@@ -207,76 +216,85 @@
                                         </child>
 
                                         <child>
-                                            <object class="GtkLabel" id="hysteresis_threshold_label">
-                                                <property name="label" translatable="yes">Threshold</property>
+                                            <object class="GtkBox">
+                                                <property name="halign">fill</property>
+                                                <property name="homogeneous">1</property>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="hysteresis_threshold_label">
+                                                        <property name="label" translatable="yes">Threshold</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="hysteresis_zone_label">
+                                                        <property name="label" translatable="yes">Zone</property>
+                                                    </object>
+                                                </child>
+
                                                 <layout>
                                                     <property name="column">4</property>
                                                     <property name="row">1</property>
+                                                    <property name="column-span">2</property>
                                                 </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="hysteresis_threshold">
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">3</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="digits">1</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="sensitive" bind-source="hysteresis" bind-property="active" bind-flags="sync-create" />
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">-60</property>
-                                                        <property name="upper">0</property>
-                                                        <property name="value">-12</property>
-                                                        <property name="step-increment">0.1</property>
-                                                        <property name="page-increment">1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">4</property>
-                                                    <property name="row">2</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">hysteresis_threshold_label</relation>
-                                                </accessibility>
                                             </object>
                                         </child>
 
                                         <child>
-                                            <object class="GtkLabel" id="hysteresis_zone_label">
-                                                <property name="label" translatable="yes">Zone</property>
-                                                <layout>
-                                                    <property name="column">5</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="hysteresis_zone">
-                                                <property name="margin-start">3</property>
-                                                <property name="margin-end">6</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="digits">1</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="sensitive" bind-source="hysteresis" bind-property="active" bind-flags="sync-create" />
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">-60</property>
-                                                        <property name="upper">0</property>
-                                                        <property name="value">-6</property>
-                                                        <property name="step-increment">0.1</property>
-                                                        <property name="page-increment">1</property>
+                                            <object class="GtkBox">
+                                                <property name="margin-top">4</property>
+                                                <property name="halign">center</property>
+                                                <style>
+                                                    <class name="linked" />
+                                                </style>
+
+                                                <child>
+                                                    <object class="GtkSpinButton" id="hysteresis_threshold">
+                                                        <property name="orientation">vertical</property>
+                                                        <property name="digits">1</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="sensitive" bind-source="hysteresis" bind-property="active" bind-flags="sync-create" />
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">-60</property>
+                                                                <property name="upper">0</property>
+                                                                <property name="value">-12</property>
+                                                                <property name="step-increment">0.1</property>
+                                                                <property name="page-increment">1</property>
+                                                            </object>
+                                                        </property>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">hysteresis_threshold_label</relation>
+                                                        </accessibility>
                                                     </object>
-                                                </property>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkSpinButton" id="hysteresis_zone">
+                                                        <property name="orientation">vertical</property>
+                                                        <property name="digits">1</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="sensitive" bind-source="hysteresis" bind-property="active" bind-flags="sync-create" />
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">-60</property>
+                                                                <property name="upper">0</property>
+                                                                <property name="value">-6</property>
+                                                                <property name="step-increment">0.1</property>
+                                                                <property name="page-increment">1</property>
+                                                            </object>
+                                                        </property>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">hysteresis_zone_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
                                                 <layout>
-                                                    <property name="column">5</property>
+                                                    <property name="column">4</property>
                                                     <property name="row">2</property>
+                                                    <property name="column-span">2</property>
                                                 </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">hysteresis_zone_label</relation>
-                                                </accessibility>
                                             </object>
                                         </child>
 
@@ -291,8 +309,7 @@
                                         </child>
                                         <child>
                                             <object class="GtkSpinButton" id="reduction">
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">6</property>
+                                                <property name="margin-top">4</property>
                                                 <property name="orientation">vertical</property>
                                                 <property name="width-chars">10</property>
                                                 <property name="digits">1</property>
@@ -328,8 +345,7 @@
                                         </child>
                                         <child>
                                             <object class="GtkSpinButton" id="makeup">
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">6</property>
+                                                <property name="margin-top">4</property>
                                                 <property name="orientation">vertical</property>
                                                 <property name="width-chars">10</property>
                                                 <property name="digits">1</property>

--- a/include/gate.hpp
+++ b/include/gate.hpp
@@ -45,7 +45,7 @@ class Gate : public PluginBase {
   void update_probe_links() override;
 
   sigc::signal<void(const float)> attack_zone_start, attack_threshold, release_zone_start, release_threshold, reduction,
-      sidechain, curve, envelope, latency;
+      sidechain, curve, envelope, gating, latency;
 
   float attack_zone_start_port_value = 0.0F;
   float attack_threshold_port_value = 0.0F;
@@ -55,6 +55,7 @@ class Gate : public PluginBase {
   float sidechain_port_value = 0.0F;
   float curve_port_value = 0.0F;
   float envelope_port_value = 0.0F;
+  float gating_port_value = 0.0F;
   float latency_port_value = 0.0F;
 
  private:

--- a/include/ui_helpers.hpp
+++ b/include/ui_helpers.hpp
@@ -33,6 +33,10 @@
 
 namespace ui {
 
+void show_fixed_toast(AdwToastOverlay* toast_overlay,
+                      const std::string& text,
+                      const AdwToastPriority& priority = ADW_TOAST_PRIORITY_HIGH);
+
 auto parse_spinbutton_output(GtkSpinButton* button, const char* unit) -> bool;
 
 auto parse_spinbutton_input(GtkSpinButton* button, double* new_value) -> int;

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -46,6 +46,8 @@ void critical(const std::string& s, std::source_location location = std::source_
 void warning(const std::string& s, std::source_location location = std::source_location::current());
 void info(const std::string& s, std::source_location location = std::source_location::current());
 
+auto normalize(const float& x, const float& min, const float& max) -> float;
+
 auto logspace(const float& start, const float& stop, const uint& npoints) -> std::vector<float>;
 auto linspace(const float& start, const float& stop, const uint& npoints) -> std::vector<float>;
 

--- a/src/application_ui.cpp
+++ b/src/application_ui.cpp
@@ -99,9 +99,12 @@ void setup_simple_message_dialog(GtkWidget* parent, const std::string& title, co
   // Modal flag prevents interaction with other windows in the same application
   auto* dialog = gtk_message_dialog_new(GTK_WINDOW(parent),
                                         static_cast<GtkDialogFlags>(GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL),
-                                        GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, "%s", title.c_str());
+                                        GTK_MESSAGE_ERROR, GTK_BUTTONS_NONE, "%s", title.c_str());
 
   gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", descr.c_str());
+
+  // Add custom button to hint the user to press ESC to destroy the dialog
+  gtk_dialog_add_button(GTK_DIALOG(dialog), _("Close (Press ESC)"), 0);
 
   // Destroy the dialog when the user responds to it
   g_signal_connect(dialog, "response", G_CALLBACK(gtk_window_destroy), NULL);

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -190,6 +190,12 @@ void Gate::process(std::span<float>& left_in,
       curve_port_value = lv2_wrapper->get_control_port_value("clm");
       envelope_port_value = lv2_wrapper->get_control_port_value("elm");
 
+      // Normalize the current gain reduction amount as a percentage,
+      // where 0% is no gating, and 100% is a fully closed gate.
+      const float max_reduction_port_value = lv2_wrapper->get_control_port_value("gr");
+      const float no_reduction = 1.0F;  // aka, db_to_linear(0 /*dB*/);
+      gating_port_value = 1.0F - util::normalize(reduction_port_value, max_reduction_port_value, no_reduction);
+
       attack_zone_start.emit(attack_zone_start_port_value);
       attack_threshold.emit(attack_threshold_port_value);
       release_zone_start.emit(release_zone_start_port_value);
@@ -198,6 +204,7 @@ void Gate::process(std::span<float>& left_in,
       sidechain.emit(sidechain_port_value);
       curve.emit(curve_port_value);
       envelope.emit(envelope_port_value);
+      gating.emit(gating_port_value);
 
       notify();
 

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -47,6 +47,10 @@ struct _GateBox {
 
   GtkLabel *gain_label, *sidechain_label, *curve_label, *envelope_label;
 
+  GtkLevelBar* gating;
+
+  GtkLabel* gating_label;
+
   GtkToggleButton* hysteresis;
 
   GtkSpinButton *attack, *release, *curve_threshold, *curve_zone, *hysteresis_threshold, *hysteresis_zone, *reduction,
@@ -213,11 +217,26 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
         return;
       }
 
-      if (!GTK_IS_LABEL(self->gain_label)) {
+      if (!GTK_IS_LABEL(self->gain_label) || !GTK_IS_LABEL(self->gating_label)) {
         return;
       }
 
+      gtk_label_set_text(self->gating_label, fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
       gtk_label_set_text(self->gain_label, fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
+    });
+  }));
+
+  self->data->connections.push_back(gate->gating.connect([=](const double& value) {
+    util::idle_add([=]() {
+      if (get_ignore_filter_idle_add(serial)) {
+        return;
+      }
+
+      if (!GTK_IS_LEVEL_BAR(self->gating)) {
+        return;
+      }
+
+      gtk_level_bar_set_value(self->gating, value);
     });
   }));
 
@@ -411,6 +430,8 @@ void gate_box_class_init(GateBoxClass* klass) {
   gtk_widget_class_bind_template_child(widget_class, GateBox, input_level_right_label);
   gtk_widget_class_bind_template_child(widget_class, GateBox, output_level_left_label);
   gtk_widget_class_bind_template_child(widget_class, GateBox, output_level_right_label);
+  gtk_widget_class_bind_template_child(widget_class, GateBox, gating);
+  gtk_widget_class_bind_template_child(widget_class, GateBox, gating_label);
 
   gtk_widget_class_bind_template_child(widget_class, GateBox, attack_zone_start_label);
   gtk_widget_class_bind_template_child(widget_class, GateBox, attack_threshold_label);

--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -14,6 +14,19 @@ namespace ui {
 
 using namespace std::string_literals;
 
+void show_fixed_toast(AdwToastOverlay* toast_overlay, const std::string& text, const AdwToastPriority& priority) {
+  // This helper is for showing fixed toasts which the user has to close them.
+  // For autohiding toasts we'll make another helper specifying the timeout as parameter.
+
+  auto* toast = adw_toast_new(text.c_str());
+
+  adw_toast_set_timeout(toast, 0U);
+
+  adw_toast_set_priority(toast, priority);
+
+  adw_toast_overlay_add_toast(toast_overlay, toast);
+}
+
 auto parse_spinbutton_output(GtkSpinButton* button, const char* unit) -> bool {
   auto* adjustment = gtk_spin_button_get_adjustment(button);
   auto value = gtk_adjustment_get_value(adjustment);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -53,6 +53,10 @@ void print_thread_id() {
   std::cout << "thread id: " << std::this_thread::get_id() << std::endl;
 }
 
+auto normalize(const float& x, const float& min, const float& max) -> float {
+  return (x - min) / (max - min);
+}
+
 auto logspace(const float& start, const float& stop, const uint& npoints) -> std::vector<float> {
   std::vector<float> output;
 


### PR DESCRIPTION
- Added workaround for preset error message dialogs #1616
- Implemented a Toast for APO load error in Equalizer UI
- Improved Gate UI @LebedevRI Fixes #1633

As discussed in #1633 I like the spinbuttons with the same height in one row. But I didn't implement it here. @wwmm please decide which is the better thing to do. 

![Schermata del 2022-07-06 16-10-49](https://user-images.githubusercontent.com/25790525/177601437-37363a4b-6817-40ee-a9be-a38f22e21f8c.png)

As discussed in #1616 I tested AdwToast and finally found a way to show them properly. I put the constructor in the ui_helpers, so we don't have to rewrite the method to show them over and over inside every plugin ui. 

![image](https://user-images.githubusercontent.com/25790525/177602584-02319231-a476-4146-8df1-4b5753dc05bf.png)

It's good how it behave, but maybe it would be better if the background is full opaque? I don't know how to change it, and maybe other people like it this way. @wwmm let me know what do you think. 