### PR TITLE
Various UI fixes and improvements

### DIFF
--- a/data/ui/autogain.ui
+++ b/data/ui/autogain.ui
@@ -150,7 +150,7 @@
                 <child>
                     <object class="GtkLabel" id="m_label">
                         <property name="halign">end</property>
-                        <property name="width-chars">4</property>
+                        <property name="width-chars">6</property>
                         <property name="label">0</property>
                     </object>
                 </child>
@@ -180,7 +180,7 @@
                 <child>
                     <object class="GtkLabel" id="s_label">
                         <property name="halign">end</property>
-                        <property name="width-chars">4</property>
+                        <property name="width-chars">6</property>
                         <property name="label">0</property>
                     </object>
                 </child>
@@ -210,7 +210,7 @@
                 <child>
                     <object class="GtkLabel" id="i_label">
                         <property name="halign">end</property>
-                        <property name="width-chars">4</property>
+                        <property name="width-chars">6</property>
                         <property name="label">0</property>
                     </object>
                 </child>
@@ -240,7 +240,7 @@
                 <child>
                     <object class="GtkLabel" id="r_label">
                         <property name="halign">end</property>
-                        <property name="width-chars">4</property>
+                        <property name="width-chars">6</property>
                         <property name="label">0</property>
                     </object>
                 </child>
@@ -272,7 +272,7 @@
                 <child>
                     <object class="GtkLabel" id="lra_label">
                         <property name="halign">end</property>
-                        <property name="width-chars">4</property>
+                        <property name="width-chars">6</property>
                         <property name="label">0</property>
 
                     </object>
@@ -304,7 +304,7 @@
                 <child>
                     <object class="GtkLabel" id="l_label">
                         <property name="halign">end</property>
-                        <property name="width-chars">4</property>
+                        <property name="width-chars">6</property>
                         <property name="label">0</property>
                     </object>
                 </child>
@@ -336,7 +336,7 @@
                 <child>
                     <object class="GtkLabel" id="g_label">
                         <property name="halign">end</property>
-                        <property name="width-chars">4</property>
+                        <property name="width-chars">6</property>
                         <property name="label">0</property>
                     </object>
                 </child>
@@ -398,7 +398,7 @@
                                 <child>
                                     <object class="GtkLabel" id="input_level_left_label">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
+                                        <property name="width-chars">6</property>
                                         <property name="label">0</property>
                                     </object>
                                 </child>
@@ -416,7 +416,7 @@
                                 <child>
                                     <object class="GtkLabel" id="input_level_right_label">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
+                                        <property name="width-chars">6</property>
                                         <property name="label">0</property>
                                     </object>
                                 </child>
@@ -482,7 +482,7 @@
                                 <child>
                                     <object class="GtkLabel" id="output_level_left_label">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
+                                        <property name="width-chars">6</property>
                                         <property name="label">0</property>
                                     </object>
                                 </child>
@@ -500,7 +500,7 @@
                                 <child>
                                     <object class="GtkLabel" id="output_level_right_label">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
+                                        <property name="width-chars">6</property>
                                         <property name="label">0</property>
                                     </object>
                                 </child>

--- a/data/ui/convolver.ui
+++ b/data/ui/convolver.ui
@@ -10,9 +10,8 @@
 
         <child>
             <object class="GtkLabel" id="label_file_name">
-                <style>
-                    <class name="dim-label" />
-                </style>
+                <property name="wrap">1</property>
+                <property name="wrap-mode">word-char</property>
             </object>
         </child>
 

--- a/data/ui/convolver.ui
+++ b/data/ui/convolver.ui
@@ -72,7 +72,7 @@
 
                         <child>
                             <object class="GtkLabel" id="ir_width_label">
-                                <property name="margin-top">6</property>
+                                <property name="margin-top">12</property>
                                 <property name="label" translatable="yes">Stereo Width</property>
                             </object>
                         </child>
@@ -100,7 +100,6 @@
 
                         <child>
                             <object class="GtkToggleButton" id="show_fft">
-                                <property name="halign">center</property>
                                 <property name="valign">center</property>
                                 <property name="label" translatable="yes">Spectrum</property>
                                 <signal name="toggled" handler="on_show_fft" object="ConvolverBox" />
@@ -110,7 +109,6 @@
                         <child>
                             <object class="GtkToggleButton" id="enable_log_scale">
                                 <property name="halign">center</property>
-                                <property name="valign">center</property>
                                 <property name="label" translatable="yes">Log Scale</property>
                                 <property name="visible" bind-source="show_fft" bind-property="active" bind-flags="sync-create" />
                                 <signal name="toggled" handler="on_enable_log_scale" object="ConvolverBox" />
@@ -119,7 +117,7 @@
 
                         <child>
                             <object class="GtkToggleButton" id="autogain">
-                                <property name="halign">center</property>
+                                <property name="margin-top">12</property>
                                 <property name="valign">center</property>
                                 <property name="label" translatable="yes">Autogain</property>
                             </object>

--- a/data/ui/convolver.ui
+++ b/data/ui/convolver.ui
@@ -147,7 +147,6 @@
                 </child>
                 <child>
                     <object class="GtkLabel" id="label_sampling_rate">
-                        <property name="label">f</property>
                         <style>
                             <class name="dim-label" />
                         </style>
@@ -169,7 +168,6 @@
                 </child>
                 <child>
                     <object class="GtkLabel" id="label_samples">
-                        <property name="label">r</property>
                         <style>
                             <class name="dim-label" />
                         </style>
@@ -191,7 +189,6 @@
                 </child>
                 <child>
                     <object class="GtkLabel" id="label_duration">
-                        <property name="label">c</property>
                         <style>
                             <class name="dim-label" />
                         </style>

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -46,6 +46,8 @@ struct Data {
   std::vector<gulong> gconnections;
 
   std::vector<float> left_mag, right_mag, time_axis, left_spectrum, right_spectrum, freq_axis;
+
+  std::locale user_locale;
 };
 
 struct _ConvolverBox {
@@ -448,9 +450,14 @@ void get_irs_info(ConvolverBox* self) {
     gtk_widget_add_css_class(GTK_WIDGET(self->label_file_name), "dim-label");
     gtk_label_set_text(self->label_file_name, fpath.stem().c_str());
 
-    gtk_label_set_text(self->label_sampling_rate, fmt::format("{0:d} Hz", rate_copy).c_str());
-    gtk_label_set_text(self->label_samples, fmt::format("{0:d}", n_samples).c_str());
-    gtk_label_set_text(self->label_duration, fmt::format("{0:.3f}", duration).c_str());
+    try {
+      self->data->user_locale = std::locale("");
+    } catch (...) {
+    }
+
+    gtk_label_set_text(self->label_sampling_rate, fmt::format(self->data->user_locale, "{0:Ld} Hz", rate_copy).c_str());
+    gtk_label_set_text(self->label_samples, fmt::format(self->data->user_locale, "{0:Ld}", n_samples).c_str());
+    gtk_label_set_text(self->label_duration, fmt::format(self->data->user_locale, "{0:.3Lf}", duration).c_str());
 
     if (gtk_toggle_button_get_active(self->show_fft) == 0) {
       plot_waveform(self);

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -317,6 +317,15 @@ void get_irs_info(ConvolverBox* self) {
   if (path.empty()) {
     util::warning(": irs file path is null.");
 
+    // Set label to initial empty state
+    gtk_widget_remove_css_class(GTK_WIDGET(self->label_file_name), "error");
+    gtk_widget_add_css_class(GTK_WIDGET(self->label_file_name), "dim-label");
+    gtk_label_set_text(self->label_file_name, _("No Impulse File Loaded"));
+
+    gtk_label_set_text(self->label_sampling_rate, "");
+    gtk_label_set_text(self->label_samples, "");
+    gtk_label_set_text(self->label_duration, "");
+
     return;
   }
 
@@ -330,10 +339,14 @@ void get_irs_info(ConvolverBox* self) {
         return;
       }
 
-      gtk_label_set_text(self->label_sampling_rate, _("Failed"));
-      gtk_label_set_text(self->label_samples, _("Failed"));
-      gtk_label_set_text(self->label_sampling_rate, _("Failed"));
-      gtk_label_set_text(self->label_file_name, _("Could Not Load The Impulse File"));
+      // Move label to error state
+      gtk_widget_remove_css_class(GTK_WIDGET(self->label_file_name), "dim-label");
+      gtk_widget_add_css_class(GTK_WIDGET(self->label_file_name), "error");
+      gtk_label_set_text(self->label_file_name, _("Failed To Load The Impulse File"));
+
+      gtk_label_set_text(self->label_sampling_rate, "");
+      gtk_label_set_text(self->label_samples, "");
+      gtk_label_set_text(self->label_duration, "");
     });
 
     return;
@@ -428,13 +441,16 @@ void get_irs_info(ConvolverBox* self) {
       return;
     }
 
+    const auto fpath = std::filesystem::path{path};
+
+    // Set label to ready state and update with filename
+    gtk_widget_remove_css_class(GTK_WIDGET(self->label_file_name), "error");
+    gtk_widget_add_css_class(GTK_WIDGET(self->label_file_name), "dim-label");
+    gtk_label_set_text(self->label_file_name, fpath.stem().c_str());
+
     gtk_label_set_text(self->label_sampling_rate, fmt::format("{0:d} Hz", rate_copy).c_str());
     gtk_label_set_text(self->label_samples, fmt::format("{0:d}", n_samples).c_str());
     gtk_label_set_text(self->label_duration, fmt::format("{0:.3f}", duration).c_str());
-
-    const auto fpath = std::filesystem::path{path};
-
-    gtk_label_set_text(self->label_file_name, fpath.stem().c_str());
 
     if (gtk_toggle_button_get_active(self->show_fft) == 0) {
       plot_waveform(self);

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -32,6 +32,8 @@ struct Data {
   std::vector<sigc::connection> connections;
 
   std::vector<gulong> gconnections;
+
+  std::locale user_locale;
 };
 
 struct _GateBox {
@@ -165,7 +167,13 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
         return;
       }
 
-      gtk_label_set_text(self->attack_zone_start_label, fmt::format("{0:.1f}", util::linear_to_db(value)).c_str());
+      try {
+        self->data->user_locale = std::locale("");
+      } catch (...) {
+      }
+
+      gtk_label_set_text(self->attack_zone_start_label,
+                         fmt::format(self->data->user_locale, "{0:.1Lf}", util::linear_to_db(value)).c_str());
     });
   }));
 
@@ -179,7 +187,13 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
         return;
       }
 
-      gtk_label_set_text(self->attack_threshold_label, fmt::format("{0:.1f}", util::linear_to_db(value)).c_str());
+      try {
+        self->data->user_locale = std::locale("");
+      } catch (...) {
+      }
+
+      gtk_label_set_text(self->attack_threshold_label,
+                         fmt::format(self->data->user_locale, "{0:.1Lf}", util::linear_to_db(value)).c_str());
     });
   }));
 
@@ -193,7 +207,13 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
         return;
       }
 
-      gtk_label_set_text(self->release_zone_start_label, fmt::format("{0:.1f}", util::linear_to_db(value)).c_str());
+      try {
+        self->data->user_locale = std::locale("");
+      } catch (...) {
+      }
+
+      gtk_label_set_text(self->release_zone_start_label,
+                         fmt::format(self->data->user_locale, "{0:.1Lf}", util::linear_to_db(value)).c_str());
     });
   }));
 
@@ -207,7 +227,13 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
         return;
       }
 
-      gtk_label_set_text(self->release_threshold_label, fmt::format("{0:.1f}", util::linear_to_db(value)).c_str());
+      try {
+        self->data->user_locale = std::locale("");
+      } catch (...) {
+      }
+
+      gtk_label_set_text(self->release_threshold_label,
+                         fmt::format(self->data->user_locale, "{0:.1Lf}", util::linear_to_db(value)).c_str());
     });
   }));
 
@@ -221,8 +247,15 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
         return;
       }
 
-      gtk_label_set_text(self->gating_label, fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
-      gtk_label_set_text(self->gain_label, fmt::format("{0:.0f}", util::linear_to_db(value)).c_str());
+      try {
+        self->data->user_locale = std::locale("");
+      } catch (...) {
+      }
+
+      gtk_label_set_text(self->gating_label,
+                         fmt::format(self->data->user_locale, "{0:.0Lf}", util::linear_to_db(value)).c_str());
+      gtk_label_set_text(self->gain_label,
+                         fmt::format(self->data->user_locale, "{0:.0Lf}", util::linear_to_db(value)).c_str());
     });
   }));
 


### PR DESCRIPTION
* The Convolver updates the `file_name_label` showing an error message when a corrupted irs file is loaded (placed in `/.config/easyeffects/irs/` and showed in the Convolver menu list)
* When an empty irs is specified, the `file_name_label` informs the user that no file is loaded in the Convolver.
* Improved spacing in Autogain and Convolver
* Fixed locale formatting for Gate and Convolver