### PR TITLE
Convolver dialog and RNnoise toast

### DIFF
--- a/data/ui/gate.ui
+++ b/data/ui/gate.ui
@@ -38,54 +38,41 @@
                                         <property name="halign">center</property>
                                         <property name="column-spacing">18</property>
 
+                                        <!-- Attack/Release section -->
                                         <child>
-                                            <object class="GtkLabel" id="attack_time_label">
-                                                <property name="label" translatable="yes">Attack</property>
+                                            <object class="GtkBox">
+                                                <property name="halign">fill</property>
+                                                <property name="homogeneous">1</property>
+                                                <property name="margin-bottom">6</property>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="attack_time_label">
+                                                        <property name="label" translatable="yes">Attack</property>
+
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="release_time_label">
+                                                        <property name="label" translatable="yes">Release</property>
+                                                    </object>
+                                                </child>
+
                                                 <layout>
                                                     <property name="column">0</property>
                                                     <property name="row">1</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel" id="release_time_label">
-                                                <property name="label" translatable="yes">Release</property>
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="label" translatable="yes">Curve</property>
-                                                <layout>
-                                                    <property name="column">2</property>
-                                                    <property name="row">0</property>
-                                                    <property name="column-span">2</property>
                                                 </layout>
                                             </object>
                                         </child>
 
                                         <child>
                                             <object class="GtkBox">
-                                                <property name="margin-top">4</property>
                                                 <property name="halign">center</property>
                                                 <style>
                                                     <class name="linked" />
                                                 </style>
 
-                                                <layout>
-                                                    <property name="column">0</property>
-                                                    <property name="row">2</property>
-                                                    <property name="column-span">2</property>
-                                                </layout>
-
                                                 <child>
                                                     <object class="GtkSpinButton" id="attack">
-                                                        <property name="margin-top">4</property>
                                                         <property name="orientation">vertical</property>
                                                         <property name="digits">2</property>
                                                         <property name="width-chars">11</property>
@@ -106,7 +93,6 @@
 
                                                 <child>
                                                     <object class="GtkSpinButton" id="release">
-                                                        <property name="margin-top">4</property>
                                                         <property name="orientation">vertical</property>
                                                         <property name="digits">2</property>
                                                         <property name="width-chars">11</property>
@@ -124,6 +110,25 @@
                                                         </accessibility>
                                                     </object>
                                                 </child>
+
+                                                <layout>
+                                                    <property name="column">0</property>
+                                                    <property name="row">2</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+
+                                        <!-- Curve section -->
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="margin-bottom">4</property>
+                                                <property name="label" translatable="yes">Curve</property>
+                                                <layout>
+                                                    <property name="column">1</property>
+                                                    <property name="row">0</property>
+                                                </layout>
                                             </object>
                                         </child>
 
@@ -146,16 +151,14 @@
                                                 </child>
 
                                                 <layout>
-                                                    <property name="column">2</property>
+                                                    <property name="column">1</property>
                                                     <property name="row">1</property>
-                                                    <property name="column-span">2</property>
                                                 </layout>
                                             </object>
                                         </child>
 
                                         <child>
                                             <object class="GtkBox">
-                                                <property name="margin-top">4</property>
                                                 <property name="halign">center</property>
                                                 <style>
                                                     <class name="linked" />
@@ -203,22 +206,22 @@
                                                 </child>
 
                                                 <layout>
-                                                    <property name="column">2</property>
+                                                    <property name="column">1</property>
                                                     <property name="row">2</property>
-                                                    <property name="column-span">2</property>
                                                 </layout>
                                             </object>
                                         </child>
 
+                                        <!-- Hysteresis section -->
                                         <child>
                                             <object class="GtkToggleButton" id="hysteresis">
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
+                                                <property name="margin-bottom">4</property>
                                                 <property name="label" translatable="yes">Hysteresis</property>
                                                 <layout>
-                                                    <property name="column">4</property>
+                                                    <property name="column">2</property>
                                                     <property name="row">0</property>
-                                                    <property name="column-span">2</property>
                                                 </layout>
                                             </object>
                                         </child>
@@ -227,6 +230,7 @@
                                             <object class="GtkBox">
                                                 <property name="halign">fill</property>
                                                 <property name="homogeneous">1</property>
+                                                <property name="margin-bottom">6</property>
 
                                                 <child>
                                                     <object class="GtkLabel" id="hysteresis_threshold_label">
@@ -240,16 +244,14 @@
                                                 </child>
 
                                                 <layout>
-                                                    <property name="column">4</property>
+                                                    <property name="column">2</property>
                                                     <property name="row">1</property>
-                                                    <property name="column-span">2</property>
                                                 </layout>
                                             </object>
                                         </child>
 
                                         <child>
                                             <object class="GtkBox">
-                                                <property name="margin-top">4</property>
                                                 <property name="halign">center</property>
                                                 <style>
                                                     <class name="linked" />
@@ -299,30 +301,46 @@
                                                 </child>
 
                                                 <layout>
-                                                    <property name="column">4</property>
+                                                    <property name="column">2</property>
                                                     <property name="row">2</property>
-                                                    <property name="column-span">2</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+
+                                        <!-- Reduction/Makeup section -->
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="halign">fill</property>
+                                                <property name="homogeneous">1</property>
+                                                <property name="margin-bottom">6</property>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="reduction_label">
+                                                        <property name="label" translatable="yes">Reduction</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="makeup_label">
+                                                        <property name="label" translatable="yes">Makeup</property>
+                                                    </object>
+                                                </child>
+
+                                                <layout>
+                                                    <property name="column">3</property>
+                                                    <property name="row">1</property>
                                                 </layout>
                                             </object>
                                         </child>
 
                                         <child>
                                             <object class="GtkBox">
-                                                <property name="margin-top">4</property>
                                                 <property name="halign">center</property>
                                                 <style>
                                                     <class name="linked" />
                                                 </style>
 
-                                                <layout>
-                                                    <property name="column">6</property>
-                                                    <property name="row">2</property>
-                                                    <property name="column-span">2</property>
-                                                </layout>
-
                                                 <child>
                                                     <object class="GtkSpinButton" id="reduction">
-                                                        <property name="margin-top">4</property>
                                                         <property name="orientation">vertical</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">1</property>
@@ -341,10 +359,8 @@
                                                         </accessibility>
                                                     </object>
                                                 </child>
-
                                                 <child>
                                                     <object class="GtkSpinButton" id="makeup">
-                                                        <property name="margin-top">4</property>
                                                         <property name="orientation">vertical</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">1</property>
@@ -362,25 +378,10 @@
                                                         </accessibility>
                                                     </object>
                                                 </child>
-                                            </object>
-                                        </child>
 
-                                        <child>
-                                            <object class="GtkLabel" id="reduction_label">
-                                                <property name="label" translatable="yes">Reduction</property>
                                                 <layout>
-                                                    <property name="column">6</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel" id="makeup_label">
-                                                <property name="label" translatable="yes">Makeup</property>
-                                                <layout>
-                                                    <property name="column">7</property>
-                                                    <property name="row">1</property>
+                                                    <property name="column">3</property>
+                                                    <property name="row">2</property>
                                                 </layout>
                                             </object>
                                         </child>

--- a/data/ui/rnnoise.ui
+++ b/data/ui/rnnoise.ui
@@ -89,7 +89,17 @@
                 <property name="spacing">6</property>
                 <property name="halign">center</property>
                 <child>
-                    <object class="GtkLabel">
+                    <object class="GtkLabel" id="model_error_state">
+                        <style>
+                            <class name="error" />
+                        </style>
+                        <property name="visible">0</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Model Not Loaded</property>
+                    </object>
+                </child>
+                <child>
+                    <object class="GtkLabel" id="model_active_state">
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Active Model</property>
                     </object>
@@ -97,6 +107,8 @@
                 <child>
                     <object class="GtkLabel" id="active_model_name">
                         <property name="halign">start</property>
+                        <property name="wrap">1</property>
+                        <property name="wrap-mode">word-char</property>
                         <property name="label" translatable="yes">Standard RNNoise Model</property>
 
                         <binding name="label">

--- a/data/ui/rnnoise.ui
+++ b/data/ui/rnnoise.ui
@@ -5,331 +5,346 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
         <child>
-            <object class="GtkBox">
-                <property name="spacing">24</property>
-                <property name="halign">center</property>
-                <property name="homogeneous">1</property>
-                <child>
-                    <object class="GtkButton" id="import_model">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="icon-name">document-open-symbolic</property>
-                        <property name="label" translatable="yes">Import Model</property>
-                        <signal name="clicked" handler="on_import_model_clicked" object="RNNoiseBox" />
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkLabel">
-                <property name="label" translatable="yes">Models</property>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkFrame" id="model_list_frame">
                 <child>
-                    <object class="GtkScrolledWindow">
+                    <object class="GtkBox">
+                        <property name="spacing">12</property>
+                        <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkListView" id="listview">
-                                <property name="hexpand">1</property>
-                                <property name="vexpand">1</property>
-                                <property name="show-separators">1</property>
+                            <object class="GtkBox">
+                                <property name="spacing">24</property>
+                                <property name="halign">center</property>
+                                <property name="homogeneous">1</property>
+                                <child>
+                                    <object class="GtkButton" id="import_model">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="icon-name">document-open-symbolic</property>
+                                        <property name="label" translatable="yes">Import Model</property>
+                                        <signal name="clicked" handler="on_import_model_clicked" object="RNNoiseBox" />
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
 
-                                <property name="model">
-                                    <object class="GtkSingleSelection" id="selection_model">
-                                        <property name="model">
-                                            <object class="GtkSortListModel">
+                        <child>
+                            <object class="GtkLabel">
+                                <property name="label" translatable="yes">Models</property>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkFrame" id="model_list_frame">
+                                <child>
+                                    <object class="GtkScrolledWindow">
+                                        <child>
+                                            <object class="GtkListView" id="listview">
+                                                <property name="hexpand">1</property>
+                                                <property name="vexpand">1</property>
+                                                <property name="show-separators">1</property>
+
                                                 <property name="model">
-                                                    <object class="GtkStringList" id="string_list">
-                                                        <items>
-                                                            <item translatable="yes">Standard Model</item>
-                                                        </items>
-                                                    </object>
-                                                </property>
+                                                    <object class="GtkSingleSelection" id="selection_model">
+                                                        <property name="model">
+                                                            <object class="GtkSortListModel">
+                                                                <property name="model">
+                                                                    <object class="GtkStringList" id="string_list">
+                                                                        <items>
+                                                                            <item translatable="yes">Standard Model</item>
+                                                                        </items>
+                                                                    </object>
+                                                                </property>
 
-                                                <property name="sorter">
-                                                    <object class="GtkStringSorter">
-                                                        <property name="expression">
-                                                            <lookup name="string" type="GtkStringObject"></lookup>
+                                                                <property name="sorter">
+                                                                    <object class="GtkStringSorter">
+                                                                        <property name="expression">
+                                                                            <lookup name="string" type="GtkStringObject"></lookup>
+                                                                        </property>
+                                                                    </object>
+                                                                </property>
+                                                            </object>
                                                         </property>
                                                     </object>
                                                 </property>
+
+
+                                                <property name="factory">
+                                                    <object class="GtkBuilderListItemFactory">
+                                                        <property name="resource">/com/github/wwmm/easyeffects/ui/factory_rnnoise_listview.ui</property>
+                                                    </object>
+                                                </property>
+
+                                                <style>
+                                                    <class name="rich-list" />
+                                                </style>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">RNNoise Models List</property>
+                                                </accessibility>
                                             </object>
-                                        </property>
+                                        </child>
                                     </object>
-                                </property>
-
-
-                                <property name="factory">
-                                    <object class="GtkBuilderListItemFactory">
-                                        <property name="resource">/com/github/wwmm/easyeffects/ui/factory_rnnoise_listview.ui</property>
-                                    </object>
-                                </property>
-
-                                <style>
-                                    <class name="rich-list" />
-                                </style>
-                                <accessibility>
-                                    <property name="label" translatable="yes">RNNoise Models List</property>
-                                </accessibility>
+                                </child>
                             </object>
                         </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="spacing">6</property>
-                <property name="halign">center</property>
-                <child>
-                    <object class="GtkLabel" id="model_error_state">
-                        <style>
-                            <class name="error" />
-                        </style>
-                        <property name="visible">0</property>
-                        <property name="halign">end</property>
-                        <property name="label" translatable="yes">Model Not Loaded</property>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkLabel" id="model_active_state">
-                        <property name="halign">end</property>
-                        <property name="label" translatable="yes">Active Model</property>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkLabel" id="active_model_name">
-                        <property name="halign">start</property>
-                        <property name="wrap">1</property>
-                        <property name="wrap-mode">word-char</property>
-                        <property name="label" translatable="yes">Standard RNNoise Model</property>
-
-                        <binding name="label">
-                            <lookup name="string" type="GtkStringObject">
-                                <lookup name="selected-item">selection_model</lookup>
-                            </lookup>
-                        </binding>
-
-                        <style>
-                            <class name="dim-label" />
-                        </style>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
                         <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
+                            <object class="GtkBox">
+                                <property name="spacing">6</property>
+                                <property name="halign">center</property>
+                                <child>
+                                    <object class="GtkLabel" id="model_error_state">
+                                        <style>
+                                            <class name="error" />
+                                        </style>
+                                        <property name="visible">0</property>
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes">Model Not Loaded</property>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkLabel" id="model_active_state">
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes">Active Model</property>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkLabel" id="active_model_name">
+                                        <property name="halign">start</property>
+                                        <property name="wrap">1</property>
+                                        <property name="wrap-mode">word-char</property>
+                                        <property name="label" translatable="yes">Standard RNNoise Model</property>
+
+                                        <binding name="label">
+                                            <lookup name="string" type="GtkStringObject">
+                                                <lookup name="selected-item">selection_model</lookup>
+                                            </lookup>
+                                        </binding>
+
+                                        <style>
+                                            <class name="dim-label" />
+                                        </style>
+                                    </object>
+                                </child>
                             </object>
                         </child>
+
                         <child>
-                            <object class="GtkScale" id="input_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
                                 <property name="spacing">6</property>
                                 <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
+                                    <object class="GtkBox">
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
                                 <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
                             </object>
                         </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
                         <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="output_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="RNNoiseBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Xiph RNNoise</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="RNNoiseBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">Xiph RNNoise</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/include/application_ui.hpp
+++ b/include/application_ui.hpp
@@ -24,6 +24,7 @@
 #include "pipe_manager_box.hpp"
 #include "presets_menu.hpp"
 #include "tags_resources.hpp"
+#include "ui_helpers.hpp"
 
 namespace ui::application_window {
 

--- a/include/bass_enhancer_preset.hpp
+++ b/include/bass_enhancer_preset.hpp
@@ -3,12 +3,12 @@
  *
  *  This file is part of EasyEffects
  *
- *  EasyEffectsis free software: you can redistribute it and/or modify
+ *  EasyEffects is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
  *  (at your option) any later version.
  *
- *  EasyEffectsis distributed in the hope that it will be useful,
+ *  EasyEffects is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.

--- a/include/bass_loudness_preset.hpp
+++ b/include/bass_loudness_preset.hpp
@@ -3,12 +3,12 @@
  *
  *  This file is part of EasyEffects
  *
- *  EasyEffectsis free software: you can redistribute it and/or modify
+ *  EasyEffects is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
  *  (at your option) any later version.
  *
- *  EasyEffectsis distributed in the hope that it will be useful,
+ *  EasyEffects is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.

--- a/include/convolver.hpp
+++ b/include/convolver.hpp
@@ -3,12 +3,12 @@
  *
  *  This file is part of EasyEffects
  *
- *  EasyEffectsis free software: you can redistribute it and/or modify
+ *  EasyEffects is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
  *  (at your option) any later version.
  *
- *  EasyEffectsis distributed in the hope that it will be useful,
+ *  EasyEffects is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.

--- a/include/convolver_menu_impulses.hpp
+++ b/include/convolver_menu_impulses.hpp
@@ -23,6 +23,7 @@
 #include <filesystem>
 #include <sndfile.hh>
 #include "application.hpp"
+#include "ui_helpers.hpp"
 
 namespace ui::convolver_menu_impulses {
 

--- a/include/equalizer.hpp
+++ b/include/equalizer.hpp
@@ -3,12 +3,12 @@
  *
  *  This file is part of EasyEffects
  *
- *  EasyEffectsis free software: you can redistribute it and/or modify
+ *  EasyEffects is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
  *  (at your option) any later version.
  *
- *  EasyEffectsis distributed in the hope that it will be useful,
+ *  EasyEffects is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.

--- a/include/rnnoise.hpp
+++ b/include/rnnoise.hpp
@@ -47,6 +47,10 @@ class RNNoise : public PluginBase {
 
   float latency_value = 0.0F;
 
+  bool standard_model = true;
+
+  sigc::signal<void(const bool load_error)> model_changed;
+
  private:
   bool resample = false;
   bool notify_latency = false;

--- a/include/ui_helpers.hpp
+++ b/include/ui_helpers.hpp
@@ -22,6 +22,7 @@
 #include <adwaita.h>
 #include <fmt/core.h>
 #include <fmt/format.h>
+#include <glib/gi18n.h>
 #include <algorithm>
 #include <iostream>
 #include <map>
@@ -36,6 +37,8 @@ namespace ui {
 void show_fixed_toast(AdwToastOverlay* toast_overlay,
                       const std::string& text,
                       const AdwToastPriority& priority = ADW_TOAST_PRIORITY_HIGH);
+
+void show_simple_message_dialog(GtkWidget* parent, const std::string& title, const std::string& descr);
 
 auto parse_spinbutton_output(GtkSpinButton* button, const char* unit) -> bool;
 

--- a/include/ui_helpers.hpp
+++ b/include/ui_helpers.hpp
@@ -37,6 +37,10 @@ namespace ui {
 void show_fixed_toast(AdwToastOverlay* toast_overlay,
                       const std::string& text,
                       const AdwToastPriority& priority = ADW_TOAST_PRIORITY_HIGH);
+void show_autohiding_toast(AdwToastOverlay* toast_overlay,
+                           const std::string& text,
+                           const uint& timeout = 5U,
+                           const AdwToastPriority& priority = ADW_TOAST_PRIORITY_HIGH);
 
 void show_simple_message_dialog(GtkWidget* parent, const std::string& title, const std::string& descr);
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -61,8 +61,9 @@ src/effects_box.cpp
 src/equalizer_band_box.cpp
 src/equalizer_ui.cpp
 src/pipe_manager_box.cpp
-src/tags_plugin_name.cpp
 src/plugins_box.cpp
 src/plugins_menu.cpp
 src/presets_menu.cpp
 src/rnnoise_ui.cpp
+src/tags_plugin_name.cpp
+src/ui_helpers.cpp

--- a/src/application_ui.cpp
+++ b/src/application_ui.cpp
@@ -91,35 +91,6 @@ auto setup_icon_theme() -> GtkIconTheme* {
   return icon_theme;
 }
 
-void setup_simple_message_dialog(GtkWidget* parent, const std::string& title, const std::string& descr) {
-  if (parent == nullptr) {
-    return;
-  }
-
-  // Modal flag prevents interaction with other windows in the same application
-  auto* dialog = gtk_message_dialog_new(GTK_WINDOW(parent),
-                                        static_cast<GtkDialogFlags>(GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL),
-                                        GTK_MESSAGE_ERROR, GTK_BUTTONS_NONE, "%s", title.c_str());
-
-  gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", descr.c_str());
-
-  // Add custom button to hint the user to press ESC to destroy the dialog
-  gtk_dialog_add_button(GTK_DIALOG(dialog), _("Close (Press ESC)"), 0);
-
-  // Destroy the dialog when the user responds to it
-  g_signal_connect(dialog, "response", G_CALLBACK(gtk_window_destroy), NULL);
-
-  // Keep the dialog on top of the main window, or center the dialog over the main window
-  gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(parent));
-
-  /* Version with Adw.MessageDialog available from libAdwaita 1.2
-  auto* dialog = adw_message_dialog_new(GTK_WINDOW(parent), title.c_str(), descr.c_str());
-
-  adw_message_dialog_add_response(ADW_MESSAGE_DIALOG(dialog), "close", "OK"); */
-
-  gtk_window_present(GTK_WINDOW(dialog));
-}
-
 void apply_css_style() {
   auto* provider = gtk_css_provider_new();
 
@@ -193,7 +164,7 @@ void realize(GtkWidget* widget) {
   self->data->connections.push_back(
       app::EE_APP(self->data->gapp)
           ->presets_manager->preset_load_error.connect([=](const std::string title, const std::string descr) {
-            setup_simple_message_dialog(widget, title, descr);
+            ui::show_simple_message_dialog(widget, title, descr);
           }));
 }
 

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -366,7 +366,7 @@ void on_import_apo_preset_clicked(EqualizerBox* self, GtkButton* btn) {
 
                        if (!import_apo_preset(self, path)) {
                          // notify error on APO preset loading
-                         show_fixed_toast(
+                         ui::show_fixed_toast(
                              self->toast_overlay,
                              _("APO Preset Not Loaded. File Format May Be Wrong. Please Check Its Content."));
                        }

--- a/src/rnnoise_ui.cpp
+++ b/src/rnnoise_ui.cpp
@@ -47,6 +47,10 @@ struct Data {
 struct _RNNoiseBox {
   GtkBox parent_instance;
 
+  GtkOverlay* overlay;
+
+  AdwToastOverlay* toast_overlay;
+
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -76,6 +80,12 @@ void on_reset(RNNoiseBox* self, GtkButton* btn) {
 void update_model_state(RNNoiseBox* self, const bool& load_error) {
   gtk_widget_set_visible(GTK_WIDGET(self->model_error_state), load_error);
   gtk_widget_set_visible(GTK_WIDGET(self->model_active_state), !load_error);
+
+  if (load_error) {
+    ui::show_autohiding_toast(
+        self->toast_overlay,
+        _("Selected Model Not Loaded. Its Format May Be Unsupported. Fell Back To The Standard Model."));
+  }
 }
 
 gboolean set_model_delete_button_visibility(GtkListItem* item, const char* name) {
@@ -310,6 +320,9 @@ void rnnoise_box_class_init(RNNoiseBoxClass* klass) {
   object_class->finalize = finalize;
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::rnnoise_ui);
+
+  gtk_widget_class_bind_template_child(widget_class, RNNoiseBox, overlay);
+  gtk_widget_class_bind_template_child(widget_class, RNNoiseBox, toast_overlay);
 
   gtk_widget_class_bind_template_child(widget_class, RNNoiseBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, RNNoiseBox, output_gain);

--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -1,3 +1,22 @@
+/*
+ *  Copyright © 2017-2022 Wellington Wallace
+ *
+ *  This file is part of EasyEffects.
+ *
+ *  EasyEffects is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  EasyEffects is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with EasyEffects.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include "ui_helpers.hpp"
 
 namespace {
@@ -25,6 +44,38 @@ void show_fixed_toast(AdwToastOverlay* toast_overlay, const std::string& text, c
   adw_toast_set_priority(toast, priority);
 
   adw_toast_overlay_add_toast(toast_overlay, toast);
+}
+
+void show_simple_message_dialog(GtkWidget* parent, const std::string& title, const std::string& descr) {
+  if (parent == nullptr) {
+    return;
+  }
+
+  // Modal flag prevents interaction with other windows in the same application
+  auto* dialog = gtk_message_dialog_new(GTK_WINDOW(parent),
+                                        static_cast<GtkDialogFlags>(GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL),
+                                        GTK_MESSAGE_ERROR, GTK_BUTTONS_NONE, "%s", title.c_str());
+
+  gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", descr.c_str());
+
+  // Add custom button to hint the user to press ESC to destroy the dialog.
+  // This has been introduced because multiple GTK4 dialogs shown at
+  // the same time could have issues on Wayland and the only way to
+  // close the outer one is pressing ESC, the mouse click does not work.
+  gtk_dialog_add_button(GTK_DIALOG(dialog), _("Close (Press ESC)"), 0);
+
+  // Destroy the dialog when the user responds to it
+  g_signal_connect(dialog, "response", G_CALLBACK(gtk_window_destroy), NULL);
+
+  // Keep the dialog on top of the main window, or center the dialog over the main window
+  gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(parent));
+
+  /* Version with Adw.MessageDialog available from libAdwaita 1.2
+  auto* dialog = adw_message_dialog_new(GTK_WINDOW(parent), title.c_str(), descr.c_str());
+
+  adw_message_dialog_add_response(ADW_MESSAGE_DIALOG(dialog), "close", "OK"); */
+
+  gtk_window_present(GTK_WINDOW(dialog));
 }
 
 auto parse_spinbutton_output(GtkSpinButton* button, const char* unit) -> bool {

--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -33,17 +33,21 @@ namespace ui {
 
 using namespace std::string_literals;
 
-void show_fixed_toast(AdwToastOverlay* toast_overlay, const std::string& text, const AdwToastPriority& priority) {
-  // This helper is for showing fixed toasts which the user has to close them.
-  // For autohiding toasts we'll make another helper specifying the timeout as parameter.
-
+void show_autohiding_toast(AdwToastOverlay* toast_overlay,
+                           const std::string& text,
+                           const uint& timeout,
+                           const AdwToastPriority& priority) {
   auto* toast = adw_toast_new(text.c_str());
 
-  adw_toast_set_timeout(toast, 0U);
+  adw_toast_set_timeout(toast, timeout);
 
   adw_toast_set_priority(toast, priority);
 
   adw_toast_overlay_add_toast(toast_overlay, toast);
+}
+
+void show_fixed_toast(AdwToastOverlay* toast_overlay, const std::string& text, const AdwToastPriority& priority) {
+  show_autohiding_toast(toast_overlay, text, 0U, priority);
 }
 
 void show_simple_message_dialog(GtkWidget* parent, const std::string& title, const std::string& descr) {


### PR DESCRIPTION
* Dialogs are shown when an impulse import operation fails inside the Convolver.
This can be tested importing an empty .irs file or a non-stereo .wav (I took from [here](http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/Samples.html)).
* RNnoise now updates the labels reporting if the selected mode has been loaded.
In case of failing, an autohiding toast is also shown to inform the user that the format may be unsupported and the model has fallen back to the Standard one.  
* Fixed spinbuttons alignment in Gate UI.

@wwmm after this what do you think of a new release? Especially to fix the missing exception handling on locale object construction. 

Anyway before the new release, #1628 has to be resolved. 