### PR TITLE
flatpak: Don't ignore patch files in patch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__
 _build
 build
+build-dir
 locale
 gschemas.compiled
 obj-*-linux-gnu
@@ -58,3 +59,7 @@ util/flatpak/build-dir
 util/flatpak/repo
 util/flatpak/.flatpak-builder
 .flatpak
+.flatpak-builder
+
+# explictly include flatpak patch directory which includes usually ignored patch files
+!util/flatpak/patch/**/*.patch


### PR DESCRIPTION
This was only working before by luck, now the patch files are actually tracked.