### PR TITLE
Fix artifact comment PR number finding

### DIFF
--- a/.github/workflows/artifact-pr-comment.yaml
+++ b/.github/workflows/artifact-pr-comment.yaml
@@ -27,8 +27,11 @@ jobs:
         run: |
           # Query the issue search API to get the PR associated with it
           PR_RAW=$(curl 'https://api.github.com/search/issues?q=${{ github.event.workflow_run.head_commit.id }}')
+
           # Get the event number from the search results, which will be the PR number
-          PR_NUM=$(echo $PR_RAW | jq '.items[].number')
+          # Filter by PRs only in this repository, as a PR with an identical head commit may be made in another repository (e.g. a fork)
+          # Assume the 0th index in the array of found PRs is the correct one (it seems to usually be the latest one)
+          PR_NUM=$(echo $PR_RAW | jq '.items | map(select(.repository_url=="https://api.github.com/repos/${{ github.repository }}")) | .[0].number')
           echo "PR_NUM=${PR_NUM}" >> ${GITHUB_ENV}
       
       - name: Comment on PR

--- a/.github/workflows/artifact-pr-comment.yaml
+++ b/.github/workflows/artifact-pr-comment.yaml
@@ -1,4 +1,4 @@
-name: Artifact comment
+name: Artifact PR comment
 
 on:
   workflow_run:
@@ -10,8 +10,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  pr_comment:
-    name: Update PR comment
+  artifact_pr_comment:
+    name: Update Artifact PR comment
     if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
This could fail if there were two PRs with the same head commit, which I only saw after merge in https://github.com/wwmm/easyeffects/actions/runs/2768616405.