### PR TITLE
Show missing plugin alerts

### DIFF
--- a/data/ui/autogain.ui
+++ b/data/ui/autogain.ui
@@ -5,549 +5,564 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
         <child>
-            <object class="GtkGrid">
-                <property name="halign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">24</property>
-                <property name="margin-bottom">6</property>
-                <child>
-                    <object class="GtkLabel" id="label_target">
-                        <property name="label" translatable="yes">Target</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="target">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="width-chars">10</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-100</property>
-                                <property name="value">-23</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">label_target</relation>
-                        </accessibility>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
-                <child>
-                    <object class="GtkLabel" id="label_maximum_history">
-                        <property name="label" translatable="yes">Maximum History</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="maximum_history">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="width-chars">10</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">6</property>
-                                <property name="upper">3600</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">10</property>
-                            </object>
-                        </property>
-                        <property name="digits">0</property>
-                        <property name="update-policy">if-valid</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">label_maximum_history</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="reference_label">
-                        <property name="label" translatable="yes">Reference</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkComboBoxText" id="reference">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <items>
-                            <item translatable="yes" id="Momentary">Momentary</item>
-                            <item translatable="yes" id="Shortterm">Short-Term</item>
-                            <item translatable="yes" id="Integrated">Integrated</item>
-                            <item translatable="yes" id="Geometric Mean (MSI)">Geometric Mean (MSI)</item>
-                            <item translatable="yes" id="Geometric Mean (MS)">Geometric Mean (MS)</item>
-                            <item translatable="yes" id="Geometric Mean (MI)">Geometric Mean (MI)</item>
-                            <item translatable="yes" id="Geometric Mean (SI)">Geometric Mean (SI)</item>
-                        </items>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">reference_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkButton" id="reset_history">
-                        <property name="valign">center</property>
-                        <property name="label" translatable="yes">Reset History</property>
-                        <signal name="clicked" handler="on_reset_history" object="AutogainBox" />
-                        <layout>
-                            <property name="column">3</property>
-                            <property name="row">1</property>
-                        </layout>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="m_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Momentary</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="m_level">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="m_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">6</property>
-                        <property name="label">0</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="s_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Short-Term</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="s_level">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="s_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">6</property>
-                        <property name="label">0</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="i_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Integrated</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="i_level">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="i_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">6</property>
-                        <property name="label">0</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="r_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Relative</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="r_level">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="r_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">6</property>
-                        <property name="label">0</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="lra_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Range</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="lra_level">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="min-value">1</property>
-                        <property name="max-value">30</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="lra_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">6</property>
-                        <property name="label">0</property>
-
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="l_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Loudness</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="l_level">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="max-value">5</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="l_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">6</property>
-                        <property name="label">0</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="margin-bottom">6</property>
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="g_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Output Gain</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="g_level">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="max-value">30</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="g_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">6</property>
-                        <property name="label">0</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
                 <child>
                     <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
-                                <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
+                        <property name="spacing">12</property>
                         <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+                            <object class="GtkGrid">
+                                <property name="halign">center</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">24</property>
+                                <property name="margin-bottom">6</property>
                                 <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
+                                    <object class="GtkLabel" id="label_target">
+                                        <property name="label" translatable="yes">Target</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="target">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-100</property>
+                                                <property name="value">-23</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">label_target</relation>
+                                        </accessibility>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">6</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">6</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
+                                <child>
+                                    <object class="GtkLabel" id="label_maximum_history">
+                                        <property name="label" translatable="yes">Maximum History</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="maximum_history">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">6</property>
+                                                <property name="upper">3600</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">10</property>
+                                            </object>
+                                        </property>
+                                        <property name="digits">0</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">label_maximum_history</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="reference_label">
+                                        <property name="label" translatable="yes">Reference</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkComboBoxText" id="reference">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <items>
+                                            <item translatable="yes" id="Momentary">Momentary</item>
+                                            <item translatable="yes" id="Shortterm">Short-Term</item>
+                                            <item translatable="yes" id="Integrated">Integrated</item>
+                                            <item translatable="yes" id="Geometric Mean (MSI)">Geometric Mean (MSI)</item>
+                                            <item translatable="yes" id="Geometric Mean (MS)">Geometric Mean (MS)</item>
+                                            <item translatable="yes" id="Geometric Mean (MI)">Geometric Mean (MI)</item>
+                                            <item translatable="yes" id="Geometric Mean (SI)">Geometric Mean (SI)</item>
+                                        </items>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">reference_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkButton" id="reset_history">
+                                        <property name="valign">center</property>
+                                        <property name="label" translatable="yes">Reset History</property>
+                                        <signal name="clicked" handler="on_reset_history" object="AutogainBox" />
+                                        <layout>
+                                            <property name="column">3</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
                             </object>
                         </child>
+
                         <child>
-                            <object class="GtkScale" id="output_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkLabel" id="m_title">
+                                        <property name="halign">end</property>
+                                        <property name="xalign">1</property>
+                                        <property name="label" translatable="yes">Momentary</property>
                                     </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLevelBar" id="m_level">
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">1</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="m_label">
+                                        <property name="halign">end</property>
+                                        <property name="width-chars">6</property>
+                                        <property name="label">0</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkLabel" id="s_title">
+                                        <property name="halign">end</property>
+                                        <property name="xalign">1</property>
+                                        <property name="label" translatable="yes">Short-Term</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLevelBar" id="s_level">
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">1</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="s_label">
+                                        <property name="halign">end</property>
+                                        <property name="width-chars">6</property>
+                                        <property name="label">0</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkLabel" id="i_title">
+                                        <property name="halign">end</property>
+                                        <property name="xalign">1</property>
+                                        <property name="label" translatable="yes">Integrated</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLevelBar" id="i_level">
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">1</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="i_label">
+                                        <property name="halign">end</property>
+                                        <property name="width-chars">6</property>
+                                        <property name="label">0</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkLabel" id="r_title">
+                                        <property name="halign">end</property>
+                                        <property name="xalign">1</property>
+                                        <property name="label" translatable="yes">Relative</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLevelBar" id="r_level">
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">1</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="r_label">
+                                        <property name="halign">end</property>
+                                        <property name="width-chars">6</property>
+                                        <property name="label">0</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkLabel" id="lra_title">
+                                        <property name="halign">end</property>
+                                        <property name="xalign">1</property>
+                                        <property name="label" translatable="yes">Range</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLevelBar" id="lra_level">
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">1</property>
+                                        <property name="min-value">1</property>
+                                        <property name="max-value">30</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="lra_label">
+                                        <property name="halign">end</property>
+                                        <property name="width-chars">6</property>
+                                        <property name="label">0</property>
+
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkLabel" id="l_title">
+                                        <property name="halign">end</property>
+                                        <property name="xalign">1</property>
+                                        <property name="label" translatable="yes">Loudness</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLevelBar" id="l_level">
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">1</property>
+                                        <property name="max-value">5</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="l_label">
+                                        <property name="halign">end</property>
+                                        <property name="width-chars">6</property>
+                                        <property name="label">0</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="margin-bottom">6</property>
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkLabel" id="g_title">
+                                        <property name="halign">end</property>
+                                        <property name="xalign">1</property>
+                                        <property name="label" translatable="yes">Output Gain</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLevelBar" id="g_level">
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">1</property>
+                                        <property name="max-value">30</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="g_label">
+                                        <property name="halign">end</property>
+                                        <property name="width-chars">6</property>
+                                        <property name="label">0</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">6</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">6</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">6</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">6</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="AutogainBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">6</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">libebur128</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">6</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="AutogainBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">libebur128</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/bass_enhancer.ui
+++ b/data/ui/bass_enhancer.ui
@@ -5,470 +5,485 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
         <child>
-            <object class="GtkToggleButton" id="listen">
-                <property name="label" translatable="yes">Listen</property>
-                <property name="halign">center</property>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkGrid">
-                <property name="halign">center</property>
-                <property name="row-spacing">2</property>
-                <child>
-                    <object class="GtkLabel" id="blend_label">
-                        <property name="label" translatable="yes">Blend Harmonics</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="column-span">3</property>
-                            <property name="row">0</property>
-                        </layout>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
-                <child>
-                    <object class="GtkLabel">
-                        <property name="halign">end</property>
-                        <property name="label" translatable="yes">3rd</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkScale" id="blend">
-                        <property name="width-request">500</property>
-                        <property name="valign">center</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-10</property>
-                                <property name="upper">10</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <property name="draw-value">1</property>
-                        <property name="digits">0</property>
-                        <property name="value-pos">top</property>
-                        <marks>
-                            <mark value="-10" position="bottom"></mark>
-                            <mark value="-5" position="bottom"></mark>
-                            <mark value="0" position="bottom"></mark>
-                            <mark value="5" position="bottom"></mark>
-                            <mark value="10" position="bottom"></mark>
-                        </marks>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">blend_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel">
-                        <property name="halign">start</property>
-                        <property name="label" translatable="yes">2nd</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkGrid">
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">48</property>
-                <property name="margin-bottom">12</property>
-                <child>
-                    <object class="GtkLabel" id="amount_label">
-                        <property name="label" translatable="yes">Amount</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="amount">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-100</property>
-                                <property name="upper">36</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">amount_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="harmonics_spinbutton_label">
-                        <property name="label" translatable="yes">Harmonics</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="harmonics">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">0.1</property>
-                                <property name="upper">10</property>
-                                <property name="value">8.5</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">harmonics_spinbutton_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="scope_label">
-                        <property name="label" translatable="yes">Scope</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="scope">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">10</property>
-                                <property name="upper">250</property>
-                                <property name="value">100</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">10</property>
-                            </object>
-                        </property>
-                        <property name="update-policy">if-valid</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">scope_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkToggleButton" id="floor_active">
-                        <property name="label" translatable="yes">Floor</property>
-                        <property name="halign">center</property>
-                        <layout>
-                            <property name="column">3</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="floor">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="sensitive" bind-source="floor_active" bind-property="active" bind-flags="sync-create" />
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">10</property>
-                                <property name="upper">120</property>
-                                <property name="value">20</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">10</property>
-                            </object>
-                        </property>
-                        <property name="update-policy">if-valid</property>
-                        <layout>
-                            <property name="column">3</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <property name="label" translatable="yes">Floor Value</property>
-                        </accessibility>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
                 <child>
                     <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
+                        <property name="spacing">12</property>
+                        <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
+                            <object class="GtkToggleButton" id="listen">
+                                <property name="label" translatable="yes">Listen</property>
+                                <property name="halign">center</property>
                             </object>
                         </child>
+
                         <child>
-                            <object class="GtkScale" id="input_gain">
-                                <property name="hexpand">1</property>
+                            <object class="GtkGrid">
+                                <property name="halign">center</property>
+                                <property name="row-spacing">2</property>
+                                <child>
+                                    <object class="GtkLabel" id="blend_label">
+                                        <property name="label" translatable="yes">Blend Harmonics</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="column-span">3</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes">3rd</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkScale" id="blend">
+                                        <property name="width-request">500</property>
+                                        <property name="valign">center</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-10</property>
+                                                <property name="upper">10</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <property name="draw-value">1</property>
+                                        <property name="digits">0</property>
+                                        <property name="value-pos">top</property>
+                                        <marks>
+                                            <mark value="-10" position="bottom"></mark>
+                                            <mark value="-5" position="bottom"></mark>
+                                            <mark value="0" position="bottom"></mark>
+                                            <mark value="5" position="bottom"></mark>
+                                            <mark value="10" position="bottom"></mark>
+                                        </marks>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">blend_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">2nd</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkGrid">
+                                <property name="halign">center</property>
                                 <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">48</property>
+                                <property name="margin-bottom">12</property>
                                 <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
+                                    <object class="GtkLabel" id="amount_label">
+                                        <property name="label" translatable="yes">Amount</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
                                     </object>
                                 </child>
                                 <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
+                                    <object class="GtkSpinButton" id="amount">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-100</property>
+                                                <property name="upper">36</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">amount_label</relation>
+                                        </accessibility>
                                     </object>
                                 </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
+                                <child>
+                                    <object class="GtkLabel" id="harmonics_spinbutton_label">
+                                        <property name="label" translatable="yes">Harmonics</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="harmonics">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">0.1</property>
+                                                <property name="upper">10</property>
+                                                <property name="value">8.5</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">harmonics_spinbutton_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="scope_label">
+                                        <property name="label" translatable="yes">Scope</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="scope">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">10</property>
+                                                <property name="upper">250</property>
+                                                <property name="value">100</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">10</property>
+                                            </object>
+                                        </property>
+                                        <property name="update-policy">if-valid</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">scope_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkToggleButton" id="floor_active">
+                                        <property name="label" translatable="yes">Floor</property>
+                                        <property name="halign">center</property>
+                                        <layout>
+                                            <property name="column">3</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="floor">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="sensitive" bind-source="floor_active" bind-property="active" bind-flags="sync-create" />
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">10</property>
+                                                <property name="upper">120</property>
+                                                <property name="value">20</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">10</property>
+                                            </object>
+                                        </property>
+                                        <property name="update-policy">if-valid</property>
+                                        <layout>
+                                            <property name="column">3</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">Floor Value</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
                             </object>
                         </child>
+
                         <child>
-                            <object class="GtkScale" id="output_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkLabel" id="harmonics_title">
+                                        <property name="halign">end</property>
+                                        <property name="xalign">1</property>
+                                        <property name="label" translatable="yes">Harmonics</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLevelBar" id="harmonics_levelbar">
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">1</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="harmonics_levelbar_label">
+                                        <property name="halign">end</property>
+                                        <property name="width-chars">4</property>
+                                        <property name="label">0</property>
+
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="BassEnhancerBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Calf Studio Gear</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="harmonics_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Harmonics</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="harmonics_levelbar">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="harmonics_levelbar_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">4</property>
-                        <property name="label">0</property>
-
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="BassEnhancerBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">Calf Studio Gear</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/bass_loudness.ui
+++ b/data/ui/bass_loudness.ui
@@ -1,328 +1,342 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface domain="easyeffects">
     <template class="BassLoudnessBox" parent="GtkBox">
-        <property name="orientation">vertical</property>
         <property name="margin-start">6</property>
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
-
+        <property name="orientation">vertical</property>
         <child>
-            <object class="GtkGrid">
-                <property name="halign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">48</property>
-                <property name="margin-bottom">6</property>
-                <child>
-                    <object class="GtkLabel" id="loudness_label">
-                        <property name="label" translatable="yes">Loudness</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="loudness">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-100</property>
-                                <property name="upper">0</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">loudness_label</relation>
-                        </accessibility>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
-                <child>
-                    <object class="GtkLabel" id="output_label">
-                        <property name="label" translatable="yes">Output</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="output">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-100</property>
-                                <property name="upper">0</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">output_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="link_label">
-                        <property name="label" translatable="yes">Link</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="link">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-100</property>
-                                <property name="upper">0</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">link_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
                 <child>
                     <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
+                        <property name="spacing">12</property>
+                        <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
+                            <object class="GtkGrid">
+                                <property name="halign">center</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">48</property>
+                                <property name="margin-bottom">6</property>
+                                <child>
+                                    <object class="GtkLabel" id="loudness_label">
+                                        <property name="label" translatable="yes">Loudness</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="loudness">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-100</property>
+                                                <property name="upper">0</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">loudness_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="output_label">
+                                        <property name="label" translatable="yes">Output</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="output">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-100</property>
+                                                <property name="upper">0</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">output_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="link_label">
+                                        <property name="label" translatable="yes">Link</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="link">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-100</property>
+                                                <property name="upper">0</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">link_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
                             </object>
                         </child>
+
                         <child>
-                            <object class="GtkScale" id="input_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
                                 <property name="spacing">6</property>
                                 <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
+                                    <object class="GtkBox">
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
                                 <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
                             </object>
                         </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
                         <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="output_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="BassLoudnessBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">MDA Plugins</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="BassLoudnessBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">MDA Plugins</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/compressor.ui
+++ b/data/ui/compressor.ui
@@ -5,1236 +5,1250 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
-
         <child>
-            <object class="GtkStackSwitcher" id="stack_switcher">
-                <property name="halign">center</property>
-                <property name="stack">stack</property>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkStack" id="stack">
-                <property name="margin-top">6</property>
-                <property name="margin-bottom">6</property>
-                <property name="hexpand">1</property>
-                <property name="hhomogeneous">0</property>
-                <property name="vhomogeneous">0</property>
-                <property name="transition-duration">250</property>
-                <property name="transition-type">slide-left-right</property>
-
-                <child>
-                    <object class="GtkStackPage">
-                        <property name="name">page_compressor</property>
-                        <property name="title" translatable="yes">Compressor</property>
-                        <property name="child">
-                            <object class="GtkBox">
-                                <property name="spacing">24</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                    <object class="GtkGrid">
-                                        <property name="halign">center</property>
-                                        <property name="row-spacing">6</property>
-                                        <property name="column-spacing">24</property>
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="label" translatable="yes">Mode</property>
-                                                <layout>
-                                                    <property name="column">0</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkComboBoxText" id="compression_mode">
-                                                <property name="halign">center</property>
-                                                <items>
-                                                    <item id="Downward" translatable="yes">Downward</item>
-                                                    <item id="Upward" translatable="yes">Upward</item>
-                                                    <item id="Boosting" translatable="yes">Boosting</item>
-                                                </items>
-                                                <layout>
-                                                    <property name="column">0</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <property name="label" translatable="yes">Compression Mode</property>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel" id="boost_threshold_label">
-                                                <property name="label" translatable="yes">Boost Threshold</property>
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="boost_threshold">
-                                                <property name="halign">center</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">1</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <binding name="sensitive">
-                                                    <closure type="gboolean" function="set_boost_threshold_sensitive">
-                                                        <lookup name="active-id">compression_mode</lookup>
-                                                    </closure>
-                                                </binding>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">-120</property>
-                                                        <property name="upper">-60</property>
-                                                        <property name="value">-72</property>
-                                                        <property name="step-increment">0.1</property>
-                                                        <property name="page-increment">1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">boost_threshold_label</relation>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel" id="boost_amount_label">
-                                                <property name="label" translatable="yes">Boost Amount</property>
-                                                <layout>
-                                                    <property name="column">2</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="boost_amount">
-                                                <property name="halign">center</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">1</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <binding name="sensitive">
-                                                    <closure type="gboolean" function="set_boost_amount_sensitive">
-                                                        <lookup name="active-id">compression_mode</lookup>
-                                                    </closure>
-                                                </binding>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">0</property>
-                                                        <property name="upper">72</property>
-                                                        <property name="value">6</property>
-                                                        <property name="step-increment">0.1</property>
-                                                        <property name="page-increment">1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">2</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">boost_amount_label</relation>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkGrid">
-                                        <property name="halign">center</property>
-                                        <property name="row-spacing">6</property>
-                                        <property name="column-spacing">12</property>
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="label" translatable="yes">Attack</property>
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="halign">end</property>
-                                                <property name="valign">center</property>
-                                                <property name="label" translatable="yes">Time</property>
-                                                <layout>
-                                                    <property name="column">0</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="halign">end</property>
-                                                <property name="label" translatable="yes">Threshold</property>
-                                                <layout>
-                                                    <property name="column">0</property>
-                                                    <property name="row">2</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="attack">
-                                                <property name="valign">center</property>
-                                                <property name="digits">2</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="upper">2000</property>
-                                                        <property name="value">20</property>
-                                                        <property name="step-increment">0.01</property>
-                                                        <property name="page-increment">0.1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <property name="label" translatable="yes">Attack Time</property>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="threshold">
-                                                <property name="valign">center</property>
-                                                <property name="digits">1</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">-60</property>
-                                                        <property name="value">-12</property>
-                                                        <property name="step-increment">0.1</property>
-                                                        <property name="page-increment">1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">2</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <property name="label" translatable="yes">Attack Threshold</property>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="label" translatable="yes">Release</property>
-                                                <layout>
-                                                    <property name="column">2</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="release">
-                                                <property name="valign">center</property>
-                                                <property name="margin-end">6</property>
-                                                <property name="digits">2</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="upper">5000</property>
-                                                        <property name="value">100</property>
-                                                        <property name="step-increment">0.01</property>
-                                                        <property name="page-increment">0.1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">2</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <property name="label" translatable="yes">Release Time</property>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="release_threshold">
-                                                <property name="valign">center</property>
-                                                <property name="margin-end">6</property>
-                                                <property name="digits">1</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">-100</property>
-                                                        <property name="value">-100</property>
-                                                        <property name="step-increment">0.1</property>
-                                                        <property name="page-increment">1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">2</property>
-                                                    <property name="row">2</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <property name="label" translatable="yes">Release Threshold</property>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel" id="ratio_label">
-                                                <property name="label" translatable="yes">Ratio</property>
-                                                <layout>
-                                                    <property name="column">3</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="ratio">
-                                                <property name="valign">center</property>
-                                                <property name="margin-start">6</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">2</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">1</property>
-                                                        <property name="upper">100</property>
-                                                        <property name="value">4</property>
-                                                        <property name="step-increment">0.01</property>
-                                                        <property name="page-increment">0.1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">3</property>
-                                                    <property name="row">1</property>
-                                                    <property name="row-span">2</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">ratio_label</relation>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel" id="knee_label">
-                                                <property name="label" translatable="yes">Knee</property>
-                                                <layout>
-                                                    <property name="column">4</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="knee">
-                                                <property name="valign">center</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">1</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">-23.9</property>
-                                                        <property name="value">-6</property>
-                                                        <property name="step-increment">0.1</property>
-                                                        <property name="page-increment">1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">4</property>
-                                                    <property name="row">1</property>
-                                                    <property name="row-span">2</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">knee_label</relation>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel" id="makeup_label">
-                                                <property name="label" translatable="yes">Makeup</property>
-                                                <layout>
-                                                    <property name="column">5</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="makeup">
-                                                <property name="valign">center</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">1</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">-60</property>
-                                                        <property name="upper">60</property>
-                                                        <property name="step-increment">0.1</property>
-                                                        <property name="page-increment">1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">5</property>
-                                                    <property name="row">1</property>
-                                                    <property name="row-span">2</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">makeup_label</relation>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel" id="dry_label">
-                                                <property name="label" translatable="yes">Dry Level</property>
-                                                <layout>
-                                                    <property name="column">6</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="dry">
-                                                <property name="valign">center</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">1</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">-100</property>
-                                                        <property name="upper">20</property>
-                                                        <property name="value">-100</property>
-                                                        <property name="step-increment">0.1</property>
-                                                        <property name="page-increment">1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">6</property>
-                                                    <property name="row">1</property>
-                                                    <property name="row-span">2</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">dry_label</relation>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkLabel" id="wet_label">
-                                                <property name="label" translatable="yes">Wet Level</property>
-                                                <layout>
-                                                    <property name="column">7</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="wet">
-                                                <property name="valign">center</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">1</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">-100</property>
-                                                        <property name="upper">20</property>
-                                                        <property name="step-increment">0.1</property>
-                                                        <property name="page-increment">1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">7</property>
-                                                    <property name="row">1</property>
-                                                    <property name="row-span">2</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">wet_label</relation>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-                            </object>
-                        </property>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
                 <child>
-                    <object class="GtkStackPage">
-                        <property name="name">page_sidechain</property>
-                        <property name="title" translatable="yes">Sidechain</property>
-                        <property name="child">
-                            <object class="GtkBox">
+                    <object class="GtkBox">
+                        <property name="spacing">12</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                            <object class="GtkStackSwitcher" id="stack_switcher">
                                 <property name="halign">center</property>
-                                <property name="spacing">24</property>
-                                <property name="orientation">vertical</property>
+                                <property name="stack">stack</property>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkStack" id="stack">
+                                <property name="margin-top">6</property>
+                                <property name="margin-bottom">6</property>
+                                <property name="hexpand">1</property>
+                                <property name="hhomogeneous">0</property>
+                                <property name="vhomogeneous">0</property>
+                                <property name="transition-duration">250</property>
+                                <property name="transition-type">slide-left-right</property>
 
                                 <child>
-                                    <object class="GtkBox">
-                                        <property name="halign">center</property>
-                                        <property name="homogeneous">1</property>
-                                        <property name="spacing">24</property>
-                                        <child>
+                                    <object class="GtkStackPage">
+                                        <property name="name">page_compressor</property>
+                                        <property name="title" translatable="yes">Compressor</property>
+                                        <property name="child">
+                                            <object class="GtkBox">
+                                                <property name="spacing">24</property>
+                                                <property name="orientation">vertical</property>
+                                                <child>
+                                                    <object class="GtkGrid">
+                                                        <property name="halign">center</property>
+                                                        <property name="row-spacing">6</property>
+                                                        <property name="column-spacing">24</property>
+                                                        <child>
+                                                            <object class="GtkLabel">
+                                                                <property name="label" translatable="yes">Mode</property>
+                                                                <layout>
+                                                                    <property name="column">0</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkComboBoxText" id="compression_mode">
+                                                                <property name="halign">center</property>
+                                                                <items>
+                                                                    <item id="Downward" translatable="yes">Downward</item>
+                                                                    <item id="Upward" translatable="yes">Upward</item>
+                                                                    <item id="Boosting" translatable="yes">Boosting</item>
+                                                                </items>
+                                                                <layout>
+                                                                    <property name="column">0</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <property name="label" translatable="yes">Compression Mode</property>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkLabel" id="boost_threshold_label">
+                                                                <property name="label" translatable="yes">Boost Threshold</property>
+                                                                <layout>
+                                                                    <property name="column">1</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="boost_threshold">
+                                                                <property name="halign">center</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">1</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <binding name="sensitive">
+                                                                    <closure type="gboolean" function="set_boost_threshold_sensitive">
+                                                                        <lookup name="active-id">compression_mode</lookup>
+                                                                    </closure>
+                                                                </binding>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-120</property>
+                                                                        <property name="upper">-60</property>
+                                                                        <property name="value">-72</property>
+                                                                        <property name="step-increment">0.1</property>
+                                                                        <property name="page-increment">1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">1</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">boost_threshold_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkLabel" id="boost_amount_label">
+                                                                <property name="label" translatable="yes">Boost Amount</property>
+                                                                <layout>
+                                                                    <property name="column">2</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="boost_amount">
+                                                                <property name="halign">center</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">1</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <binding name="sensitive">
+                                                                    <closure type="gboolean" function="set_boost_amount_sensitive">
+                                                                        <lookup name="active-id">compression_mode</lookup>
+                                                                    </closure>
+                                                                </binding>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">0</property>
+                                                                        <property name="upper">72</property>
+                                                                        <property name="value">6</property>
+                                                                        <property name="step-increment">0.1</property>
+                                                                        <property name="page-increment">1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">2</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">boost_amount_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkGrid">
+                                                        <property name="halign">center</property>
+                                                        <property name="row-spacing">6</property>
+                                                        <property name="column-spacing">12</property>
+                                                        <child>
+                                                            <object class="GtkLabel">
+                                                                <property name="label" translatable="yes">Attack</property>
+                                                                <layout>
+                                                                    <property name="column">1</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkLabel">
+                                                                <property name="halign">end</property>
+                                                                <property name="valign">center</property>
+                                                                <property name="label" translatable="yes">Time</property>
+                                                                <layout>
+                                                                    <property name="column">0</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkLabel">
+                                                                <property name="halign">end</property>
+                                                                <property name="label" translatable="yes">Threshold</property>
+                                                                <layout>
+                                                                    <property name="column">0</property>
+                                                                    <property name="row">2</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="attack">
+                                                                <property name="valign">center</property>
+                                                                <property name="digits">2</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="upper">2000</property>
+                                                                        <property name="value">20</property>
+                                                                        <property name="step-increment">0.01</property>
+                                                                        <property name="page-increment">0.1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">1</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <property name="label" translatable="yes">Attack Time</property>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="threshold">
+                                                                <property name="valign">center</property>
+                                                                <property name="digits">1</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-60</property>
+                                                                        <property name="value">-12</property>
+                                                                        <property name="step-increment">0.1</property>
+                                                                        <property name="page-increment">1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">1</property>
+                                                                    <property name="row">2</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <property name="label" translatable="yes">Attack Threshold</property>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkLabel">
+                                                                <property name="label" translatable="yes">Release</property>
+                                                                <layout>
+                                                                    <property name="column">2</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="release">
+                                                                <property name="valign">center</property>
+                                                                <property name="margin-end">6</property>
+                                                                <property name="digits">2</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="upper">5000</property>
+                                                                        <property name="value">100</property>
+                                                                        <property name="step-increment">0.01</property>
+                                                                        <property name="page-increment">0.1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">2</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <property name="label" translatable="yes">Release Time</property>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="release_threshold">
+                                                                <property name="valign">center</property>
+                                                                <property name="margin-end">6</property>
+                                                                <property name="digits">1</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-100</property>
+                                                                        <property name="value">-100</property>
+                                                                        <property name="step-increment">0.1</property>
+                                                                        <property name="page-increment">1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">2</property>
+                                                                    <property name="row">2</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <property name="label" translatable="yes">Release Threshold</property>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkLabel" id="ratio_label">
+                                                                <property name="label" translatable="yes">Ratio</property>
+                                                                <layout>
+                                                                    <property name="column">3</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="ratio">
+                                                                <property name="valign">center</property>
+                                                                <property name="margin-start">6</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">2</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">1</property>
+                                                                        <property name="upper">100</property>
+                                                                        <property name="value">4</property>
+                                                                        <property name="step-increment">0.01</property>
+                                                                        <property name="page-increment">0.1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">3</property>
+                                                                    <property name="row">1</property>
+                                                                    <property name="row-span">2</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">ratio_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkLabel" id="knee_label">
+                                                                <property name="label" translatable="yes">Knee</property>
+                                                                <layout>
+                                                                    <property name="column">4</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="knee">
+                                                                <property name="valign">center</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">1</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-23.9</property>
+                                                                        <property name="value">-6</property>
+                                                                        <property name="step-increment">0.1</property>
+                                                                        <property name="page-increment">1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">4</property>
+                                                                    <property name="row">1</property>
+                                                                    <property name="row-span">2</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">knee_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkLabel" id="makeup_label">
+                                                                <property name="label" translatable="yes">Makeup</property>
+                                                                <layout>
+                                                                    <property name="column">5</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="makeup">
+                                                                <property name="valign">center</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">1</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-60</property>
+                                                                        <property name="upper">60</property>
+                                                                        <property name="step-increment">0.1</property>
+                                                                        <property name="page-increment">1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">5</property>
+                                                                    <property name="row">1</property>
+                                                                    <property name="row-span">2</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">makeup_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkLabel" id="dry_label">
+                                                                <property name="label" translatable="yes">Dry Level</property>
+                                                                <layout>
+                                                                    <property name="column">6</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="dry">
+                                                                <property name="valign">center</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">1</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-100</property>
+                                                                        <property name="upper">20</property>
+                                                                        <property name="value">-100</property>
+                                                                        <property name="step-increment">0.1</property>
+                                                                        <property name="page-increment">1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">6</property>
+                                                                    <property name="row">1</property>
+                                                                    <property name="row-span">2</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">dry_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkLabel" id="wet_label">
+                                                                <property name="label" translatable="yes">Wet Level</property>
+                                                                <layout>
+                                                                    <property name="column">7</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="wet">
+                                                                <property name="valign">center</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">1</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-100</property>
+                                                                        <property name="upper">20</property>
+                                                                        <property name="step-increment">0.1</property>
+                                                                        <property name="page-increment">1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">7</property>
+                                                                    <property name="row">1</property>
+                                                                    <property name="row-span">2</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">wet_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkStackPage">
+                                        <property name="name">page_sidechain</property>
+                                        <property name="title" translatable="yes">Sidechain</property>
+                                        <property name="child">
+                                            <object class="GtkBox">
+                                                <property name="halign">center</property>
+                                                <property name="spacing">24</property>
+                                                <property name="orientation">vertical</property>
+
+                                                <child>
+                                                    <object class="GtkBox">
+                                                        <property name="halign">center</property>
+                                                        <property name="homogeneous">1</property>
+                                                        <property name="spacing">24</property>
+                                                        <child>
+                                                            <object class="GtkGrid">
+                                                                <property name="row-spacing">6</property>
+                                                                <property name="column-spacing">18</property>
+                                                                <property name="column-homogeneous">1</property>
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">Mode</property>
+                                                                        <layout>
+                                                                            <property name="column">0</property>
+                                                                            <property name="row">0</property>
+                                                                        </layout>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkComboBoxText" id="sidechain_mode">
+                                                                        <items>
+                                                                            <item translatable="yes" id="Peak">Peak</item>
+                                                                            <item translatable="yes" id="RMS">RMS</item>
+                                                                            <item translatable="yes" id="Low-Pass">Low-Pass</item>
+                                                                            <item translatable="yes" id="Uniform">Uniform</item>
+                                                                        </items>
+                                                                        <layout>
+                                                                            <property name="column">0</property>
+                                                                            <property name="row">1</property>
+                                                                        </layout>
+                                                                        <accessibility>
+                                                                            <property name="label" translatable="yes">Sidechain Mode</property>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkToggleButton" id="listen">
+                                                                        <property name="halign">center</property>
+                                                                        <property name="label" translatable="yes">Listen</property>
+                                                                        <layout>
+                                                                            <property name="column">1</property>
+                                                                            <property name="row">1</property>
+                                                                        </layout>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">Source</property>
+                                                                        <layout>
+                                                                            <property name="column">2</property>
+                                                                            <property name="row">0</property>
+                                                                        </layout>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkComboBoxText" id="sidechain_source">
+                                                                        <items>
+                                                                            <item translatable="yes" id="Middle">Middle</item>
+                                                                            <item translatable="yes" id="Side">Side</item>
+                                                                            <item translatable="yes" id="Left">Left</item>
+                                                                            <item translatable="yes" id="Right">Right</item>
+                                                                        </items>
+                                                                        <layout>
+                                                                            <property name="column">2</property>
+                                                                            <property name="row">1</property>
+                                                                        </layout>
+                                                                        <accessibility>
+                                                                            <property name="label" translatable="yes">Sidechain Source</property>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkGrid">
+                                                        <property name="halign">center</property>
+                                                        <property name="row-spacing">6</property>
+                                                        <property name="column-spacing">12</property>
+
+                                                        <child>
+                                                            <object class="GtkLabel">
+                                                                <property name="label" translatable="yes">Input</property>
+                                                                <layout>
+                                                                    <property name="column">1</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkLabel">
+                                                                <property name="halign">end</property>
+                                                                <property name="valign">center</property>
+                                                                <property name="label" translatable="yes">Type</property>
+                                                                <layout>
+                                                                    <property name="column">0</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkLabel">
+                                                                <property name="halign">end</property>
+                                                                <property name="valign">center</property>
+                                                                <property name="label" translatable="yes">Device</property>
+                                                                <layout>
+                                                                    <property name="column">0</property>
+                                                                    <property name="row">2</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkComboBoxText" id="sidechain_type">
+                                                                <property name="valign">center</property>
+                                                                <property name="margin-end">6</property>
+                                                                <items>
+                                                                    <item id="Feed-forward" translatable="yes">Feed-forward</item>
+                                                                    <item id="Feed-back" translatable="yes">Feed-back</item>
+                                                                    <item id="External" translatable="yes">External</item>
+                                                                </items>
+                                                                <layout>
+                                                                    <property name="column">1</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <property name="label" translatable="yes">Sidechain Type</property>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkDropDown" id="dropdown_input_devices">
+                                                                <property name="valign">center</property>
+                                                                <property name="margin-end">6</property>
+
+                                                                <binding name="sensitive">
+                                                                    <closure type="gboolean" function="set_dropdown_sensitive">
+                                                                        <lookup name="active-id">sidechain_type</lookup>
+                                                                    </closure>
+                                                                </binding>
+
+                                                                <property name="factory">
+                                                                    <object class="GtkBuilderListItemFactory">
+                                                                        <property name="resource">/com/github/wwmm/easyeffects/ui/factory_input_device_dropdown.ui</property>
+                                                                    </object>
+                                                                </property>
+
+                                                                <layout>
+                                                                    <property name="column">1</property>
+                                                                    <property name="row">2</property>
+                                                                </layout>
+
+                                                                <accessibility>
+                                                                    <property name="label" translatable="yes">Input Device</property>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+
+
+                                                        <child>
+                                                            <object class="GtkLabel" id="preamp_label">
+                                                                <property name="label" translatable="yes">PreAmplification</property>
+                                                                <layout>
+                                                                    <property name="column">2</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="preamp">
+                                                                <property name="halign">center</property>
+                                                                <property name="margin-start">6</property>
+                                                                <property name="margin-end">6</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">1</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-120</property>
+                                                                        <property name="upper">40</property>
+                                                                        <property name="step-increment">0.1</property>
+                                                                        <property name="page-increment">1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">2</property>
+                                                                    <property name="row">1</property>
+                                                                    <property name="row-span">2</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">preamp_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkLabel" id="reactivity_label">
+                                                                <property name="label" translatable="yes">Reactivity</property>
+                                                                <layout>
+                                                                    <property name="column">3</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="reactivity">
+                                                                <property name="halign">center</property>
+                                                                <property name="margin-start">6</property>
+                                                                <property name="margin-end">6</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">2</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="upper">250</property>
+                                                                        <property name="value">10</property>
+                                                                        <property name="step-increment">0.01</property>
+                                                                        <property name="page-increment">0.1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">3</property>
+                                                                    <property name="row">1</property>
+                                                                    <property name="row-span">2</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">reactivity_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkLabel" id="lookahead_label">
+                                                                <property name="label" translatable="yes">Lookahead</property>
+                                                                <layout>
+                                                                    <property name="column">4</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="lookahead">
+                                                                <property name="halign">center</property>
+                                                                <property name="margin-start">6</property>
+                                                                <property name="margin-end">6</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">2</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="upper">20</property>
+                                                                        <property name="step-increment">0.01</property>
+                                                                        <property name="page-increment">0.1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">4</property>
+                                                                    <property name="row">1</property>
+                                                                    <property name="row-span">2</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">lookahead_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkStackPage">
+                                        <property name="name">page_sidechain_filters</property>
+                                        <property name="title" translatable="yes">Sidechain Filters</property>
+                                        <property name="child">
                                             <object class="GtkGrid">
+                                                <property name="halign">center</property>
                                                 <property name="row-spacing">6</property>
-                                                <property name="column-spacing">18</property>
-                                                <property name="column-homogeneous">1</property>
+                                                <property name="column-spacing">12</property>
+                                                <property name="margin-top">12</property>
+                                                <property name="margin-bottom">12</property>
                                                 <child>
                                                     <object class="GtkLabel">
-                                                        <property name="label" translatable="yes">Mode</property>
+                                                        <property name="label" translatable="yes">High-Pass</property>
                                                         <layout>
-                                                            <property name="column">0</property>
+                                                            <property name="column">1</property>
                                                             <property name="row">0</property>
                                                         </layout>
                                                     </object>
                                                 </child>
+
                                                 <child>
-                                                    <object class="GtkComboBoxText" id="sidechain_mode">
-                                                        <items>
-                                                            <item translatable="yes" id="Peak">Peak</item>
-                                                            <item translatable="yes" id="RMS">RMS</item>
-                                                            <item translatable="yes" id="Low-Pass">Low-Pass</item>
-                                                            <item translatable="yes" id="Uniform">Uniform</item>
-                                                        </items>
+                                                    <object class="GtkLabel">
+                                                        <property name="halign">end</property>
+                                                        <property name="valign">center</property>
+                                                        <property name="margin-bottom">6</property>
+                                                        <property name="label" translatable="yes">Mode</property>
                                                         <layout>
                                                             <property name="column">0</property>
                                                             <property name="row">1</property>
                                                         </layout>
-                                                        <accessibility>
-                                                            <property name="label" translatable="yes">Sidechain Mode</property>
-                                                        </accessibility>
                                                     </object>
                                                 </child>
 
                                                 <child>
-                                                    <object class="GtkToggleButton" id="listen">
-                                                        <property name="halign">center</property>
-                                                        <property name="label" translatable="yes">Listen</property>
+                                                    <object class="GtkLabel">
+                                                        <property name="halign">end</property>
+                                                        <property name="valign">center</property>
+                                                        <property name="margin-top">6</property>
+                                                        <property name="label" translatable="yes">Frequency</property>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">2</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkComboBoxText" id="hpf_mode">
+                                                        <property name="margin-bottom">6</property>
+                                                        <property name="margin-end">6</property>
+                                                        <items>
+                                                            <item translatable="yes" id="off">Off</item>
+                                                            <item translatable="yes" id="12 dB/oct">12 dB/oct</item>
+                                                            <item translatable="yes" id="24 dB/oct">24 dB/oct</item>
+                                                            <item translatable="yes" id="36 dB/oct">36 dB/oct</item>
+                                                        </items>
                                                         <layout>
                                                             <property name="column">1</property>
                                                             <property name="row">1</property>
                                                         </layout>
+                                                        <accessibility>
+                                                            <property name="label" translatable="yes">High-Pass Filter Mode</property>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkSpinButton" id="hpf_freq">
+                                                        <property name="margin-top">6</property>
+                                                        <property name="margin-end">6</property>
+                                                        <property name="digits">0</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">10</property>
+                                                                <property name="upper">20000</property>
+                                                                <property name="value">10</property>
+                                                                <property name="step-increment">1</property>
+                                                                <property name="page-increment">100</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">2</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <property name="label" translatable="yes">High-Pass Filter Frequency</property>
+                                                        </accessibility>
                                                     </object>
                                                 </child>
 
                                                 <child>
                                                     <object class="GtkLabel">
-                                                        <property name="label" translatable="yes">Source</property>
+                                                        <property name="label" translatable="yes">Low-Pass</property>
                                                         <layout>
                                                             <property name="column">2</property>
                                                             <property name="row">0</property>
                                                         </layout>
                                                     </object>
                                                 </child>
+
                                                 <child>
-                                                    <object class="GtkComboBoxText" id="sidechain_source">
+                                                    <object class="GtkComboBoxText" id="lpf_mode">
+                                                        <property name="margin-bottom">6</property>
+                                                        <property name="margin-start">6</property>
                                                         <items>
-                                                            <item translatable="yes" id="Middle">Middle</item>
-                                                            <item translatable="yes" id="Side">Side</item>
-                                                            <item translatable="yes" id="Left">Left</item>
-                                                            <item translatable="yes" id="Right">Right</item>
+                                                            <item translatable="yes" id="off">Off</item>
+                                                            <item translatable="yes" id="12 dB/oct">12 dB/oct</item>
+                                                            <item translatable="yes" id="24 dB/oct">24 dB/oct</item>
+                                                            <item translatable="yes" id="36 dB/oct">36 dB/oct</item>
                                                         </items>
                                                         <layout>
                                                             <property name="column">2</property>
                                                             <property name="row">1</property>
                                                         </layout>
                                                         <accessibility>
-                                                            <property name="label" translatable="yes">Sidechain Source</property>
+                                                            <property name="label" translatable="yes">Low-Pass Filter Mode</property>
                                                         </accessibility>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkSpinButton" id="lpf_freq">
+                                                        <property name="margin-top">6</property>
+                                                        <property name="margin-start">6</property>
+                                                        <property name="digits">0</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">10</property>
+                                                                <property name="upper">20000</property>
+                                                                <property name="value">20000</property>
+                                                                <property name="step-increment">1</property>
+                                                                <property name="page-increment">100</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">2</property>
+                                                            <property name="row">2</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <property name="label" translatable="yes">High-Pass Filter Frequency</property>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="margin-top">4</property>
+                                <property name="margin-bottom">4</property>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <child>
+                                            <object class="GtkLabel" id="gain_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Gain</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="gain_label">
+                                                <property name="width-chars">6</property>
+                                                <property name="label">0</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">start</property>
+                                                <property name="label">db</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <child>
+                                            <object class="GtkLabel" id="envelope_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Envelope</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="envelope_label">
+                                                <property name="width-chars">6</property>
+                                                <property name="label">0</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">start</property>
+                                                <property name="label">db</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <child>
+                                            <object class="GtkLabel" id="sidechain_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Sidechain</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="sidechain_label">
+                                                <property name="width-chars">6</property>
+                                                <property name="label">0</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">start</property>
+                                                <property name="label">db</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <child>
+                                            <object class="GtkLabel" id="curve_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Curve</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="curve_label">
+                                                <property name="width-chars">6</property>
+                                                <property name="label">0</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">start</property>
+                                                <property name="label">db</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
                                                     </object>
                                                 </child>
                                             </object>
                                         </child>
                                     </object>
                                 </child>
+                            </object>
+                        </child>
 
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
                                 <child>
-                                    <object class="GtkGrid">
-                                        <property name="halign">center</property>
-                                        <property name="row-spacing">6</property>
-                                        <property name="column-spacing">12</property>
-
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
                                         <child>
-                                            <object class="GtkLabel">
-                                                <property name="label" translatable="yes">Input</property>
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel">
+                                            <object class="GtkLabel" id="output_level_title">
                                                 <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
                                                 <property name="valign">center</property>
-                                                <property name="label" translatable="yes">Type</property>
-                                                <layout>
-                                                    <property name="column">0</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="halign">end</property>
-                                                <property name="valign">center</property>
-                                                <property name="label" translatable="yes">Device</property>
-                                                <layout>
-                                                    <property name="column">0</property>
-                                                    <property name="row">2</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkComboBoxText" id="sidechain_type">
-                                                <property name="valign">center</property>
-                                                <property name="margin-end">6</property>
-                                                <items>
-                                                    <item id="Feed-forward" translatable="yes">Feed-forward</item>
-                                                    <item id="Feed-back" translatable="yes">Feed-back</item>
-                                                    <item id="External" translatable="yes">External</item>
-                                                </items>
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <property name="label" translatable="yes">Sidechain Type</property>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkDropDown" id="dropdown_input_devices">
-                                                <property name="valign">center</property>
-                                                <property name="margin-end">6</property>
-
-                                                <binding name="sensitive">
-                                                    <closure type="gboolean" function="set_dropdown_sensitive">
-                                                        <lookup name="active-id">sidechain_type</lookup>
-                                                    </closure>
-                                                </binding>
-
-                                                <property name="factory">
-                                                    <object class="GtkBuilderListItemFactory">
-                                                        <property name="resource">/com/github/wwmm/easyeffects/ui/factory_input_device_dropdown.ui</property>
-                                                    </object>
-                                                </property>
-
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">2</property>
-                                                </layout>
-
-                                                <accessibility>
-                                                    <property name="label" translatable="yes">Input Device</property>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-
-
-                                        <child>
-                                            <object class="GtkLabel" id="preamp_label">
-                                                <property name="label" translatable="yes">PreAmplification</property>
-                                                <layout>
-                                                    <property name="column">2</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="preamp">
-                                                <property name="halign">center</property>
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">6</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">1</property>
-                                                <property name="update-policy">if-valid</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
-                                                        <property name="lower">-120</property>
-                                                        <property name="upper">40</property>
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
                                                         <property name="step-increment">0.1</property>
                                                         <property name="page-increment">1</property>
                                                     </object>
                                                 </property>
-                                                <layout>
-                                                    <property name="column">2</property>
-                                                    <property name="row">1</property>
-                                                    <property name="row-span">2</property>
-                                                </layout>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
                                                 <accessibility>
-                                                    <relation name="labelled-by">preamp_label</relation>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
                                                 </accessibility>
                                             </object>
                                         </child>
-
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
                                         <child>
-                                            <object class="GtkLabel" id="reactivity_label">
-                                                <property name="label" translatable="yes">Reactivity</property>
-                                                <layout>
-                                                    <property name="column">3</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="reactivity">
-                                                <property name="halign">center</property>
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">6</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">2</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="upper">250</property>
-                                                        <property name="value">10</property>
-                                                        <property name="step-increment">0.01</property>
-                                                        <property name="page-increment">0.1</property>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
                                                     </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">3</property>
-                                                    <property name="row">1</property>
-                                                    <property name="row-span">2</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">reactivity_label</relation>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel" id="lookahead_label">
-                                                <property name="label" translatable="yes">Lookahead</property>
-                                                <layout>
-                                                    <property name="column">4</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="lookahead">
-                                                <property name="halign">center</property>
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">6</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">2</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="upper">20</property>
-                                                        <property name="step-increment">0.01</property>
-                                                        <property name="page-increment">0.1</property>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
                                                     </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">4</property>
-                                                    <property name="row">1</property>
-                                                    <property name="row-span">2</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">lookahead_label</relation>
-                                                </accessibility>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
                                             </object>
                                         </child>
                                     </object>
                                 </child>
                             </object>
-                        </property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkStackPage">
-                        <property name="name">page_sidechain_filters</property>
-                        <property name="title" translatable="yes">Sidechain Filters</property>
-                        <property name="child">
-                            <object class="GtkGrid">
-                                <property name="halign">center</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">12</property>
-                                <property name="margin-top">12</property>
-                                <property name="margin-bottom">12</property>
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="label" translatable="yes">High-Pass</property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                        <property name="margin-bottom">6</property>
-                                        <property name="label" translatable="yes">Mode</property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                        <property name="margin-top">6</property>
-                                        <property name="label" translatable="yes">Frequency</property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">2</property>
-                                        </layout>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkComboBoxText" id="hpf_mode">
-                                        <property name="margin-bottom">6</property>
-                                        <property name="margin-end">6</property>
-                                        <items>
-                                            <item translatable="yes" id="off">Off</item>
-                                            <item translatable="yes" id="12 dB/oct">12 dB/oct</item>
-                                            <item translatable="yes" id="24 dB/oct">24 dB/oct</item>
-                                            <item translatable="yes" id="36 dB/oct">36 dB/oct</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <property name="label" translatable="yes">High-Pass Filter Mode</property>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkSpinButton" id="hpf_freq">
-                                        <property name="margin-top">6</property>
-                                        <property name="margin-end">6</property>
-                                        <property name="digits">0</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">10</property>
-                                                <property name="upper">20000</property>
-                                                <property name="value">10</property>
-                                                <property name="step-increment">1</property>
-                                                <property name="page-increment">100</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">2</property>
-                                        </layout>
-                                        <accessibility>
-                                            <property name="label" translatable="yes">High-Pass Filter Frequency</property>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="label" translatable="yes">Low-Pass</property>
-                                        <layout>
-                                            <property name="column">2</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkComboBoxText" id="lpf_mode">
-                                        <property name="margin-bottom">6</property>
-                                        <property name="margin-start">6</property>
-                                        <items>
-                                            <item translatable="yes" id="off">Off</item>
-                                            <item translatable="yes" id="12 dB/oct">12 dB/oct</item>
-                                            <item translatable="yes" id="24 dB/oct">24 dB/oct</item>
-                                            <item translatable="yes" id="36 dB/oct">36 dB/oct</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">2</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <property name="label" translatable="yes">Low-Pass Filter Mode</property>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkSpinButton" id="lpf_freq">
-                                        <property name="margin-top">6</property>
-                                        <property name="margin-start">6</property>
-                                        <property name="digits">0</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">10</property>
-                                                <property name="upper">20000</property>
-                                                <property name="value">20000</property>
-                                                <property name="step-increment">1</property>
-                                                <property name="page-increment">100</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">2</property>
-                                            <property name="row">2</property>
-                                        </layout>
-                                        <accessibility>
-                                            <property name="label" translatable="yes">High-Pass Filter Frequency</property>
-                                        </accessibility>
-                                    </object>
-                                </child>
-                            </object>
-                        </property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="margin-top">4</property>
-                <property name="margin-bottom">4</property>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">center</property>
-                        <child>
-                            <object class="GtkLabel" id="gain_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Gain</property>
-                            </object>
                         </child>
 
                         <child>
-                            <object class="GtkLabel" id="gain_label">
-                                <property name="width-chars">6</property>
-                                <property name="label">0</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">start</property>
-                                <property name="label">db</property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">center</property>
-                        <child>
-                            <object class="GtkLabel" id="envelope_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Envelope</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel" id="envelope_label">
-                                <property name="width-chars">6</property>
-                                <property name="label">0</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">start</property>
-                                <property name="label">db</property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">center</property>
-                        <child>
-                            <object class="GtkLabel" id="sidechain_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Sidechain</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel" id="sidechain_label">
-                                <property name="width-chars">6</property>
-                                <property name="label">0</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">start</property>
-                                <property name="label">db</property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">center</property>
-                        <child>
-                            <object class="GtkLabel" id="curve_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Curve</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel" id="curve_label">
-                                <property name="width-chars">6</property>
-                                <property name="label">0</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">start</property>
-                                <property name="label">db</property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="CompressorBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Linux Studio Plugins</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="output_gain">
-                                <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="CompressorBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">Linux Studio Plugins</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/convolver.ui
+++ b/data/ui/convolver.ui
@@ -5,404 +5,418 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
-
         <child>
-            <object class="GtkLabel" id="label_file_name">
-                <property name="wrap">1</property>
-                <property name="wrap-mode">word-char</property>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox" id="chart_box">
-                <property name="spacing">12</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="homogeneous">1</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkCheckButton" id="check_left">
-                                <property name="valign">end</property>
-                                <property name="halign">center</property>
-                                <property name="active">1</property>
-                                <property name="label" translatable="yes">L</property>
-                                <signal name="toggled" handler="on_show_channel" object="ConvolverBox" />
-                                <accessibility>
-                                    <property name="label" translatable="yes">Left Channel</property>
-                                </accessibility>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkCheckButton" id="check_right">
-                                <property name="valign">start</property>
-                                <property name="halign">center</property>
-                                <property name="group">check_left</property>
-                                <property name="label" translatable="yes">R</property>
-                                <signal name="toggled" handler="on_show_channel" object="ConvolverBox" />
-                                <accessibility>
-                                    <property name="label" translatable="yes">Right Channel</property>
-                                </accessibility>
-                            </object>
-                        </child>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
                 <child>
                     <object class="GtkBox">
-                        <property name="spacing">6</property>
+                        <property name="spacing">12</property>
                         <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkMenuButton" id="menu_button_impulses">
-                                <property name="valign">center</property>
-                                <property name="direction">left</property>
-                                <property name="label" translatable="yes">Impulses</property>
+                            <object class="GtkLabel" id="label_file_name">
+                                <property name="wrap">1</property>
+                                <property name="wrap-mode">word-char</property>
                             </object>
                         </child>
 
                         <child>
-                            <object class="GtkMenuButton" id="menu_button_combine">
-                                <property name="valign">center</property>
-                                <property name="direction">left</property>
-                                <property name="label" translatable="yes">Combine</property>
-                            </object>
-                        </child>
+                            <object class="GtkBox" id="chart_box">
+                                <property name="spacing">12</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="homogeneous">1</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkCheckButton" id="check_left">
+                                                <property name="valign">end</property>
+                                                <property name="halign">center</property>
+                                                <property name="active">1</property>
+                                                <property name="label" translatable="yes">L</property>
+                                                <signal name="toggled" handler="on_show_channel" object="ConvolverBox" />
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Left Channel</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
 
-                        <child>
-                            <object class="GtkLabel" id="ir_width_label">
-                                <property name="margin-top">12</property>
-                                <property name="label" translatable="yes">Stereo Width</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkSpinButton" id="ir_width">
-                                <property name="halign">center</property>
-                                <property name="orientation">vertical</property>
-                                <property name="width-chars">10</property>
-                                <property name="digits">0</property>
-                                <property name="update-policy">if-valid</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="upper">200</property>
-                                        <property name="value">100</property>
-                                        <property name="step-increment">1</property>
-                                        <property name="page-increment">10</property>
+                                        <child>
+                                            <object class="GtkCheckButton" id="check_right">
+                                                <property name="valign">start</property>
+                                                <property name="halign">center</property>
+                                                <property name="group">check_left</property>
+                                                <property name="label" translatable="yes">R</property>
+                                                <signal name="toggled" handler="on_show_channel" object="ConvolverBox" />
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Right Channel</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
-                                </property>
-                                <accessibility>
-                                    <relation name="labelled-by">ir_width_label</relation>
-                                </accessibility>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="spacing">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkMenuButton" id="menu_button_impulses">
+                                                <property name="valign">center</property>
+                                                <property name="direction">left</property>
+                                                <property name="label" translatable="yes">Impulses</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkMenuButton" id="menu_button_combine">
+                                                <property name="valign">center</property>
+                                                <property name="direction">left</property>
+                                                <property name="label" translatable="yes">Combine</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="ir_width_label">
+                                                <property name="margin-top">12</property>
+                                                <property name="label" translatable="yes">Stereo Width</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkSpinButton" id="ir_width">
+                                                <property name="halign">center</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">0</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="upper">200</property>
+                                                        <property name="value">100</property>
+                                                        <property name="step-increment">1</property>
+                                                        <property name="page-increment">10</property>
+                                                    </object>
+                                                </property>
+                                                <accessibility>
+                                                    <relation name="labelled-by">ir_width_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkToggleButton" id="show_fft">
+                                                <property name="valign">center</property>
+                                                <property name="label" translatable="yes">Spectrum</property>
+                                                <signal name="toggled" handler="on_show_fft" object="ConvolverBox" />
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkToggleButton" id="enable_log_scale">
+                                                <property name="halign">center</property>
+                                                <property name="label" translatable="yes">Log Scale</property>
+                                                <property name="visible" bind-source="show_fft" bind-property="active" bind-flags="sync-create" />
+                                                <signal name="toggled" handler="on_enable_log_scale" object="ConvolverBox" />
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkToggleButton" id="autogain">
+                                                <property name="margin-top">12</property>
+                                                <property name="valign">center</property>
+                                                <property name="label" translatable="yes">Autogain</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
                             </object>
                         </child>
 
                         <child>
-                            <object class="GtkToggleButton" id="show_fft">
-                                <property name="valign">center</property>
-                                <property name="label" translatable="yes">Spectrum</property>
-                                <signal name="toggled" handler="on_show_fft" object="ConvolverBox" />
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkToggleButton" id="enable_log_scale">
+                            <object class="GtkGrid">
                                 <property name="halign">center</property>
-                                <property name="label" translatable="yes">Log Scale</property>
-                                <property name="visible" bind-source="show_fft" bind-property="active" bind-flags="sync-create" />
-                                <signal name="toggled" handler="on_enable_log_scale" object="ConvolverBox" />
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkToggleButton" id="autogain">
-                                <property name="margin-top">12</property>
                                 <property name="valign">center</property>
-                                <property name="label" translatable="yes">Autogain</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">48</property>
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="label" translatable="yes">Rate</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkLabel" id="label_sampling_rate">
+                                        <style>
+                                            <class name="dim-label" />
+                                        </style>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="label" translatable="yes">Samples</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkLabel" id="label_samples">
+                                        <style>
+                                            <class name="dim-label" />
+                                        </style>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="label" translatable="yes">Duration</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkLabel" id="label_duration">
+                                        <style>
+                                            <class name="dim-label" />
+                                        </style>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
                             </object>
                         </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkGrid">
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">48</property>
-                <child>
-                    <object class="GtkLabel">
-                        <property name="label" translatable="yes">Rate</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkLabel" id="label_sampling_rate">
-                        <style>
-                            <class name="dim-label" />
-                        </style>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel">
-                        <property name="label" translatable="yes">Samples</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkLabel" id="label_samples">
-                        <style>
-                            <class name="dim-label" />
-                        </style>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel">
-                        <property name="label" translatable="yes">Duration</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkLabel" id="label_duration">
-                        <style>
-                            <class name="dim-label" />
-                        </style>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
                         <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
                                 <property name="spacing">6</property>
                                 <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
+                                    <object class="GtkBox">
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
                                 <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
                             </object>
                         </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
                         <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="output_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="ConvolverBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Zita-convolver</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="ConvolverBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">Zita-convolver</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/crossfeed.ui
+++ b/data/ui/crossfeed.ui
@@ -5,321 +5,335 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
-
         <child>
-            <object class="GtkBox">
-                <property name="halign">center</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">48</property>
-                <child>
-                    <object class="GtkButton" id="preset_cmoy">
-                        <property name="label">Cmoy</property>
-                        <signal name="clicked" handler="on_preset_cmoy" object="CrossfeedBox" />
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
-                <child>
-                    <object class="GtkButton" id="preset_default">
-                        <property name="label" translatable="yes">Default</property>
-                        <signal name="clicked" handler="on_preset_default" object="CrossfeedBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkButton" id="preset_jmeier">
-                        <property name="label">Jmeier</property>
-                        <signal name="clicked" handler="on_preset_jmeier" object="CrossfeedBox" />
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkGrid">
-                <property name="margin-bottom">6</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">48</property>
-                <child>
-                    <object class="GtkLabel" id="fcut_label">
-                        <property name="label" translatable="yes">Cutoff</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="fcut">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">0</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">300</property>
-                                <property name="upper">2000</property>
-                                <property name="value">700</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">10</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">fcut_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="feed_label">
-                        <property name="label" translatable="yes">Feed</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="feed">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">1</property>
-                                <property name="upper">15</property>
-                                <property name="value">4.5</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">feed_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
                 <child>
                     <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
+                        <property name="spacing">12</property>
+                        <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
+                            <object class="GtkBox">
+                                <property name="halign">center</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">48</property>
+                                <child>
+                                    <object class="GtkButton" id="preset_cmoy">
+                                        <property name="label">Cmoy</property>
+                                        <signal name="clicked" handler="on_preset_cmoy" object="CrossfeedBox" />
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkButton" id="preset_default">
+                                        <property name="label" translatable="yes">Default</property>
+                                        <signal name="clicked" handler="on_preset_default" object="CrossfeedBox" />
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkButton" id="preset_jmeier">
+                                        <property name="label">Jmeier</property>
+                                        <signal name="clicked" handler="on_preset_jmeier" object="CrossfeedBox" />
+                                    </object>
+                                </child>
                             </object>
                         </child>
+
                         <child>
-                            <object class="GtkScale" id="input_gain">
-                                <property name="hexpand">1</property>
+                            <object class="GtkGrid">
+                                <property name="margin-bottom">6</property>
+                                <property name="halign">center</property>
                                 <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">48</property>
                                 <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
+                                    <object class="GtkLabel" id="fcut_label">
+                                        <property name="label" translatable="yes">Cutoff</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
                                     </object>
                                 </child>
                                 <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
+                                    <object class="GtkSpinButton" id="fcut">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">0</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">300</property>
+                                                <property name="upper">2000</property>
+                                                <property name="value">700</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">10</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">fcut_label</relation>
+                                        </accessibility>
                                     </object>
                                 </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
+                                <child>
+                                    <object class="GtkLabel" id="feed_label">
+                                        <property name="label" translatable="yes">Feed</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="feed">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">1</property>
+                                                <property name="upper">15</property>
+                                                <property name="value">4.5</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">feed_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
                             </object>
                         </child>
+
                         <child>
-                            <object class="GtkScale" id="output_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="CrossfeedBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">bs2b</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="CrossfeedBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">bs2b</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/crystalizer.ui
+++ b/data/ui/crystalizer.ui
@@ -5,191 +5,205 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
-
         <child>
-            <object class="GtkBox" id="bands_box">
-                <property name="halign">center</property>
-                <property name="spacing">24</property>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
-                                <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
+
                 <child>
                     <object class="GtkBox">
+                        <property name="spacing">12</property>
                         <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
+                            <object class="GtkBox" id="bands_box">
+                                <property name="halign">center</property>
+                                <property name="spacing">24</property>
                             </object>
                         </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
                         <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="output_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
                                 <property name="spacing">6</property>
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
-                                        <property name="valign">center</property>
+                                    <object class="GtkBox">
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
                             </object>
                         </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkButton" id="reset_button">
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="hexpand">1</property>
-                <property name="label" translatable="yes">Reset</property>
-                <signal name="clicked" handler="on_reset" object="CrystalizerBox" />
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkButton" id="reset_button">
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="hexpand">1</property>
+                                <property name="label" translatable="yes">Reset</property>
+                                <signal name="clicked" handler="on_reset" object="CrystalizerBox" />
+                            </object>
+                        </child>
+                    </object>
+                </child>
             </object>
         </child>
     </template>

--- a/data/ui/deesser.ui
+++ b/data/ui/deesser.ui
@@ -5,655 +5,669 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
-
         <child>
-            <object class="GtkToggleButton" id="sc_listen">
-                <property name="halign">center</property>
-                <property name="label" translatable="yes">Listen</property>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="margin-top">6</property>
-                <property name="halign">center</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">48</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="spacing">6</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkLabel" id="detection_label">
-                                <property name="label" translatable="yes">Detection</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkComboBoxText" id="detection">
-                                <items>
-                                    <item translatable="yes" id="RMS">RMS</item>
-                                    <item translatable="yes" id="Peak">Peak</item>
-                                </items>
-                                <accessibility>
-                                    <relation name="labelled-by">detection_label</relation>
-                                </accessibility>
-                            </object>
-                        </child>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
                 <child>
                     <object class="GtkBox">
-                        <property name="spacing">6</property>
+                        <property name="spacing">12</property>
                         <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkLabel" id="mode_label">
-                                <property name="label" translatable="yes">Mode</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkComboBoxText" id="mode">
-                                <items>
-                                    <item translatable="yes" id="Wide">Wide</item>
-                                    <item translatable="yes" id="Split">Split</item>
-                                </items>
-                                <accessibility>
-                                    <relation name="labelled-by">mode_label</relation>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="spacing">6</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="label" translatable="yes">F1 Split</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkSpinButton" id="f1_freq">
+                            <object class="GtkToggleButton" id="sc_listen">
                                 <property name="halign">center</property>
-                                <property name="width-chars">10</property>
-                                <property name="digits">0</property>
-                                <property name="update-policy">if-valid</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">10</property>
-                                        <property name="upper">18000</property>
-                                        <property name="value">6000</property>
-                                        <property name="step-increment">1</property>
-                                        <property name="page-increment">100</property>
-                                    </object>
-                                </property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Frequency 1 Split</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="spacing">6</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="label" translatable="yes">F2 Peak</property>
+                                <property name="label" translatable="yes">Listen</property>
                             </object>
                         </child>
 
                         <child>
-                            <object class="GtkSpinButton" id="f2_freq">
+                            <object class="GtkBox">
+                                <property name="margin-top">6</property>
                                 <property name="halign">center</property>
-                                <property name="width-chars">10</property>
-                                <property name="digits">0</property>
-                                <property name="update-policy">if-valid</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">10</property>
-                                        <property name="upper">18000</property>
-                                        <property name="value">4500</property>
-                                        <property name="step-increment">1</property>
-                                        <property name="page-increment">100</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">48</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="spacing">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkLabel" id="detection_label">
+                                                <property name="label" translatable="yes">Detection</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkComboBoxText" id="detection">
+                                                <items>
+                                                    <item translatable="yes" id="RMS">RMS</item>
+                                                    <item translatable="yes" id="Peak">Peak</item>
+                                                </items>
+                                                <accessibility>
+                                                    <relation name="labelled-by">detection_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
-                                </property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Frequency 2 Peak</property>
-                                </accessibility>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="spacing">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkLabel" id="mode_label">
+                                                <property name="label" translatable="yes">Mode</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkComboBoxText" id="mode">
+                                                <items>
+                                                    <item translatable="yes" id="Wide">Wide</item>
+                                                    <item translatable="yes" id="Split">Split</item>
+                                                </items>
+                                                <accessibility>
+                                                    <relation name="labelled-by">mode_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="spacing">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="label" translatable="yes">F1 Split</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkSpinButton" id="f1_freq">
+                                                <property name="halign">center</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">0</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">10</property>
+                                                        <property name="upper">18000</property>
+                                                        <property name="value">6000</property>
+                                                        <property name="step-increment">1</property>
+                                                        <property name="page-increment">100</property>
+                                                    </object>
+                                                </property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Frequency 1 Split</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="spacing">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="label" translatable="yes">F2 Peak</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkSpinButton" id="f2_freq">
+                                                <property name="halign">center</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">0</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">10</property>
+                                                        <property name="upper">18000</property>
+                                                        <property name="value">4500</property>
+                                                        <property name="step-increment">1</property>
+                                                        <property name="page-increment">100</property>
+                                                    </object>
+                                                </property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Frequency 2 Peak</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
                             </object>
                         </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkGrid">
-                <property name="margin-bottom">12</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">24</property>
-                <child>
-                    <object class="GtkLabel">
-                        <property name="label" translatable="yes">F1 Gain</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="f1_level">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-24</property>
-                                <property name="upper">24</property>
-                                <property name="value">1</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <property name="label" translatable="yes">Frequency 1 Gain</property>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel">
-                        <property name="label" translatable="yes">F2 Level</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="f2_level">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-24</property>
-                                <property name="upper">24</property>
-                                <property name="value">4</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <property name="label" translatable="yes">Frequency 2 Level</property>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel">
-                        <property name="label" translatable="yes">F2 Peak Q</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="f2_q">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">0.1</property>
-                                <property name="upper">100</property>
-                                <property name="value">1</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <property name="label" translatable="yes">Frequency 2 Peak Q</property>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="laxity_label">
-                        <property name="label" translatable="yes">Laxity</property>
-                        <layout>
-                            <property name="column">3</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="laxity">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">0</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">1</property>
-                                <property name="upper">100</property>
-                                <property name="value">15</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">10</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">3</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">laxity_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="threshold_label">
-                        <property name="label" translatable="yes">Threshold</property>
-                        <layout>
-                            <property name="column">4</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="threshold">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-60</property>
-                                <property name="value">-18</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">4</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">threshold_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="ratio_label">
-                        <property name="label" translatable="yes">Ratio</property>
-                        <layout>
-                            <property name="column">5</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="ratio">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">0</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">1</property>
-                                <property name="upper">20</property>
-                                <property name="value">3</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">5</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">ratio_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-
-                <child>
-                    <object class="GtkLabel" id="makeup_label">
-                        <property name="label" translatable="yes">Makeup</property>
-                        <layout>
-                            <property name="column">6</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="makeup">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="upper">36</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">6</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">makeup_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
                         <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
-                                <property name="hexpand">1</property>
+                            <object class="GtkGrid">
+                                <property name="margin-bottom">12</property>
+                                <property name="halign">center</property>
                                 <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">24</property>
                                 <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
+                                    <object class="GtkLabel">
+                                        <property name="label" translatable="yes">F1 Gain</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
                                     </object>
                                 </child>
                                 <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
+                                    <object class="GtkSpinButton" id="f1_level">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-24</property>
+                                                <property name="upper">24</property>
+                                                <property name="value">1</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">Frequency 1 Gain</property>
+                                        </accessibility>
                                     </object>
                                 </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="label" translatable="yes">F2 Level</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="f2_level">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-24</property>
+                                                <property name="upper">24</property>
+                                                <property name="value">4</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">Frequency 2 Level</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="label" translatable="yes">F2 Peak Q</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="f2_q">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">0.1</property>
+                                                <property name="upper">100</property>
+                                                <property name="value">1</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">Frequency 2 Peak Q</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="laxity_label">
+                                        <property name="label" translatable="yes">Laxity</property>
+                                        <layout>
+                                            <property name="column">3</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="laxity">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">0</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">1</property>
+                                                <property name="upper">100</property>
+                                                <property name="value">15</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">10</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">3</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">laxity_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="threshold_label">
+                                        <property name="label" translatable="yes">Threshold</property>
+                                        <layout>
+                                            <property name="column">4</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="threshold">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-60</property>
+                                                <property name="value">-18</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">4</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">threshold_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="ratio_label">
+                                        <property name="label" translatable="yes">Ratio</property>
+                                        <layout>
+                                            <property name="column">5</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="ratio">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">0</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">1</property>
+                                                <property name="upper">20</property>
+                                                <property name="value">3</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">5</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">ratio_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+
+                                <child>
+                                    <object class="GtkLabel" id="makeup_label">
+                                        <property name="label" translatable="yes">Makeup</property>
+                                        <layout>
+                                            <property name="column">6</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="makeup">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="upper">36</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">6</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">makeup_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
                             </object>
                         </child>
+
                         <child>
-                            <object class="GtkScale" id="output_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkLabel" id="detected_title">
+                                        <property name="halign">end</property>
+                                        <property name="xalign">1</property>
+                                        <property name="label" translatable="yes">Detected</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLevelBar" id="detected">
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">1</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="detected_label">
+                                        <property name="halign">end</property>
+                                        <property name="width-chars">4</property>
+                                        <property name="label">0</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkLabel" id="compression_title">
+                                        <property name="halign">end</property>
+                                        <property name="xalign">1</property>
+                                        <property name="label" translatable="yes">Reduction</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLevelBar" id="compression">
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">1</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="compression_label">
+                                        <property name="halign">end</property>
+                                        <property name="width-chars">4</property>
+                                        <property name="label">0</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="DeesserBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Calf Studio Gear</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="detected_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Detected</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="detected">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="detected_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">4</property>
-                        <property name="label">0</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="compression_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Reduction</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="compression">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="compression_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">4</property>
-                        <property name="label">0</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="DeesserBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">Calf Studio Gear</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/delay.ui
+++ b/data/ui/delay.ui
@@ -5,413 +5,427 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
-
         <child>
-            <object class="GtkGrid">
-                <property name="margin-bottom">6</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row-spacing">12</property>
-                <property name="column-spacing">12</property>
-                <child>
-                    <object class="GtkLabel" id="time_l_label">
-                        <property name="label" translatable="yes">Left</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkLabel" id="time_r_label">
-                        <property name="label" translatable="yes">Right</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">0</property>
-                        </layout>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
-                <child>
-                    <object class="GtkLabel">
-                        <property name="halign">end</property>
-                        <property name="label" translatable="yes">Delay</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="time_l">
-                        <property name="halign">center</property>
-                        <property name="width-chars">11</property>
-                        <property name="digits">2</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="upper">1000</property>
-                                <property name="step-increment">0.01</property>
-                                <property name="page-increment">0.1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <property name="label" translatable="yes">Left Delay</property>
-                        </accessibility>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="time_r">
-                        <property name="halign">center</property>
-                        <property name="width-chars">11</property>
-                        <property name="digits">2</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="upper">1000</property>
-                                <property name="step-increment">0.01</property>
-                                <property name="page-increment">0.1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <property name="label" translatable="yes">Right Delay</property>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel">
-                        <property name="halign">end</property>
-                        <property name="label" translatable="yes">Dry Level</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">2</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="dry_l">
-                        <property name="valign">center</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-100</property>
-                                <property name="upper">20</property>
-                                <property name="value">-100</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">2</property>
-                        </layout>
-                        <accessibility>
-                            <property name="label" translatable="yes">Left Dry Level</property>
-                        </accessibility>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="dry_r">
-                        <property name="valign">center</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-100</property>
-                                <property name="upper">20</property>
-                                <property name="value">-100</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">2</property>
-                        </layout>
-                        <accessibility>
-                            <property name="label" translatable="yes">Right Dry Level</property>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel">
-                        <property name="halign">end</property>
-                        <property name="label" translatable="yes">Wet Level</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">3</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="wet_l">
-                        <property name="valign">center</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-100</property>
-                                <property name="upper">20</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">3</property>
-                        </layout>
-                        <accessibility>
-                            <property name="label" translatable="yes">Left Wet Level</property>
-                        </accessibility>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="wet_r">
-                        <property name="valign">center</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-100</property>
-                                <property name="upper">20</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">3</property>
-                        </layout>
-                        <accessibility>
-                            <property name="label" translatable="yes">Right Wet Level</property>
-                        </accessibility>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
                 <child>
                     <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
-                                <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
+                        <property name="spacing">12</property>
                         <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="output_gain">
-                                <property name="hexpand">1</property>
+                            <object class="GtkGrid">
+                                <property name="margin-bottom">6</property>
+                                <property name="halign">center</property>
                                 <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="row-spacing">12</property>
+                                <property name="column-spacing">12</property>
+                                <child>
+                                    <object class="GtkLabel" id="time_l_label">
+                                        <property name="label" translatable="yes">Left</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
                                     </object>
+                                </child>
+                                <child>
+                                    <object class="GtkLabel" id="time_r_label">
+                                        <property name="label" translatable="yes">Right</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes">Delay</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="time_l">
+                                        <property name="halign">center</property>
+                                        <property name="width-chars">11</property>
+                                        <property name="digits">2</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="upper">1000</property>
+                                                <property name="step-increment">0.01</property>
+                                                <property name="page-increment">0.1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">Left Delay</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="time_r">
+                                        <property name="halign">center</property>
+                                        <property name="width-chars">11</property>
+                                        <property name="digits">2</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="upper">1000</property>
+                                                <property name="step-increment">0.01</property>
+                                                <property name="page-increment">0.1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">Right Delay</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes">Dry Level</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">2</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="dry_l">
+                                        <property name="valign">center</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-100</property>
+                                                <property name="upper">20</property>
+                                                <property name="value">-100</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">2</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">Left Dry Level</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="dry_r">
+                                        <property name="valign">center</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-100</property>
+                                                <property name="upper">20</property>
+                                                <property name="value">-100</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">2</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">Right Dry Level</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes">Wet Level</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">3</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="wet_l">
+                                        <property name="valign">center</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-100</property>
+                                                <property name="upper">20</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">3</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">Left Wet Level</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="wet_r">
+                                        <property name="valign">center</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-100</property>
+                                                <property name="upper">20</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">3</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">Right Wet Level</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="DelayBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Linux Studio Plugins</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="DelayBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">Linux Studio Plugins</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/echo_canceller.ui
+++ b/data/ui/echo_canceller.ui
@@ -5,293 +5,307 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
-
         <child>
-            <object class="GtkGrid">
-                <property name="margin-bottom">6</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">48</property>
-                <child>
-                    <object class="GtkLabel" id="frame_size_label">
-                        <property name="label" translatable="yes">Frame Size</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="frame_size">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">0</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">1</property>
-                                <property name="upper">100</property>
-                                <property name="value">20</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">10</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">frame_size_label</relation>
-                        </accessibility>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
-                <child>
-                    <object class="GtkLabel" id="filter_length_label">
-                        <property name="label" translatable="yes">Filter Length</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="filter_length">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">0</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">1</property>
-                                <property name="upper">1000</property>
-                                <property name="value">100</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">10</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">filter_length_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
                 <child>
                     <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
+                        <property name="spacing">12</property>
+                        <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
-                                <property name="hexpand">1</property>
+                            <object class="GtkGrid">
+                                <property name="margin-bottom">6</property>
+                                <property name="halign">center</property>
                                 <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">48</property>
                                 <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
+                                    <object class="GtkLabel" id="frame_size_label">
+                                        <property name="label" translatable="yes">Frame Size</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
                                     </object>
                                 </child>
                                 <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
+                                    <object class="GtkSpinButton" id="frame_size">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">0</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">1</property>
+                                                <property name="upper">100</property>
+                                                <property name="value">20</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">10</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">frame_size_label</relation>
+                                        </accessibility>
                                     </object>
                                 </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
+                                <child>
+                                    <object class="GtkLabel" id="filter_length_label">
+                                        <property name="label" translatable="yes">Filter Length</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="filter_length">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">0</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">1</property>
+                                                <property name="upper">1000</property>
+                                                <property name="value">100</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">10</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">filter_length_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
                             </object>
                         </child>
+
                         <child>
-                            <object class="GtkScale" id="output_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="EchoCancellerBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">SpeexDSP</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="EchoCancellerBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">SpeexDSP</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/exciter.ui
+++ b/data/ui/exciter.ui
@@ -5,469 +5,484 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
         <child>
-            <object class="GtkToggleButton" id="listen">
-                <property name="label" translatable="yes">Listen</property>
-                <property name="halign">center</property>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkGrid">
-                <property name="halign">center</property>
-                <property name="row-spacing">2</property>
-                <child>
-                    <object class="GtkLabel" id="blend_label">
-                        <property name="label" translatable="yes">Blend Harmonics</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="column-span">3</property>
-                            <property name="row">0</property>
-                        </layout>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
-                <child>
-                    <object class="GtkLabel">
-                        <property name="halign">end</property>
-                        <property name="label" translatable="yes">3rd</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkScale" id="blend">
-                        <property name="width-request">500</property>
-                        <property name="valign">center</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-10</property>
-                                <property name="upper">10</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <property name="draw-value">1</property>
-                        <property name="digits">0</property>
-                        <property name="value-pos">top</property>
-                        <marks>
-                            <mark value="-10" position="bottom"></mark>
-                            <mark value="-5" position="bottom"></mark>
-                            <mark value="0" position="bottom"></mark>
-                            <mark value="5" position="bottom"></mark>
-                            <mark value="10" position="bottom"></mark>
-                        </marks>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">blend_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel">
-                        <property name="halign">start</property>
-                        <property name="label" translatable="yes">2nd</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkGrid">
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">48</property>
-                <property name="margin-bottom">12</property>
-                <child>
-                    <object class="GtkLabel" id="amount_label">
-                        <property name="label" translatable="yes">Amount</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="amount">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-100</property>
-                                <property name="upper">36</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">amount_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="harmonics_spinbutton_label">
-                        <property name="label" translatable="yes">Harmonics</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="harmonics">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">0.1</property>
-                                <property name="upper">10</property>
-                                <property name="value">8.5</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">harmonics_spinbutton_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="scope_label">
-                        <property name="label" translatable="yes">Scope</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="scope">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">2000</property>
-                                <property name="upper">12000</property>
-                                <property name="value">7500</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">100</property>
-                            </object>
-                        </property>
-                        <property name="update-policy">if-valid</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">scope_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkToggleButton" id="ceil_active">
-                        <property name="label" translatable="yes">Ceil</property>
-                        <property name="halign">center</property>
-                        <layout>
-                            <property name="column">3</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="ceil">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="sensitive" bind-source="ceil_active" bind-property="active" bind-flags="sync-create" />
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">10000</property>
-                                <property name="upper">20000</property>
-                                <property name="value">16000</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">100</property>
-                            </object>
-                        </property>
-                        <property name="update-policy">if-valid</property>
-                        <layout>
-                            <property name="column">3</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <property name="label" translatable="yes">Ceil Value</property>
-                        </accessibility>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
                 <child>
                     <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
+                        <property name="spacing">12</property>
+                        <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
+                            <object class="GtkToggleButton" id="listen">
+                                <property name="label" translatable="yes">Listen</property>
+                                <property name="halign">center</property>
                             </object>
                         </child>
+
                         <child>
-                            <object class="GtkScale" id="input_gain">
-                                <property name="hexpand">1</property>
+                            <object class="GtkGrid">
+                                <property name="halign">center</property>
+                                <property name="row-spacing">2</property>
+                                <child>
+                                    <object class="GtkLabel" id="blend_label">
+                                        <property name="label" translatable="yes">Blend Harmonics</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="column-span">3</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes">3rd</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkScale" id="blend">
+                                        <property name="width-request">500</property>
+                                        <property name="valign">center</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-10</property>
+                                                <property name="upper">10</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <property name="draw-value">1</property>
+                                        <property name="digits">0</property>
+                                        <property name="value-pos">top</property>
+                                        <marks>
+                                            <mark value="-10" position="bottom"></mark>
+                                            <mark value="-5" position="bottom"></mark>
+                                            <mark value="0" position="bottom"></mark>
+                                            <mark value="5" position="bottom"></mark>
+                                            <mark value="10" position="bottom"></mark>
+                                        </marks>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">blend_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">2nd</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkGrid">
+                                <property name="halign">center</property>
                                 <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">48</property>
+                                <property name="margin-bottom">12</property>
                                 <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
+                                    <object class="GtkLabel" id="amount_label">
+                                        <property name="label" translatable="yes">Amount</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
                                     </object>
                                 </child>
                                 <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
+                                    <object class="GtkSpinButton" id="amount">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-100</property>
+                                                <property name="upper">36</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">amount_label</relation>
+                                        </accessibility>
                                     </object>
                                 </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
+                                <child>
+                                    <object class="GtkLabel" id="harmonics_spinbutton_label">
+                                        <property name="label" translatable="yes">Harmonics</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="harmonics">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">0.1</property>
+                                                <property name="upper">10</property>
+                                                <property name="value">8.5</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">harmonics_spinbutton_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="scope_label">
+                                        <property name="label" translatable="yes">Scope</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="scope">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">2000</property>
+                                                <property name="upper">12000</property>
+                                                <property name="value">7500</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">100</property>
+                                            </object>
+                                        </property>
+                                        <property name="update-policy">if-valid</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">scope_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkToggleButton" id="ceil_active">
+                                        <property name="label" translatable="yes">Ceil</property>
+                                        <property name="halign">center</property>
+                                        <layout>
+                                            <property name="column">3</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="ceil">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="sensitive" bind-source="ceil_active" bind-property="active" bind-flags="sync-create" />
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">10000</property>
+                                                <property name="upper">20000</property>
+                                                <property name="value">16000</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">100</property>
+                                            </object>
+                                        </property>
+                                        <property name="update-policy">if-valid</property>
+                                        <layout>
+                                            <property name="column">3</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">Ceil Value</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
                             </object>
                         </child>
+
                         <child>
-                            <object class="GtkScale" id="output_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkLabel" id="harmonics_title">
+                                        <property name="halign">end</property>
+                                        <property name="xalign">1</property>
+                                        <property name="label" translatable="yes">Harmonics</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLevelBar" id="harmonics_levelbar">
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">1</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="harmonics_levelbar_label">
+                                        <property name="halign">end</property>
+                                        <property name="width-chars">4</property>
+                                        <property name="label">0</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="ExciterBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Calf Studio Gear</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="harmonics_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Harmonics</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="harmonics_levelbar">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="harmonics_levelbar_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">4</property>
-                        <property name="label">0</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="ExciterBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">Calf Studio Gear</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/filter.ui
+++ b/data/ui/filter.ui
@@ -5,351 +5,365 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
-
         <child>
-            <object class="GtkComboBoxText" id="mode">
-                <property name="halign">center</property>
-                <items>
-                    <item translatable="yes" id="12dB/oct Lowpass">12dB/oct Lowpass</item>
-                    <item translatable="yes" id="24dB/oct Lowpass">24dB/oct Lowpass</item>
-                    <item translatable="yes" id="36dB/oct Lowpass">36dB/oct Lowpass</item>
-                    <item translatable="yes" id="12dB/oct Highpass">12dB/oct Highpass</item>
-                    <item translatable="yes" id="24dB/oct Highpass">24dB/oct Highpass</item>
-                    <item translatable="yes" id="36dB/oct Highpass">36dB/oct Highpass</item>
-                    <item translatable="yes" id="6dB/oct Bandpass">6dB/oct Bandpass</item>
-                    <item translatable="yes" id="12dB/oct Bandpass">12dB/oct Bandpass</item>
-                    <item translatable="yes" id="18dB/oct Bandpass">18dB/oct Bandpass</item>
-                    <item translatable="yes" id="6dB/oct Bandreject">6dB/oct Bandreject</item>
-                    <item translatable="yes" id="12dB/oct Bandreject">12dB/oct Bandreject</item>
-                    <item translatable="yes" id="18dB/oct Bandreject">18dB/oct Bandreject</item>
-                </items>
-                <accessibility>
-                    <property name="label">Filter Mode</property>
-                </accessibility>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkGrid">
-                <property name="margin-bottom">6</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">48</property>
-                <child>
-                    <object class="GtkLabel" id="frequency_label">
-                        <property name="label" translatable="yes">Frequency</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="frequency">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">10</property>
-                                <property name="upper">20000</property>
-                                <property name="value">2000</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">100</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">frequency_label</relation>
-                        </accessibility>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
-                <child>
-                    <object class="GtkLabel" id="resonance_label">
-                        <property name="label" translatable="yes">Resonance</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="resonance">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-3</property>
-                                <property name="upper">30</property>
-                                <property name="value">-3</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">resonance_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="inertia_label">
-                        <property name="label" translatable="yes">Inertia</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="inertia">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">2</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">5</property>
-                                <property name="upper">100</property>
-                                <property name="value">20</property>
-                                <property name="step-increment">0.01</property>
-                                <property name="page-increment">0.1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">inertia_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
                 <child>
                     <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
+                        <property name="spacing">12</property>
+                        <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
-                                <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
+                            <object class="GtkComboBoxText" id="mode">
+                                <property name="halign">center</property>
+                                <items>
+                                    <item translatable="yes" id="12dB/oct Lowpass">12dB/oct Lowpass</item>
+                                    <item translatable="yes" id="24dB/oct Lowpass">24dB/oct Lowpass</item>
+                                    <item translatable="yes" id="36dB/oct Lowpass">36dB/oct Lowpass</item>
+                                    <item translatable="yes" id="12dB/oct Highpass">12dB/oct Highpass</item>
+                                    <item translatable="yes" id="24dB/oct Highpass">24dB/oct Highpass</item>
+                                    <item translatable="yes" id="36dB/oct Highpass">36dB/oct Highpass</item>
+                                    <item translatable="yes" id="6dB/oct Bandpass">6dB/oct Bandpass</item>
+                                    <item translatable="yes" id="12dB/oct Bandpass">12dB/oct Bandpass</item>
+                                    <item translatable="yes" id="18dB/oct Bandpass">18dB/oct Bandpass</item>
+                                    <item translatable="yes" id="6dB/oct Bandreject">6dB/oct Bandreject</item>
+                                    <item translatable="yes" id="12dB/oct Bandreject">12dB/oct Bandreject</item>
+                                    <item translatable="yes" id="18dB/oct Bandreject">18dB/oct Bandreject</item>
+                                </items>
                                 <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                    <property name="label">Filter Mode</property>
                                 </accessibility>
                             </object>
                         </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
                         <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="output_gain">
-                                <property name="hexpand">1</property>
+                            <object class="GtkGrid">
+                                <property name="margin-bottom">6</property>
+                                <property name="halign">center</property>
                                 <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">48</property>
+                                <child>
+                                    <object class="GtkLabel" id="frequency_label">
+                                        <property name="label" translatable="yes">Frequency</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
                                     </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="frequency">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">10</property>
+                                                <property name="upper">20000</property>
+                                                <property name="value">2000</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">100</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">frequency_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="resonance_label">
+                                        <property name="label" translatable="yes">Resonance</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="resonance">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-3</property>
+                                                <property name="upper">30</property>
+                                                <property name="value">-3</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">resonance_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="inertia_label">
+                                        <property name="label" translatable="yes">Inertia</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="inertia">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">2</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">5</property>
+                                                <property name="upper">100</property>
+                                                <property name="value">20</property>
+                                                <property name="step-increment">0.01</property>
+                                                <property name="page-increment">0.1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">inertia_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="FilterBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Calf Studio Gear</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="FilterBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">Calf Studio Gear</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/gate.ui
+++ b/data/ui/gate.ui
@@ -5,1404 +5,1418 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
-
         <child>
-            <object class="GtkStackSwitcher" id="stack_switcher">
-                <property name="halign">center</property>
-                <property name="stack">stack</property>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkStack" id="stack">
-                <property name="margin-top">6</property>
-                <property name="margin-bottom">6</property>
-                <property name="hexpand">1</property>
-                <property name="hhomogeneous">0</property>
-                <property name="vhomogeneous">0</property>
-                <property name="transition-duration">250</property>
-                <property name="transition-type">slide-left-right</property>
-
-                <child>
-                    <object class="GtkStackPage">
-                        <property name="name">page_gate</property>
-                        <property name="title" translatable="yes">Gate</property>
-                        <property name="child">
-                            <object class="GtkBox">
-                                <property name="spacing">24</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                    <object class="GtkGrid">
-                                        <property name="halign">center</property>
-                                        <property name="column-spacing">18</property>
-
-                                        <!-- Attack/Release section -->
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="halign">fill</property>
-                                                <property name="homogeneous">1</property>
-                                                <property name="margin-bottom">6</property>
-
-                                                <child>
-                                                    <object class="GtkLabel" id="attack_time_label">
-                                                        <property name="label" translatable="yes">Attack</property>
-
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkLabel" id="release_time_label">
-                                                        <property name="label" translatable="yes">Release</property>
-                                                    </object>
-                                                </child>
-
-                                                <layout>
-                                                    <property name="column">0</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="halign">center</property>
-                                                <style>
-                                                    <class name="linked" />
-                                                </style>
-
-                                                <child>
-                                                    <object class="GtkSpinButton" id="attack">
-                                                        <property name="orientation">vertical</property>
-                                                        <property name="digits">2</property>
-                                                        <property name="width-chars">11</property>
-                                                        <property name="update-policy">if-valid</property>
-                                                        <property name="adjustment">
-                                                            <object class="GtkAdjustment">
-                                                                <property name="upper">2000</property>
-                                                                <property name="value">20</property>
-                                                                <property name="step-increment">0.01</property>
-                                                                <property name="page-increment">0.1</property>
-                                                            </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">attack_time_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-
-                                                <child>
-                                                    <object class="GtkSpinButton" id="release">
-                                                        <property name="orientation">vertical</property>
-                                                        <property name="digits">2</property>
-                                                        <property name="width-chars">11</property>
-                                                        <property name="update-policy">if-valid</property>
-                                                        <property name="adjustment">
-                                                            <object class="GtkAdjustment">
-                                                                <property name="upper">5000</property>
-                                                                <property name="value">100</property>
-                                                                <property name="step-increment">0.01</property>
-                                                                <property name="page-increment">0.1</property>
-                                                            </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">release_time_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-
-                                                <layout>
-                                                    <property name="column">0</property>
-                                                    <property name="row">2</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <!-- Curve section -->
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="halign">center</property>
-                                                <property name="valign">center</property>
-                                                <property name="margin-bottom">4</property>
-                                                <property name="label" translatable="yes">Curve</property>
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="halign">fill</property>
-                                                <property name="homogeneous">1</property>
-                                                <property name="margin-bottom">6</property>
-
-                                                <child>
-                                                    <object class="GtkLabel" id="curve_threshold_label">
-                                                        <property name="label" translatable="yes">Threshold</property>
-
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkLabel" id="curve_zone_label">
-                                                        <property name="label" translatable="yes">Zone</property>
-                                                    </object>
-                                                </child>
-
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="halign">center</property>
-                                                <style>
-                                                    <class name="linked" />
-                                                </style>
-
-                                                <child>
-                                                    <object class="GtkSpinButton" id="curve_threshold">
-                                                        <property name="orientation">vertical</property>
-                                                        <property name="digits">1</property>
-                                                        <property name="width-chars">10</property>
-                                                        <property name="update-policy">if-valid</property>
-                                                        <property name="adjustment">
-                                                            <object class="GtkAdjustment">
-                                                                <property name="lower">-60</property>
-                                                                <property name="upper">0</property>
-                                                                <property name="value">-24</property>
-                                                                <property name="step-increment">0.1</property>
-                                                                <property name="page-increment">1</property>
-                                                            </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">curve_threshold_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkSpinButton" id="curve_zone">
-                                                        <property name="orientation">vertical</property>
-                                                        <property name="digits">1</property>
-                                                        <property name="width-chars">10</property>
-                                                        <property name="update-policy">if-valid</property>
-                                                        <property name="adjustment">
-                                                            <object class="GtkAdjustment">
-                                                                <property name="lower">-60</property>
-                                                                <property name="upper">0</property>
-                                                                <property name="value">-6</property>
-                                                                <property name="step-increment">0.1</property>
-                                                                <property name="page-increment">1</property>
-                                                            </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">curve_zone_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">2</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <!-- Hysteresis section -->
-                                        <child>
-                                            <object class="GtkToggleButton" id="hysteresis">
-                                                <property name="halign">center</property>
-                                                <property name="valign">center</property>
-                                                <property name="margin-bottom">4</property>
-                                                <property name="label" translatable="yes">Hysteresis</property>
-                                                <layout>
-                                                    <property name="column">2</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="halign">fill</property>
-                                                <property name="homogeneous">1</property>
-                                                <property name="margin-bottom">6</property>
-
-                                                <child>
-                                                    <object class="GtkLabel" id="hysteresis_threshold_label">
-                                                        <property name="label" translatable="yes">Threshold</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkLabel" id="hysteresis_zone_label">
-                                                        <property name="label" translatable="yes">Zone</property>
-                                                    </object>
-                                                </child>
-
-                                                <layout>
-                                                    <property name="column">2</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="halign">center</property>
-                                                <style>
-                                                    <class name="linked" />
-                                                </style>
-
-                                                <child>
-                                                    <object class="GtkSpinButton" id="hysteresis_threshold">
-                                                        <property name="orientation">vertical</property>
-                                                        <property name="digits">1</property>
-                                                        <property name="width-chars">10</property>
-                                                        <property name="update-policy">if-valid</property>
-                                                        <property name="sensitive" bind-source="hysteresis" bind-property="active" bind-flags="sync-create" />
-                                                        <property name="adjustment">
-                                                            <object class="GtkAdjustment">
-                                                                <property name="lower">-60</property>
-                                                                <property name="upper">0</property>
-                                                                <property name="value">-12</property>
-                                                                <property name="step-increment">0.1</property>
-                                                                <property name="page-increment">1</property>
-                                                            </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">hysteresis_threshold_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkSpinButton" id="hysteresis_zone">
-                                                        <property name="orientation">vertical</property>
-                                                        <property name="digits">1</property>
-                                                        <property name="width-chars">10</property>
-                                                        <property name="update-policy">if-valid</property>
-                                                        <property name="sensitive" bind-source="hysteresis" bind-property="active" bind-flags="sync-create" />
-                                                        <property name="adjustment">
-                                                            <object class="GtkAdjustment">
-                                                                <property name="lower">-60</property>
-                                                                <property name="upper">0</property>
-                                                                <property name="value">-6</property>
-                                                                <property name="step-increment">0.1</property>
-                                                                <property name="page-increment">1</property>
-                                                            </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">hysteresis_zone_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-
-                                                <layout>
-                                                    <property name="column">2</property>
-                                                    <property name="row">2</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <!-- Mix section -->
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="halign">center</property>
-                                                <property name="valign">center</property>
-                                                <property name="margin-bottom">4</property>
-                                                <property name="label" translatable="yes">Mix</property>
-                                                <layout>
-                                                    <property name="column">3</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="halign">fill</property>
-                                                <property name="homogeneous">1</property>
-                                                <property name="margin-bottom">6</property>
-
-                                                <child>
-                                                    <object class="GtkLabel" id="dry_label">
-                                                        <property name="label" translatable="yes">Dry Level</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkLabel" id="wet_label">
-                                                        <property name="label" translatable="yes">Wet Level</property>
-                                                    </object>
-                                                </child>
-
-                                                <layout>
-                                                    <property name="column">3</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="halign">center</property>
-                                                <style>
-                                                    <class name="linked" />
-                                                </style>
-
-                                                <child>
-                                                    <object class="GtkSpinButton" id="dry">
-                                                        <property name="valign">center</property>
-                                                        <property name="orientation">vertical</property>
-                                                        <property name="width-chars">10</property>
-                                                        <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
-                                                        <property name="adjustment">
-                                                            <object class="GtkAdjustment">
-                                                                <property name="lower">-100</property>
-                                                                <property name="upper">20</property>
-                                                                <property name="value">-100</property>
-                                                                <property name="step-increment">0.1</property>
-                                                                <property name="page-increment">1</property>
-                                                            </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">dry_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkSpinButton" id="wet">
-                                                        <property name="valign">center</property>
-                                                        <property name="orientation">vertical</property>
-                                                        <property name="width-chars">10</property>
-                                                        <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
-                                                        <property name="adjustment">
-                                                            <object class="GtkAdjustment">
-                                                                <property name="lower">-100</property>
-                                                                <property name="upper">20</property>
-                                                                <property name="step-increment">0.1</property>
-                                                                <property name="page-increment">1</property>
-                                                            </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">wet_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-
-                                                <layout>
-                                                    <property name="column">3</property>
-                                                    <property name="row">2</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <!-- Reduction/Makeup section -->
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="halign">fill</property>
-                                                <property name="homogeneous">1</property>
-                                                <property name="margin-bottom">6</property>
-
-                                                <child>
-                                                    <object class="GtkLabel" id="reduction_label">
-                                                        <property name="label" translatable="yes">Reduction</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkLabel" id="makeup_label">
-                                                        <property name="label" translatable="yes">Makeup</property>
-                                                    </object>
-                                                </child>
-
-                                                <layout>
-                                                    <property name="column">4</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="halign">center</property>
-                                                <style>
-                                                    <class name="linked" />
-                                                </style>
-
-                                                <child>
-                                                    <object class="GtkSpinButton" id="reduction">
-                                                        <property name="orientation">vertical</property>
-                                                        <property name="width-chars">10</property>
-                                                        <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
-                                                        <property name="adjustment">
-                                                            <object class="GtkAdjustment">
-                                                                <property name="lower">-72</property>
-                                                                <property name="upper">0</property>
-                                                                <property name="value">-24</property>
-                                                                <property name="step-increment">0.1</property>
-                                                                <property name="page-increment">1</property>
-                                                            </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">reduction_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkSpinButton" id="makeup">
-                                                        <property name="orientation">vertical</property>
-                                                        <property name="width-chars">10</property>
-                                                        <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
-                                                        <property name="adjustment">
-                                                            <object class="GtkAdjustment">
-                                                                <property name="lower">-60</property>
-                                                                <property name="upper">60</property>
-                                                                <property name="step-increment">0.1</property>
-                                                                <property name="page-increment">1</property>
-                                                            </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">makeup_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-
-                                                <layout>
-                                                    <property name="column">4</property>
-                                                    <property name="row">2</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkBox">
-                                        <property name="hexpand">1</property>
-                                        <property name="vexpand">0</property>
-                                        <property name="homogeneous">1</property>
-                                        <property name="margin-top">4</property>
-                                        <property name="margin-bottom">4</property>
-
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="halign">center</property>
-                                                <child>
-                                                    <object class="GtkLabel" id="attack_zone_start_title">
-                                                        <property name="halign">end</property>
-                                                        <property name="xalign">1</property>
-                                                        <property name="label" translatable="yes">Attack Zone Start</property>
-                                                    </object>
-                                                </child>
-
-                                                <child>
-                                                    <object class="GtkLabel" id="attack_zone_start_label">
-                                                        <property name="width-chars">6</property>
-                                                        <property name="label">0.0</property>
-                                                    </object>
-                                                </child>
-
-                                                <child>
-                                                    <object class="GtkLabel">
-                                                        <property name="halign">start</property>
-                                                        <property name="label">db</property>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="halign">center</property>
-                                                <child>
-                                                    <object class="GtkLabel" id="attack_threshold_title">
-                                                        <property name="halign">end</property>
-                                                        <property name="xalign">1</property>
-                                                        <property name="label" translatable="yes">Attack Threshold</property>
-                                                    </object>
-                                                </child>
-
-                                                <child>
-                                                    <object class="GtkLabel" id="attack_threshold_label">
-                                                        <property name="width-chars">6</property>
-                                                        <property name="label">0.0</property>
-                                                    </object>
-                                                </child>
-
-                                                <child>
-                                                    <object class="GtkLabel">
-                                                        <property name="halign">start</property>
-                                                        <property name="label">db</property>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="halign">center</property>
-                                                <child>
-                                                    <object class="GtkLabel" id="release_zone_start_title">
-                                                        <property name="halign">end</property>
-                                                        <property name="xalign">1</property>
-                                                        <property name="label" translatable="yes">Release Zone Start</property>
-                                                    </object>
-                                                </child>
-
-                                                <child>
-                                                    <object class="GtkLabel" id="release_zone_start_label">
-                                                        <property name="width-chars">6</property>
-                                                        <property name="label">0.0</property>
-                                                    </object>
-                                                </child>
-
-                                                <child>
-                                                    <object class="GtkLabel">
-                                                        <property name="halign">start</property>
-                                                        <property name="label">db</property>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="halign">center</property>
-                                                <child>
-                                                    <object class="GtkLabel" id="release_threshold_title">
-                                                        <property name="halign">end</property>
-                                                        <property name="xalign">1</property>
-                                                        <property name="label" translatable="yes">Release Threshold</property>
-                                                    </object>
-                                                </child>
-
-                                                <child>
-                                                    <object class="GtkLabel" id="release_threshold_label">
-                                                        <property name="width-chars">6</property>
-                                                        <property name="label">0.0</property>
-                                                    </object>
-                                                </child>
-
-                                                <child>
-                                                    <object class="GtkLabel">
-                                                        <property name="halign">start</property>
-                                                        <property name="label">db</property>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-
-                            </object>
-                        </property>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
                 <child>
-                    <object class="GtkStackPage">
-                        <property name="name">page_sidechain</property>
-                        <property name="title" translatable="yes">Sidechain</property>
-                        <property name="child">
-                            <object class="GtkBox">
+                    <object class="GtkBox">
+                        <property name="spacing">12</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                            <object class="GtkStackSwitcher" id="stack_switcher">
                                 <property name="halign">center</property>
-                                <property name="spacing">24</property>
-                                <property name="orientation">vertical</property>
+                                <property name="stack">stack</property>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkStack" id="stack">
+                                <property name="margin-top">6</property>
+                                <property name="margin-bottom">6</property>
+                                <property name="hexpand">1</property>
+                                <property name="hhomogeneous">0</property>
+                                <property name="vhomogeneous">0</property>
+                                <property name="transition-duration">250</property>
+                                <property name="transition-type">slide-left-right</property>
 
                                 <child>
-                                    <object class="GtkBox">
-                                        <property name="halign">center</property>
-                                        <property name="homogeneous">1</property>
-                                        <property name="spacing">24</property>
-                                        <child>
+                                    <object class="GtkStackPage">
+                                        <property name="name">page_gate</property>
+                                        <property name="title" translatable="yes">Gate</property>
+                                        <property name="child">
+                                            <object class="GtkBox">
+                                                <property name="spacing">24</property>
+                                                <property name="orientation">vertical</property>
+                                                <child>
+                                                    <object class="GtkGrid">
+                                                        <property name="halign">center</property>
+                                                        <property name="column-spacing">18</property>
+
+                                                        <!-- Attack/Release section -->
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="halign">fill</property>
+                                                                <property name="homogeneous">1</property>
+                                                                <property name="margin-bottom">6</property>
+
+                                                                <child>
+                                                                    <object class="GtkLabel" id="attack_time_label">
+                                                                        <property name="label" translatable="yes">Attack</property>
+
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkLabel" id="release_time_label">
+                                                                        <property name="label" translatable="yes">Release</property>
+                                                                    </object>
+                                                                </child>
+
+                                                                <layout>
+                                                                    <property name="column">0</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="halign">center</property>
+                                                                <style>
+                                                                    <class name="linked" />
+                                                                </style>
+
+                                                                <child>
+                                                                    <object class="GtkSpinButton" id="attack">
+                                                                        <property name="orientation">vertical</property>
+                                                                        <property name="digits">2</property>
+                                                                        <property name="width-chars">11</property>
+                                                                        <property name="update-policy">if-valid</property>
+                                                                        <property name="adjustment">
+                                                                            <object class="GtkAdjustment">
+                                                                                <property name="upper">2000</property>
+                                                                                <property name="value">20</property>
+                                                                                <property name="step-increment">0.01</property>
+                                                                                <property name="page-increment">0.1</property>
+                                                                            </object>
+                                                                        </property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">attack_time_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkSpinButton" id="release">
+                                                                        <property name="orientation">vertical</property>
+                                                                        <property name="digits">2</property>
+                                                                        <property name="width-chars">11</property>
+                                                                        <property name="update-policy">if-valid</property>
+                                                                        <property name="adjustment">
+                                                                            <object class="GtkAdjustment">
+                                                                                <property name="upper">5000</property>
+                                                                                <property name="value">100</property>
+                                                                                <property name="step-increment">0.01</property>
+                                                                                <property name="page-increment">0.1</property>
+                                                                            </object>
+                                                                        </property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">release_time_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+
+                                                                <layout>
+                                                                    <property name="column">0</property>
+                                                                    <property name="row">2</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+
+                                                        <!-- Curve section -->
+                                                        <child>
+                                                            <object class="GtkLabel">
+                                                                <property name="halign">center</property>
+                                                                <property name="valign">center</property>
+                                                                <property name="margin-bottom">4</property>
+                                                                <property name="label" translatable="yes">Curve</property>
+                                                                <layout>
+                                                                    <property name="column">1</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="halign">fill</property>
+                                                                <property name="homogeneous">1</property>
+                                                                <property name="margin-bottom">6</property>
+
+                                                                <child>
+                                                                    <object class="GtkLabel" id="curve_threshold_label">
+                                                                        <property name="label" translatable="yes">Threshold</property>
+
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkLabel" id="curve_zone_label">
+                                                                        <property name="label" translatable="yes">Zone</property>
+                                                                    </object>
+                                                                </child>
+
+                                                                <layout>
+                                                                    <property name="column">1</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="halign">center</property>
+                                                                <style>
+                                                                    <class name="linked" />
+                                                                </style>
+
+                                                                <child>
+                                                                    <object class="GtkSpinButton" id="curve_threshold">
+                                                                        <property name="orientation">vertical</property>
+                                                                        <property name="digits">1</property>
+                                                                        <property name="width-chars">10</property>
+                                                                        <property name="update-policy">if-valid</property>
+                                                                        <property name="adjustment">
+                                                                            <object class="GtkAdjustment">
+                                                                                <property name="lower">-60</property>
+                                                                                <property name="upper">0</property>
+                                                                                <property name="value">-24</property>
+                                                                                <property name="step-increment">0.1</property>
+                                                                                <property name="page-increment">1</property>
+                                                                            </object>
+                                                                        </property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">curve_threshold_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSpinButton" id="curve_zone">
+                                                                        <property name="orientation">vertical</property>
+                                                                        <property name="digits">1</property>
+                                                                        <property name="width-chars">10</property>
+                                                                        <property name="update-policy">if-valid</property>
+                                                                        <property name="adjustment">
+                                                                            <object class="GtkAdjustment">
+                                                                                <property name="lower">-60</property>
+                                                                                <property name="upper">0</property>
+                                                                                <property name="value">-6</property>
+                                                                                <property name="step-increment">0.1</property>
+                                                                                <property name="page-increment">1</property>
+                                                                            </object>
+                                                                        </property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">curve_zone_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+
+                                                                <layout>
+                                                                    <property name="column">1</property>
+                                                                    <property name="row">2</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+
+                                                        <!-- Hysteresis section -->
+                                                        <child>
+                                                            <object class="GtkToggleButton" id="hysteresis">
+                                                                <property name="halign">center</property>
+                                                                <property name="valign">center</property>
+                                                                <property name="margin-bottom">4</property>
+                                                                <property name="label" translatable="yes">Hysteresis</property>
+                                                                <layout>
+                                                                    <property name="column">2</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="halign">fill</property>
+                                                                <property name="homogeneous">1</property>
+                                                                <property name="margin-bottom">6</property>
+
+                                                                <child>
+                                                                    <object class="GtkLabel" id="hysteresis_threshold_label">
+                                                                        <property name="label" translatable="yes">Threshold</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkLabel" id="hysteresis_zone_label">
+                                                                        <property name="label" translatable="yes">Zone</property>
+                                                                    </object>
+                                                                </child>
+
+                                                                <layout>
+                                                                    <property name="column">2</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="halign">center</property>
+                                                                <style>
+                                                                    <class name="linked" />
+                                                                </style>
+
+                                                                <child>
+                                                                    <object class="GtkSpinButton" id="hysteresis_threshold">
+                                                                        <property name="orientation">vertical</property>
+                                                                        <property name="digits">1</property>
+                                                                        <property name="width-chars">10</property>
+                                                                        <property name="update-policy">if-valid</property>
+                                                                        <property name="sensitive" bind-source="hysteresis" bind-property="active" bind-flags="sync-create" />
+                                                                        <property name="adjustment">
+                                                                            <object class="GtkAdjustment">
+                                                                                <property name="lower">-60</property>
+                                                                                <property name="upper">0</property>
+                                                                                <property name="value">-12</property>
+                                                                                <property name="step-increment">0.1</property>
+                                                                                <property name="page-increment">1</property>
+                                                                            </object>
+                                                                        </property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">hysteresis_threshold_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSpinButton" id="hysteresis_zone">
+                                                                        <property name="orientation">vertical</property>
+                                                                        <property name="digits">1</property>
+                                                                        <property name="width-chars">10</property>
+                                                                        <property name="update-policy">if-valid</property>
+                                                                        <property name="sensitive" bind-source="hysteresis" bind-property="active" bind-flags="sync-create" />
+                                                                        <property name="adjustment">
+                                                                            <object class="GtkAdjustment">
+                                                                                <property name="lower">-60</property>
+                                                                                <property name="upper">0</property>
+                                                                                <property name="value">-6</property>
+                                                                                <property name="step-increment">0.1</property>
+                                                                                <property name="page-increment">1</property>
+                                                                            </object>
+                                                                        </property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">hysteresis_zone_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+
+                                                                <layout>
+                                                                    <property name="column">2</property>
+                                                                    <property name="row">2</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+
+                                                        <!-- Mix section -->
+                                                        <child>
+                                                            <object class="GtkLabel">
+                                                                <property name="halign">center</property>
+                                                                <property name="valign">center</property>
+                                                                <property name="margin-bottom">4</property>
+                                                                <property name="label" translatable="yes">Mix</property>
+                                                                <layout>
+                                                                    <property name="column">3</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="halign">fill</property>
+                                                                <property name="homogeneous">1</property>
+                                                                <property name="margin-bottom">6</property>
+
+                                                                <child>
+                                                                    <object class="GtkLabel" id="dry_label">
+                                                                        <property name="label" translatable="yes">Dry Level</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkLabel" id="wet_label">
+                                                                        <property name="label" translatable="yes">Wet Level</property>
+                                                                    </object>
+                                                                </child>
+
+                                                                <layout>
+                                                                    <property name="column">3</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="halign">center</property>
+                                                                <style>
+                                                                    <class name="linked" />
+                                                                </style>
+
+                                                                <child>
+                                                                    <object class="GtkSpinButton" id="dry">
+                                                                        <property name="valign">center</property>
+                                                                        <property name="orientation">vertical</property>
+                                                                        <property name="width-chars">10</property>
+                                                                        <property name="digits">1</property>
+                                                                        <property name="update-policy">if-valid</property>
+                                                                        <property name="adjustment">
+                                                                            <object class="GtkAdjustment">
+                                                                                <property name="lower">-100</property>
+                                                                                <property name="upper">20</property>
+                                                                                <property name="value">-100</property>
+                                                                                <property name="step-increment">0.1</property>
+                                                                                <property name="page-increment">1</property>
+                                                                            </object>
+                                                                        </property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">dry_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSpinButton" id="wet">
+                                                                        <property name="valign">center</property>
+                                                                        <property name="orientation">vertical</property>
+                                                                        <property name="width-chars">10</property>
+                                                                        <property name="digits">1</property>
+                                                                        <property name="update-policy">if-valid</property>
+                                                                        <property name="adjustment">
+                                                                            <object class="GtkAdjustment">
+                                                                                <property name="lower">-100</property>
+                                                                                <property name="upper">20</property>
+                                                                                <property name="step-increment">0.1</property>
+                                                                                <property name="page-increment">1</property>
+                                                                            </object>
+                                                                        </property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">wet_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+
+                                                                <layout>
+                                                                    <property name="column">3</property>
+                                                                    <property name="row">2</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+
+                                                        <!-- Reduction/Makeup section -->
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="halign">fill</property>
+                                                                <property name="homogeneous">1</property>
+                                                                <property name="margin-bottom">6</property>
+
+                                                                <child>
+                                                                    <object class="GtkLabel" id="reduction_label">
+                                                                        <property name="label" translatable="yes">Reduction</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkLabel" id="makeup_label">
+                                                                        <property name="label" translatable="yes">Makeup</property>
+                                                                    </object>
+                                                                </child>
+
+                                                                <layout>
+                                                                    <property name="column">4</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="halign">center</property>
+                                                                <style>
+                                                                    <class name="linked" />
+                                                                </style>
+
+                                                                <child>
+                                                                    <object class="GtkSpinButton" id="reduction">
+                                                                        <property name="orientation">vertical</property>
+                                                                        <property name="width-chars">10</property>
+                                                                        <property name="digits">1</property>
+                                                                        <property name="update-policy">if-valid</property>
+                                                                        <property name="adjustment">
+                                                                            <object class="GtkAdjustment">
+                                                                                <property name="lower">-72</property>
+                                                                                <property name="upper">0</property>
+                                                                                <property name="value">-24</property>
+                                                                                <property name="step-increment">0.1</property>
+                                                                                <property name="page-increment">1</property>
+                                                                            </object>
+                                                                        </property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">reduction_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSpinButton" id="makeup">
+                                                                        <property name="orientation">vertical</property>
+                                                                        <property name="width-chars">10</property>
+                                                                        <property name="digits">1</property>
+                                                                        <property name="update-policy">if-valid</property>
+                                                                        <property name="adjustment">
+                                                                            <object class="GtkAdjustment">
+                                                                                <property name="lower">-60</property>
+                                                                                <property name="upper">60</property>
+                                                                                <property name="step-increment">0.1</property>
+                                                                                <property name="page-increment">1</property>
+                                                                            </object>
+                                                                        </property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">makeup_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+
+                                                                <layout>
+                                                                    <property name="column">4</property>
+                                                                    <property name="row">2</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkBox">
+                                                        <property name="hexpand">1</property>
+                                                        <property name="vexpand">0</property>
+                                                        <property name="homogeneous">1</property>
+                                                        <property name="margin-top">4</property>
+                                                        <property name="margin-bottom">4</property>
+
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="halign">center</property>
+                                                                <child>
+                                                                    <object class="GtkLabel" id="attack_zone_start_title">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="xalign">1</property>
+                                                                        <property name="label" translatable="yes">Attack Zone Start</property>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkLabel" id="attack_zone_start_label">
+                                                                        <property name="width-chars">6</property>
+                                                                        <property name="label">0.0</property>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="halign">start</property>
+                                                                        <property name="label">db</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="halign">center</property>
+                                                                <child>
+                                                                    <object class="GtkLabel" id="attack_threshold_title">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="xalign">1</property>
+                                                                        <property name="label" translatable="yes">Attack Threshold</property>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkLabel" id="attack_threshold_label">
+                                                                        <property name="width-chars">6</property>
+                                                                        <property name="label">0.0</property>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="halign">start</property>
+                                                                        <property name="label">db</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="halign">center</property>
+                                                                <child>
+                                                                    <object class="GtkLabel" id="release_zone_start_title">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="xalign">1</property>
+                                                                        <property name="label" translatable="yes">Release Zone Start</property>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkLabel" id="release_zone_start_label">
+                                                                        <property name="width-chars">6</property>
+                                                                        <property name="label">0.0</property>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="halign">start</property>
+                                                                        <property name="label">db</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="halign">center</property>
+                                                                <child>
+                                                                    <object class="GtkLabel" id="release_threshold_title">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="xalign">1</property>
+                                                                        <property name="label" translatable="yes">Release Threshold</property>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkLabel" id="release_threshold_label">
+                                                                        <property name="width-chars">6</property>
+                                                                        <property name="label">0.0</property>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="halign">start</property>
+                                                                        <property name="label">db</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                            </object>
+                                        </property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkStackPage">
+                                        <property name="name">page_sidechain</property>
+                                        <property name="title" translatable="yes">Sidechain</property>
+                                        <property name="child">
+                                            <object class="GtkBox">
+                                                <property name="halign">center</property>
+                                                <property name="spacing">24</property>
+                                                <property name="orientation">vertical</property>
+
+                                                <child>
+                                                    <object class="GtkBox">
+                                                        <property name="halign">center</property>
+                                                        <property name="homogeneous">1</property>
+                                                        <property name="spacing">24</property>
+                                                        <child>
+                                                            <object class="GtkGrid">
+                                                                <property name="row-spacing">6</property>
+                                                                <property name="column-spacing">18</property>
+                                                                <property name="column-homogeneous">1</property>
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">Mode</property>
+                                                                        <layout>
+                                                                            <property name="column">0</property>
+                                                                            <property name="row">0</property>
+                                                                        </layout>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkComboBoxText" id="sidechain_mode">
+                                                                        <items>
+                                                                            <item translatable="yes" id="Peak">Peak</item>
+                                                                            <item translatable="yes" id="RMS">RMS</item>
+                                                                            <item translatable="yes" id="Low-Pass">Low-Pass</item>
+                                                                            <item translatable="yes" id="Uniform">Uniform</item>
+                                                                        </items>
+                                                                        <layout>
+                                                                            <property name="column">0</property>
+                                                                            <property name="row">1</property>
+                                                                        </layout>
+                                                                        <accessibility>
+                                                                            <property name="label" translatable="yes">Sidechain Mode</property>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkToggleButton" id="listen">
+                                                                        <property name="halign">center</property>
+                                                                        <property name="label" translatable="yes">Listen</property>
+                                                                        <layout>
+                                                                            <property name="column">1</property>
+                                                                            <property name="row">1</property>
+                                                                        </layout>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">Source</property>
+                                                                        <layout>
+                                                                            <property name="column">2</property>
+                                                                            <property name="row">0</property>
+                                                                        </layout>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkComboBoxText" id="sidechain_source">
+                                                                        <items>
+                                                                            <item translatable="yes" id="Middle">Middle</item>
+                                                                            <item translatable="yes" id="Side">Side</item>
+                                                                            <item translatable="yes" id="Left">Left</item>
+                                                                            <item translatable="yes" id="Right">Right</item>
+                                                                        </items>
+                                                                        <layout>
+                                                                            <property name="column">2</property>
+                                                                            <property name="row">1</property>
+                                                                        </layout>
+                                                                        <accessibility>
+                                                                            <property name="label" translatable="yes">Sidechain Source</property>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkGrid">
+                                                        <property name="halign">center</property>
+                                                        <property name="row-spacing">6</property>
+                                                        <property name="column-spacing">12</property>
+
+                                                        <child>
+                                                            <object class="GtkLabel">
+                                                                <property name="label" translatable="yes">Input</property>
+                                                                <layout>
+                                                                    <property name="column">1</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkLabel">
+                                                                <property name="halign">end</property>
+                                                                <property name="valign">center</property>
+                                                                <property name="label" translatable="yes">Type</property>
+                                                                <layout>
+                                                                    <property name="column">0</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkLabel">
+                                                                <property name="halign">end</property>
+                                                                <property name="valign">center</property>
+                                                                <property name="label" translatable="yes">Device</property>
+                                                                <layout>
+                                                                    <property name="column">0</property>
+                                                                    <property name="row">2</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkComboBoxText" id="sidechain_input">
+                                                                <property name="valign">center</property>
+                                                                <property name="margin-end">6</property>
+                                                                <items>
+                                                                    <item id="Internal" translatable="yes">Internal</item>
+                                                                    <item id="External" translatable="yes">External</item>
+                                                                </items>
+                                                                <layout>
+                                                                    <property name="column">1</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <property name="label" translatable="yes">Sidechain Type</property>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkDropDown" id="dropdown_input_devices">
+                                                                <property name="valign">center</property>
+                                                                <property name="margin-end">6</property>
+
+                                                                <binding name="sensitive">
+                                                                    <closure type="gboolean" function="set_dropdown_sensitive">
+                                                                        <lookup name="active-id">sidechain_input</lookup>
+                                                                    </closure>
+                                                                </binding>
+
+                                                                <property name="factory">
+                                                                    <object class="GtkBuilderListItemFactory">
+                                                                        <property name="resource">/com/github/wwmm/easyeffects/ui/factory_input_device_dropdown.ui</property>
+                                                                    </object>
+                                                                </property>
+
+                                                                <layout>
+                                                                    <property name="column">1</property>
+                                                                    <property name="row">2</property>
+                                                                </layout>
+
+                                                                <accessibility>
+                                                                    <property name="label" translatable="yes">Input Device</property>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+
+
+                                                        <child>
+                                                            <object class="GtkLabel" id="preamp_label">
+                                                                <property name="label" translatable="yes">PreAmplification</property>
+                                                                <layout>
+                                                                    <property name="column">2</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="preamp">
+                                                                <property name="halign">center</property>
+                                                                <property name="margin-start">6</property>
+                                                                <property name="margin-end">6</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">1</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-120</property>
+                                                                        <property name="upper">40</property>
+                                                                        <property name="step-increment">0.1</property>
+                                                                        <property name="page-increment">1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">2</property>
+                                                                    <property name="row">1</property>
+                                                                    <property name="row-span">2</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">preamp_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkLabel" id="reactivity_label">
+                                                                <property name="label" translatable="yes">Reactivity</property>
+                                                                <layout>
+                                                                    <property name="column">3</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="reactivity">
+                                                                <property name="halign">center</property>
+                                                                <property name="margin-start">6</property>
+                                                                <property name="margin-end">6</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">2</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="upper">250</property>
+                                                                        <property name="value">10</property>
+                                                                        <property name="step-increment">0.01</property>
+                                                                        <property name="page-increment">0.1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">3</property>
+                                                                    <property name="row">1</property>
+                                                                    <property name="row-span">2</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">reactivity_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkLabel" id="lookahead_label">
+                                                                <property name="label" translatable="yes">Lookahead</property>
+                                                                <layout>
+                                                                    <property name="column">4</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="lookahead">
+                                                                <property name="halign">center</property>
+                                                                <property name="margin-start">6</property>
+                                                                <property name="margin-end">6</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">2</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="upper">20</property>
+                                                                        <property name="step-increment">0.01</property>
+                                                                        <property name="page-increment">0.1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">4</property>
+                                                                    <property name="row">1</property>
+                                                                    <property name="row-span">2</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">lookahead_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkStackPage">
+                                        <property name="name">page_sidechain_filters</property>
+                                        <property name="title" translatable="yes">Sidechain Filters</property>
+                                        <property name="child">
                                             <object class="GtkGrid">
+                                                <property name="halign">center</property>
                                                 <property name="row-spacing">6</property>
-                                                <property name="column-spacing">18</property>
-                                                <property name="column-homogeneous">1</property>
+                                                <property name="column-spacing">12</property>
+                                                <property name="margin-top">12</property>
+                                                <property name="margin-bottom">12</property>
                                                 <child>
                                                     <object class="GtkLabel">
-                                                        <property name="label" translatable="yes">Mode</property>
+                                                        <property name="label" translatable="yes">High-Pass</property>
                                                         <layout>
-                                                            <property name="column">0</property>
+                                                            <property name="column">1</property>
                                                             <property name="row">0</property>
                                                         </layout>
                                                     </object>
                                                 </child>
+
                                                 <child>
-                                                    <object class="GtkComboBoxText" id="sidechain_mode">
-                                                        <items>
-                                                            <item translatable="yes" id="Peak">Peak</item>
-                                                            <item translatable="yes" id="RMS">RMS</item>
-                                                            <item translatable="yes" id="Low-Pass">Low-Pass</item>
-                                                            <item translatable="yes" id="Uniform">Uniform</item>
-                                                        </items>
+                                                    <object class="GtkLabel">
+                                                        <property name="halign">end</property>
+                                                        <property name="valign">center</property>
+                                                        <property name="margin-bottom">6</property>
+                                                        <property name="label" translatable="yes">Mode</property>
                                                         <layout>
                                                             <property name="column">0</property>
                                                             <property name="row">1</property>
                                                         </layout>
-                                                        <accessibility>
-                                                            <property name="label" translatable="yes">Sidechain Mode</property>
-                                                        </accessibility>
                                                     </object>
                                                 </child>
 
                                                 <child>
-                                                    <object class="GtkToggleButton" id="listen">
-                                                        <property name="halign">center</property>
-                                                        <property name="label" translatable="yes">Listen</property>
+                                                    <object class="GtkLabel">
+                                                        <property name="halign">end</property>
+                                                        <property name="valign">center</property>
+                                                        <property name="margin-top">6</property>
+                                                        <property name="label" translatable="yes">Frequency</property>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">2</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkComboBoxText" id="hpf_mode">
+                                                        <property name="margin-bottom">6</property>
+                                                        <property name="margin-end">6</property>
+                                                        <items>
+                                                            <item translatable="yes" id="off">Off</item>
+                                                            <item translatable="yes" id="12 dB/oct">12 dB/oct</item>
+                                                            <item translatable="yes" id="24 dB/oct">24 dB/oct</item>
+                                                            <item translatable="yes" id="36 dB/oct">36 dB/oct</item>
+                                                        </items>
                                                         <layout>
                                                             <property name="column">1</property>
                                                             <property name="row">1</property>
                                                         </layout>
+                                                        <accessibility>
+                                                            <property name="label" translatable="yes">High-Pass Filter Mode</property>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkSpinButton" id="hpf_freq">
+                                                        <property name="margin-top">6</property>
+                                                        <property name="margin-end">6</property>
+                                                        <property name="digits">0</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">10</property>
+                                                                <property name="upper">20000</property>
+                                                                <property name="value">10</property>
+                                                                <property name="step-increment">1</property>
+                                                                <property name="page-increment">100</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">2</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <property name="label" translatable="yes">High-Pass Filter Frequency</property>
+                                                        </accessibility>
                                                     </object>
                                                 </child>
 
                                                 <child>
                                                     <object class="GtkLabel">
-                                                        <property name="label" translatable="yes">Source</property>
+                                                        <property name="label" translatable="yes">Low-Pass</property>
                                                         <layout>
                                                             <property name="column">2</property>
                                                             <property name="row">0</property>
                                                         </layout>
                                                     </object>
                                                 </child>
+
                                                 <child>
-                                                    <object class="GtkComboBoxText" id="sidechain_source">
+                                                    <object class="GtkComboBoxText" id="lpf_mode">
+                                                        <property name="margin-bottom">6</property>
+                                                        <property name="margin-start">6</property>
                                                         <items>
-                                                            <item translatable="yes" id="Middle">Middle</item>
-                                                            <item translatable="yes" id="Side">Side</item>
-                                                            <item translatable="yes" id="Left">Left</item>
-                                                            <item translatable="yes" id="Right">Right</item>
+                                                            <item translatable="yes" id="off">Off</item>
+                                                            <item translatable="yes" id="12 dB/oct">12 dB/oct</item>
+                                                            <item translatable="yes" id="24 dB/oct">24 dB/oct</item>
+                                                            <item translatable="yes" id="36 dB/oct">36 dB/oct</item>
                                                         </items>
                                                         <layout>
                                                             <property name="column">2</property>
                                                             <property name="row">1</property>
                                                         </layout>
                                                         <accessibility>
-                                                            <property name="label" translatable="yes">Sidechain Source</property>
+                                                            <property name="label" translatable="yes">Low-Pass Filter Mode</property>
                                                         </accessibility>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkSpinButton" id="lpf_freq">
+                                                        <property name="margin-top">6</property>
+                                                        <property name="margin-start">6</property>
+                                                        <property name="digits">0</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">10</property>
+                                                                <property name="upper">20000</property>
+                                                                <property name="value">20000</property>
+                                                                <property name="step-increment">1</property>
+                                                                <property name="page-increment">100</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">2</property>
+                                                            <property name="row">2</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <property name="label" translatable="yes">High-Pass Filter Frequency</property>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="margin-top">4</property>
+                                <property name="margin-bottom">4</property>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <child>
+                                            <object class="GtkLabel" id="gain_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Reduction</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="gain_label">
+                                                <property name="width-chars">6</property>
+                                                <property name="label">0</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">start</property>
+                                                <property name="label">db</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <child>
+                                            <object class="GtkLabel" id="envelope_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Envelope</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="envelope_label">
+                                                <property name="width-chars">6</property>
+                                                <property name="label">0</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">start</property>
+                                                <property name="label">db</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <child>
+                                            <object class="GtkLabel" id="sidechain_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Sidechain</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="sidechain_label">
+                                                <property name="width-chars">6</property>
+                                                <property name="label">0</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">start</property>
+                                                <property name="label">db</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <child>
+                                            <object class="GtkLabel" id="curve_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Curve</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel" id="curve_label">
+                                                <property name="width-chars">6</property>
+                                                <property name="label">0</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">start</property>
+                                                <property name="label">db</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
                                                     </object>
                                                 </child>
                                             </object>
                                         </child>
                                     </object>
                                 </child>
+                            </object>
+                        </child>
 
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
                                 <child>
-                                    <object class="GtkGrid">
-                                        <property name="halign">center</property>
-                                        <property name="row-spacing">6</property>
-                                        <property name="column-spacing">12</property>
-
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
                                         <child>
-                                            <object class="GtkLabel">
-                                                <property name="label" translatable="yes">Input</property>
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel">
+                                            <object class="GtkLabel" id="output_level_title">
                                                 <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
                                                 <property name="valign">center</property>
-                                                <property name="label" translatable="yes">Type</property>
-                                                <layout>
-                                                    <property name="column">0</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="halign">end</property>
-                                                <property name="valign">center</property>
-                                                <property name="label" translatable="yes">Device</property>
-                                                <layout>
-                                                    <property name="column">0</property>
-                                                    <property name="row">2</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkComboBoxText" id="sidechain_input">
-                                                <property name="valign">center</property>
-                                                <property name="margin-end">6</property>
-                                                <items>
-                                                    <item id="Internal" translatable="yes">Internal</item>
-                                                    <item id="External" translatable="yes">External</item>
-                                                </items>
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <property name="label" translatable="yes">Sidechain Type</property>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkDropDown" id="dropdown_input_devices">
-                                                <property name="valign">center</property>
-                                                <property name="margin-end">6</property>
-
-                                                <binding name="sensitive">
-                                                    <closure type="gboolean" function="set_dropdown_sensitive">
-                                                        <lookup name="active-id">sidechain_input</lookup>
-                                                    </closure>
-                                                </binding>
-
-                                                <property name="factory">
-                                                    <object class="GtkBuilderListItemFactory">
-                                                        <property name="resource">/com/github/wwmm/easyeffects/ui/factory_input_device_dropdown.ui</property>
-                                                    </object>
-                                                </property>
-
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">2</property>
-                                                </layout>
-
-                                                <accessibility>
-                                                    <property name="label" translatable="yes">Input Device</property>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-
-
-                                        <child>
-                                            <object class="GtkLabel" id="preamp_label">
-                                                <property name="label" translatable="yes">PreAmplification</property>
-                                                <layout>
-                                                    <property name="column">2</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="preamp">
-                                                <property name="halign">center</property>
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">6</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">1</property>
-                                                <property name="update-policy">if-valid</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
-                                                        <property name="lower">-120</property>
-                                                        <property name="upper">40</property>
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
                                                         <property name="step-increment">0.1</property>
                                                         <property name="page-increment">1</property>
                                                     </object>
                                                 </property>
-                                                <layout>
-                                                    <property name="column">2</property>
-                                                    <property name="row">1</property>
-                                                    <property name="row-span">2</property>
-                                                </layout>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
                                                 <accessibility>
-                                                    <relation name="labelled-by">preamp_label</relation>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
                                                 </accessibility>
                                             </object>
                                         </child>
-
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
                                         <child>
-                                            <object class="GtkLabel" id="reactivity_label">
-                                                <property name="label" translatable="yes">Reactivity</property>
-                                                <layout>
-                                                    <property name="column">3</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="reactivity">
-                                                <property name="halign">center</property>
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">6</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">2</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="upper">250</property>
-                                                        <property name="value">10</property>
-                                                        <property name="step-increment">0.01</property>
-                                                        <property name="page-increment">0.1</property>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
                                                     </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">3</property>
-                                                    <property name="row">1</property>
-                                                    <property name="row-span">2</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">reactivity_label</relation>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel" id="lookahead_label">
-                                                <property name="label" translatable="yes">Lookahead</property>
-                                                <layout>
-                                                    <property name="column">4</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="lookahead">
-                                                <property name="halign">center</property>
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">6</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">2</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="upper">20</property>
-                                                        <property name="step-increment">0.01</property>
-                                                        <property name="page-increment">0.1</property>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
                                                     </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">4</property>
-                                                    <property name="row">1</property>
-                                                    <property name="row-span">2</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">lookahead_label</relation>
-                                                </accessibility>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
                                             </object>
                                         </child>
                                     </object>
                                 </child>
                             </object>
-                        </property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkStackPage">
-                        <property name="name">page_sidechain_filters</property>
-                        <property name="title" translatable="yes">Sidechain Filters</property>
-                        <property name="child">
-                            <object class="GtkGrid">
-                                <property name="halign">center</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">12</property>
-                                <property name="margin-top">12</property>
-                                <property name="margin-bottom">12</property>
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="label" translatable="yes">High-Pass</property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                        <property name="margin-bottom">6</property>
-                                        <property name="label" translatable="yes">Mode</property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                        <property name="margin-top">6</property>
-                                        <property name="label" translatable="yes">Frequency</property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">2</property>
-                                        </layout>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkComboBoxText" id="hpf_mode">
-                                        <property name="margin-bottom">6</property>
-                                        <property name="margin-end">6</property>
-                                        <items>
-                                            <item translatable="yes" id="off">Off</item>
-                                            <item translatable="yes" id="12 dB/oct">12 dB/oct</item>
-                                            <item translatable="yes" id="24 dB/oct">24 dB/oct</item>
-                                            <item translatable="yes" id="36 dB/oct">36 dB/oct</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <property name="label" translatable="yes">High-Pass Filter Mode</property>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkSpinButton" id="hpf_freq">
-                                        <property name="margin-top">6</property>
-                                        <property name="margin-end">6</property>
-                                        <property name="digits">0</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">10</property>
-                                                <property name="upper">20000</property>
-                                                <property name="value">10</property>
-                                                <property name="step-increment">1</property>
-                                                <property name="page-increment">100</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">2</property>
-                                        </layout>
-                                        <accessibility>
-                                            <property name="label" translatable="yes">High-Pass Filter Frequency</property>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="label" translatable="yes">Low-Pass</property>
-                                        <layout>
-                                            <property name="column">2</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkComboBoxText" id="lpf_mode">
-                                        <property name="margin-bottom">6</property>
-                                        <property name="margin-start">6</property>
-                                        <items>
-                                            <item translatable="yes" id="off">Off</item>
-                                            <item translatable="yes" id="12 dB/oct">12 dB/oct</item>
-                                            <item translatable="yes" id="24 dB/oct">24 dB/oct</item>
-                                            <item translatable="yes" id="36 dB/oct">36 dB/oct</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">2</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <property name="label" translatable="yes">Low-Pass Filter Mode</property>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkSpinButton" id="lpf_freq">
-                                        <property name="margin-top">6</property>
-                                        <property name="margin-start">6</property>
-                                        <property name="digits">0</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">10</property>
-                                                <property name="upper">20000</property>
-                                                <property name="value">20000</property>
-                                                <property name="step-increment">1</property>
-                                                <property name="page-increment">100</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">2</property>
-                                            <property name="row">2</property>
-                                        </layout>
-                                        <accessibility>
-                                            <property name="label" translatable="yes">High-Pass Filter Frequency</property>
-                                        </accessibility>
-                                    </object>
-                                </child>
-                            </object>
-                        </property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="margin-top">4</property>
-                <property name="margin-bottom">4</property>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">center</property>
-                        <child>
-                            <object class="GtkLabel" id="gain_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Reduction</property>
-                            </object>
                         </child>
 
                         <child>
-                            <object class="GtkLabel" id="gain_label">
-                                <property name="width-chars">6</property>
-                                <property name="label">0</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">start</property>
-                                <property name="label">db</property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">center</property>
-                        <child>
-                            <object class="GtkLabel" id="envelope_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Envelope</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel" id="envelope_label">
-                                <property name="width-chars">6</property>
-                                <property name="label">0</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">start</property>
-                                <property name="label">db</property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">center</property>
-                        <child>
-                            <object class="GtkLabel" id="sidechain_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Sidechain</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel" id="sidechain_label">
-                                <property name="width-chars">6</property>
-                                <property name="label">0</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">start</property>
-                                <property name="label">db</property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">center</property>
-                        <child>
-                            <object class="GtkLabel" id="curve_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Curve</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel" id="curve_label">
-                                <property name="width-chars">6</property>
-                                <property name="label">0</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">start</property>
-                                <property name="label">db</property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
+                                <property name="vexpand">0</property>
                                 <property name="spacing">6</property>
                                 <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
+                                    <object class="GtkLabel" id="gating_title">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
+                                        <property name="xalign">1</property>
+                                        <property name="label" translatable="yes">Gating</property>
                                     </object>
                                 </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
+                                <child>
+                                    <object class="GtkLevelBar" id="gating">
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">1</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="gating_label">
+                                        <property name="halign">end</property>
+                                        <property name="width-chars">4</property>
+                                        <property name="label">0</property>
+                                    </object>
+                                </child>
                             </object>
                         </child>
+
                         <child>
-                            <object class="GtkScale" id="output_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="GateBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Linux Studio Plugins</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="gating_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Gating</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="gating">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="gating_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">4</property>
-                        <property name="label">0</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="GateBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">Linux Studio Plugins</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/limiter.ui
+++ b/data/ui/limiter.ui
@@ -5,906 +5,920 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
-
         <child>
-            <object class="GtkBox">
-                <property name="margin-bottom">6</property>
-                <property name="spacing">12</property>
-                <property name="orientation">vertical</property>
-
-                <child>
-                    <object class="GtkGrid">
-                        <property name="halign">center</property>
-                        <property name="row-spacing">6</property>
-                        <property name="column-spacing">12</property>
-                        <property name="margin-start">12</property>
-
-                        <child>
-                            <object class="GtkGrid">
-                                <property name="halign">center</property>
-                                <property name="valign">end</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">12</property>
-                                <property name="margin-end">12</property>
-
-                                <child>
-                                    <object class="GtkLabel" id="mode_label">
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                        <property name="label" translatable="yes">Mode</property>
-
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="oversampling_label">
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                        <property name="label" translatable="yes">Oversampling</property>
-
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="dither_label">
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                        <property name="label" translatable="yes">Dither</property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">2</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkComboBoxText" id="mode">
-                                        <property name="hexpand">1</property>
-                                        <property name="valign">center</property>
-                                        <items>
-                                            <item translatable="yes" id="Herm Thin">Herm Thin</item>
-                                            <item translatable="yes" id="Herm Wide">Herm Wide</item>
-                                            <item translatable="yes" id="Herm Tail">Herm Tail</item>
-                                            <item translatable="yes" id="Herm Duck">Herm Duck</item>
-                                            <item translatable="yes" id="Exp Thin">Exp Thin</item>
-                                            <item translatable="yes" id="Exp Wide">Exp Wide</item>
-                                            <item translatable="yes" id="Exp Tail">Exp Tail</item>
-                                            <item translatable="yes" id="Exp Duck">Exp Duck</item>
-                                            <item translatable="yes" id="Line Thin">Line Thin</item>
-                                            <item translatable="yes" id="Line Wide">Line Wide</item>
-                                            <item translatable="yes" id="Line Tail">Line Tail</item>
-                                            <item translatable="yes" id="Line Duck">Line Duck</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">mode_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkComboBoxText" id="oversampling">
-                                        <property name="hexpand">1</property>
-                                        <property name="valign">center</property>
-                                        <items>
-                                            <item translatable="yes" id="None">None</item>
-                                            <item translatable="yes" id="Half x2(2L)">Half x2(2L)</item>
-                                            <item translatable="yes" id="Half x2(3L)">Half x2(3L)</item>
-                                            <item translatable="yes" id="Half x3(2L)">Half x3(2L)</item>
-                                            <item translatable="yes" id="Half x3(3L)">Half x3(3L)</item>
-                                            <item translatable="yes" id="Half x4(2L)">Half x4(2L)</item>
-                                            <item translatable="yes" id="Half x4(3L)">Half x4(3L)</item>
-                                            <item translatable="yes" id="Half x6(2L)">Half x6(2L)</item>
-                                            <item translatable="yes" id="Half x6(3L)">Half x6(3L)</item>
-                                            <item translatable="yes" id="Half x8(2L)">Half x8(2L)</item>
-                                            <item translatable="yes" id="Half x8(3L)">Half x8(3L)</item>
-                                            <item translatable="yes" id="Full x2(2L)">Full x2(2L)</item>
-                                            <item translatable="yes" id="Full x2(3L)">Full x2(3L)</item>
-                                            <item translatable="yes" id="Full x3(2L)">Full x3(2L)</item>
-                                            <item translatable="yes" id="Full x3(3L)">Full x3(3L)</item>
-                                            <item translatable="yes" id="Full x4(2L)">Full x4(2L)</item>
-                                            <item translatable="yes" id="Full x4(3L)">Full x4(3L)</item>
-                                            <item translatable="yes" id="Full x6(2L)">Full x6(2L)</item>
-                                            <item translatable="yes" id="Full x6(3L)">Full x6(3L)</item>
-                                            <item translatable="yes" id="Full x8(2L)">Full x8(2L)</item>
-                                            <item translatable="yes" id="Full x8(3L)">Full x8(3L)</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">oversampling_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkComboBoxText" id="dither">
-                                        <property name="hexpand">1</property>
-                                        <property name="valign">center</property>
-                                        <items>
-                                            <item id="None">None</item>
-                                            <item id="7bit">7bit</item>
-                                            <item id="8bit">8bit</item>
-                                            <item id="11bit">11bit</item>
-                                            <item id="12bit">12bit</item>
-                                            <item id="15bit">15bit</item>
-                                            <item id="16bit">16bit</item>
-                                            <item id="23bit">23bit</item>
-                                            <item id="24bit">24bit</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">2</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">dither_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-                                <layout>
-                                    <property name="column">0</property>
-                                    <property name="row">0</property>
-                                    <property name="row-span">2</property>
-                                </layout>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkBox">
-                                <property name="halign">center</property>
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="halign">center</property>
-                                        <property name="valign">end</property>
-                                        <property name="label" translatable="yes">SC PreAmp</property>
-                                    </object>
-                                </child>
-                                <layout>
-                                    <property name="column">1</property>
-                                    <property name="row">0</property>
-                                </layout>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkSpinButton" id="sc_preamp">
-                                <property name="halign">center</property>
-                                <property name="orientation">vertical</property>
-                                <property name="width-chars">10</property>
-                                <property name="digits">1</property>
-                                <property name="update-policy">if-valid</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-120</property>
-                                        <property name="upper">40</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <layout>
-                                    <property name="column">1</property>
-                                    <property name="row">1</property>
-                                </layout>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Sidechain PreAmplification</property>
-                                </accessibility>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkBox">
-                                <property name="halign">center</property>
-                                <child>
-                                    <object class="GtkLabel" id="lookahead_label">
-                                        <property name="halign">center</property>
-                                        <property name="valign">end</property>
-                                        <property name="label" translatable="yes">Lookahead</property>
-                                    </object>
-                                </child>
-                                <layout>
-                                    <property name="column">2</property>
-                                    <property name="row">0</property>
-                                </layout>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkSpinButton" id="lookahead">
-                                <property name="halign">center</property>
-                                <property name="orientation">vertical</property>
-                                <property name="width-chars">10</property>
-                                <property name="digits">2</property>
-                                <property name="update-policy">if-valid</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">0.1</property>
-                                        <property name="upper">20</property>
-                                        <property name="value">5</property>
-                                        <property name="step-increment">0.01</property>
-                                        <property name="page-increment">0.1</property>
-                                    </object>
-                                </property>
-                                <layout>
-                                    <property name="column">2</property>
-                                    <property name="row">1</property>
-                                </layout>
-                                <accessibility>
-                                    <relation name="labelled-by">lookahead_label</relation>
-                                </accessibility>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkBox">
-                                <property name="halign">center</property>
-                                <child>
-                                    <object class="GtkLabel" id="attack_label">
-                                        <property name="halign">center</property>
-                                        <property name="valign">end</property>
-                                        <property name="label" translatable="yes">Attack</property>
-                                    </object>
-                                </child>
-                                <layout>
-                                    <property name="column">3</property>
-                                    <property name="row">0</property>
-                                </layout>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkSpinButton" id="attack">
-                                <property name="halign">center</property>
-                                <property name="orientation">vertical</property>
-                                <property name="width-chars">10</property>
-                                <property name="digits">2</property>
-                                <property name="update-policy">if-valid</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">0.25</property>
-                                        <property name="upper">20</property>
-                                        <property name="value">5</property>
-                                        <property name="step-increment">0.01</property>
-                                        <property name="page-increment">0.1</property>
-                                    </object>
-                                </property>
-                                <layout>
-                                    <property name="column">3</property>
-                                    <property name="row">1</property>
-                                </layout>
-                                <accessibility>
-                                    <relation name="labelled-by">attack_label</relation>
-                                </accessibility>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkBox">
-                                <property name="halign">center</property>
-                                <child>
-                                    <object class="GtkLabel" id="release_label">
-                                        <property name="halign">center</property>
-                                        <property name="valign">end</property>
-                                        <property name="label" translatable="yes">Release</property>
-                                    </object>
-                                </child>
-                                <layout>
-                                    <property name="column">4</property>
-                                    <property name="row">0</property>
-                                </layout>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkSpinButton" id="release">
-                                <property name="halign">center</property>
-                                <property name="orientation">vertical</property>
-                                <property name="width-chars">10</property>
-                                <property name="digits">2</property>
-                                <property name="update-policy">if-valid</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">0.25</property>
-                                        <property name="upper">20</property>
-                                        <property name="value">5</property>
-                                        <property name="step-increment">0.01</property>
-                                        <property name="page-increment">0.1</property>
-                                    </object>
-                                </property>
-                                <layout>
-                                    <property name="column">4</property>
-                                    <property name="row">1</property>
-                                </layout>
-                                <accessibility>
-                                    <relation name="labelled-by">release_label</relation>
-                                </accessibility>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkBox">
-                                <property name="halign">center</property>
-                                <child>
-                                    <object class="GtkLabel" id="threshold_label">
-                                        <property name="halign">center</property>
-                                        <property name="valign">end</property>
-                                        <property name="label" translatable="yes">Threshold</property>
-                                    </object>
-                                </child>
-                                <layout>
-                                    <property name="column">5</property>
-                                    <property name="row">0</property>
-                                </layout>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkSpinButton" id="threshold">
-                                <property name="halign">center</property>
-                                <property name="orientation">vertical</property>
-                                <property name="width-chars">10</property>
-                                <property name="digits">2</property>
-                                <property name="update-policy">if-valid</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-48</property>
-                                        <property name="step-increment">0.01</property>
-                                        <property name="page-increment">0.1</property>
-                                    </object>
-                                </property>
-                                <layout>
-                                    <property name="column">5</property>
-                                    <property name="row">1</property>
-                                </layout>
-                                <accessibility>
-                                    <relation name="labelled-by">threshold_label</relation>
-                                </accessibility>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkCheckButton" id="gain_boost">
-                                <property name="halign">center</property>
-                                <property name="valign">start</property>
-                                <property name="label" translatable="yes">Boost</property>
-                                <layout>
-                                    <property name="column">5</property>
-                                    <property name="row">2</property>
-                                </layout>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkBox">
-                                <property name="halign">center</property>
-                                <child>
-                                    <object class="GtkLabel" id="stereo_link_label">
-                                        <property name="halign">center</property>
-                                        <property name="valign">end</property>
-                                        <property name="label" translatable="yes">Stereo Link</property>
-                                    </object>
-                                </child>
-                                <layout>
-                                    <property name="column">6</property>
-                                    <property name="row">0</property>
-                                </layout>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkSpinButton" id="stereo_link">
-                                <property name="halign">center</property>
-                                <property name="orientation">vertical</property>
-                                <property name="width-chars">10</property>
-                                <property name="digits">2</property>
-                                <property name="update-policy">if-valid</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">0</property>
-                                        <property name="upper">100</property>
-                                        <property name="value">100</property>
-                                        <property name="step-increment">0.01</property>
-                                        <property name="page-increment">0.1</property>
-                                    </object>
-                                </property>
-                                <layout>
-                                    <property name="column">6</property>
-                                    <property name="row">1</property>
-                                </layout>
-                                <accessibility>
-                                    <relation name="labelled-by">stereo_link_label</relation>
-                                </accessibility>
-                            </object>
-                        </child>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
                 <child>
                     <object class="GtkBox">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="spacing">24</property>
-                        <child>
-                            <object class="GtkToggleButton" id="external_sidechain">
-                                <property name="valign">center</property>
-                                <property name="label" translatable="yes">External Sidechain</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkDropDown" id="dropdown_input_devices">
-                                <property name="valign">center</property>
-                                <property name="sensitive" bind-source="external_sidechain" bind-property="active" bind-flags="sync-create" />
-                                <property name="factory">
-                                    <object class="GtkBuilderListItemFactory">
-                                        <property name="resource">/com/github/wwmm/easyeffects/ui/factory_input_device_dropdown.ui</property>
-                                    </object>
-                                </property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">External Sidechain Source</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkGrid" id="alr_grid">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="row-spacing">6</property>
-                        <property name="column-spacing">12</property>
-
-                        <child>
-                            <object class="GtkToggleButton" id="alr">
-                                <property name="margin-end">12</property>
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                                <property name="label" translatable="yes">Auto Leveling</property>
-                                <layout>
-                                    <property name="column">0</property>
-                                    <property name="row">1</property>
-                                </layout>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="label" translatable="yes">Attack</property>
-
-                                <layout>
-                                    <property name="column">1</property>
-                                    <property name="row">0</property>
-                                </layout>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkSpinButton" id="alr_attack">
-                                <property name="halign">center</property>
-                                <property name="orientation">vertical</property>
-                                <property name="width-chars">10</property>
-                                <property name="digits">2</property>
-                                <property name="update-policy">if-valid</property>
-                                <property name="sensitive" bind-source="alr" bind-property="active" bind-flags="sync-create" />
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">0.1</property>
-                                        <property name="upper">200</property>
-                                        <property name="value">5</property>
-                                        <property name="step-increment">0.01</property>
-                                        <property name="page-increment">0.1</property>
-                                    </object>
-                                </property>
-                                <layout>
-                                    <property name="column">1</property>
-                                    <property name="row">1</property>
-                                </layout>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Auto Leveling Attack</property>
-                                </accessibility>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="label" translatable="yes">Release</property>
-                                <layout>
-                                    <property name="column">2</property>
-                                    <property name="row">0</property>
-                                </layout>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkSpinButton" id="alr_release">
-                                <property name="halign">center</property>
-                                <property name="orientation">vertical</property>
-                                <property name="width-chars">11</property>
-                                <property name="digits">2</property>
-                                <property name="update-policy">if-valid</property>
-                                <property name="sensitive" bind-source="alr" bind-property="active" bind-flags="sync-create" />
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">10</property>
-                                        <property name="upper">1000</property>
-                                        <property name="value">50</property>
-                                        <property name="step-increment">0.01</property>
-                                        <property name="page-increment">0.1</property>
-                                    </object>
-                                </property>
-                                <layout>
-                                    <property name="column">2</property>
-                                    <property name="row">1</property>
-                                </layout>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Auto Leveling Release</property>
-                                </accessibility>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="label" translatable="yes">Knee</property>
-                                <layout>
-                                    <property name="column">3</property>
-                                    <property name="row">0</property>
-                                </layout>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkSpinButton" id="alr_knee">
-                                <property name="halign">center</property>
-                                <property name="orientation">vertical</property>
-                                <property name="width-chars">10</property>
-                                <property name="digits">1</property>
-                                <property name="update-policy">if-valid</property>
-                                <property name="sensitive" bind-source="alr" bind-property="active" bind-flags="sync-create" />
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-12</property>
-                                        <property name="upper">12</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <layout>
-                                    <property name="column">3</property>
-                                    <property name="row">1</property>
-                                </layout>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Auto Leveling Knee</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="margin-top">4</property>
-                <property name="margin-bottom">4</property>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <child>
-                            <object class="GtkLabel" id="gain_left_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Gain Left</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel" id="gain_left">
-                                <property name="halign">center</property>
-                                <property name="width-chars">6</property>
-                                <property name="label">0</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">start</property>
-                                <property name="label">db</property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <child>
-                            <object class="GtkLabel" id="gain_right_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Gain Right</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel" id="gain_right">
-                                <property name="halign">center</property>
-                                <property name="width-chars">6</property>
-                                <property name="label">0</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">start</property>
-                                <property name="label">db</property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <child>
-                            <object class="GtkLabel" id="sidechain_left_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Sidechain Left</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel" id="sidechain_left">
-                                <property name="halign">center</property>
-                                <property name="width-chars">6</property>
-                                <property name="label">0</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">start</property>
-                                <property name="label">db</property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <child>
-                            <object class="GtkLabel" id="sidechain_right_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Sidechain Right</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel" id="sidechain_right">
-                                <property name="halign">center</property>
-                                <property name="width-chars">6</property>
-                                <property name="label">0</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">start</property>
-                                <property name="label">db</property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
-                                <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
+                        <property name="spacing">12</property>
                         <property name="orientation">vertical</property>
                         <child>
                             <object class="GtkBox">
-                                <property name="spacing">6</property>
+                                <property name="margin-bottom">6</property>
+                                <property name="spacing">12</property>
+                                <property name="orientation">vertical</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
+                                    <object class="GtkGrid">
+                                        <property name="halign">center</property>
+                                        <property name="row-spacing">6</property>
+                                        <property name="column-spacing">12</property>
+                                        <property name="margin-start">12</property>
+
+                                        <child>
+                                            <object class="GtkGrid">
+                                                <property name="halign">center</property>
+                                                <property name="valign">end</property>
+                                                <property name="row-spacing">6</property>
+                                                <property name="column-spacing">12</property>
+                                                <property name="margin-end">12</property>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="mode_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="valign">center</property>
+                                                        <property name="label" translatable="yes">Mode</property>
+
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="oversampling_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="valign">center</property>
+                                                        <property name="label" translatable="yes">Oversampling</property>
+
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="dither_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="valign">center</property>
+                                                        <property name="label" translatable="yes">Dither</property>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">2</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkComboBoxText" id="mode">
+                                                        <property name="hexpand">1</property>
+                                                        <property name="valign">center</property>
+                                                        <items>
+                                                            <item translatable="yes" id="Herm Thin">Herm Thin</item>
+                                                            <item translatable="yes" id="Herm Wide">Herm Wide</item>
+                                                            <item translatable="yes" id="Herm Tail">Herm Tail</item>
+                                                            <item translatable="yes" id="Herm Duck">Herm Duck</item>
+                                                            <item translatable="yes" id="Exp Thin">Exp Thin</item>
+                                                            <item translatable="yes" id="Exp Wide">Exp Wide</item>
+                                                            <item translatable="yes" id="Exp Tail">Exp Tail</item>
+                                                            <item translatable="yes" id="Exp Duck">Exp Duck</item>
+                                                            <item translatable="yes" id="Line Thin">Line Thin</item>
+                                                            <item translatable="yes" id="Line Wide">Line Wide</item>
+                                                            <item translatable="yes" id="Line Tail">Line Tail</item>
+                                                            <item translatable="yes" id="Line Duck">Line Duck</item>
+                                                        </items>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">mode_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkComboBoxText" id="oversampling">
+                                                        <property name="hexpand">1</property>
+                                                        <property name="valign">center</property>
+                                                        <items>
+                                                            <item translatable="yes" id="None">None</item>
+                                                            <item translatable="yes" id="Half x2(2L)">Half x2(2L)</item>
+                                                            <item translatable="yes" id="Half x2(3L)">Half x2(3L)</item>
+                                                            <item translatable="yes" id="Half x3(2L)">Half x3(2L)</item>
+                                                            <item translatable="yes" id="Half x3(3L)">Half x3(3L)</item>
+                                                            <item translatable="yes" id="Half x4(2L)">Half x4(2L)</item>
+                                                            <item translatable="yes" id="Half x4(3L)">Half x4(3L)</item>
+                                                            <item translatable="yes" id="Half x6(2L)">Half x6(2L)</item>
+                                                            <item translatable="yes" id="Half x6(3L)">Half x6(3L)</item>
+                                                            <item translatable="yes" id="Half x8(2L)">Half x8(2L)</item>
+                                                            <item translatable="yes" id="Half x8(3L)">Half x8(3L)</item>
+                                                            <item translatable="yes" id="Full x2(2L)">Full x2(2L)</item>
+                                                            <item translatable="yes" id="Full x2(3L)">Full x2(3L)</item>
+                                                            <item translatable="yes" id="Full x3(2L)">Full x3(2L)</item>
+                                                            <item translatable="yes" id="Full x3(3L)">Full x3(3L)</item>
+                                                            <item translatable="yes" id="Full x4(2L)">Full x4(2L)</item>
+                                                            <item translatable="yes" id="Full x4(3L)">Full x4(3L)</item>
+                                                            <item translatable="yes" id="Full x6(2L)">Full x6(2L)</item>
+                                                            <item translatable="yes" id="Full x6(3L)">Full x6(3L)</item>
+                                                            <item translatable="yes" id="Full x8(2L)">Full x8(2L)</item>
+                                                            <item translatable="yes" id="Full x8(3L)">Full x8(3L)</item>
+                                                        </items>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">oversampling_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkComboBoxText" id="dither">
+                                                        <property name="hexpand">1</property>
+                                                        <property name="valign">center</property>
+                                                        <items>
+                                                            <item id="None">None</item>
+                                                            <item id="7bit">7bit</item>
+                                                            <item id="8bit">8bit</item>
+                                                            <item id="11bit">11bit</item>
+                                                            <item id="12bit">12bit</item>
+                                                            <item id="15bit">15bit</item>
+                                                            <item id="16bit">16bit</item>
+                                                            <item id="23bit">23bit</item>
+                                                            <item id="24bit">24bit</item>
+                                                        </items>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">2</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">dither_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+                                                <layout>
+                                                    <property name="column">0</property>
+                                                    <property name="row">0</property>
+                                                    <property name="row-span">2</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="halign">center</property>
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="halign">center</property>
+                                                        <property name="valign">end</property>
+                                                        <property name="label" translatable="yes">SC PreAmp</property>
+                                                    </object>
+                                                </child>
+                                                <layout>
+                                                    <property name="column">1</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="sc_preamp">
+                                                <property name="halign">center</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">1</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-120</property>
+                                                        <property name="upper">40</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">1</property>
+                                                    <property name="row">1</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Sidechain PreAmplification</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="halign">center</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="lookahead_label">
+                                                        <property name="halign">center</property>
+                                                        <property name="valign">end</property>
+                                                        <property name="label" translatable="yes">Lookahead</property>
+                                                    </object>
+                                                </child>
+                                                <layout>
+                                                    <property name="column">2</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="lookahead">
+                                                <property name="halign">center</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">2</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">0.1</property>
+                                                        <property name="upper">20</property>
+                                                        <property name="value">5</property>
+                                                        <property name="step-increment">0.01</property>
+                                                        <property name="page-increment">0.1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">2</property>
+                                                    <property name="row">1</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <relation name="labelled-by">lookahead_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="halign">center</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="attack_label">
+                                                        <property name="halign">center</property>
+                                                        <property name="valign">end</property>
+                                                        <property name="label" translatable="yes">Attack</property>
+                                                    </object>
+                                                </child>
+                                                <layout>
+                                                    <property name="column">3</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="attack">
+                                                <property name="halign">center</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">2</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">0.25</property>
+                                                        <property name="upper">20</property>
+                                                        <property name="value">5</property>
+                                                        <property name="step-increment">0.01</property>
+                                                        <property name="page-increment">0.1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">3</property>
+                                                    <property name="row">1</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <relation name="labelled-by">attack_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="halign">center</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="release_label">
+                                                        <property name="halign">center</property>
+                                                        <property name="valign">end</property>
+                                                        <property name="label" translatable="yes">Release</property>
+                                                    </object>
+                                                </child>
+                                                <layout>
+                                                    <property name="column">4</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="release">
+                                                <property name="halign">center</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">2</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">0.25</property>
+                                                        <property name="upper">20</property>
+                                                        <property name="value">5</property>
+                                                        <property name="step-increment">0.01</property>
+                                                        <property name="page-increment">0.1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">4</property>
+                                                    <property name="row">1</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <relation name="labelled-by">release_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="halign">center</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="threshold_label">
+                                                        <property name="halign">center</property>
+                                                        <property name="valign">end</property>
+                                                        <property name="label" translatable="yes">Threshold</property>
+                                                    </object>
+                                                </child>
+                                                <layout>
+                                                    <property name="column">5</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="threshold">
+                                                <property name="halign">center</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">2</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-48</property>
+                                                        <property name="step-increment">0.01</property>
+                                                        <property name="page-increment">0.1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">5</property>
+                                                    <property name="row">1</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <relation name="labelled-by">threshold_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkCheckButton" id="gain_boost">
+                                                <property name="halign">center</property>
+                                                <property name="valign">start</property>
+                                                <property name="label" translatable="yes">Boost</property>
+                                                <layout>
+                                                    <property name="column">5</property>
+                                                    <property name="row">2</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="halign">center</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="stereo_link_label">
+                                                        <property name="halign">center</property>
+                                                        <property name="valign">end</property>
+                                                        <property name="label" translatable="yes">Stereo Link</property>
+                                                    </object>
+                                                </child>
+                                                <layout>
+                                                    <property name="column">6</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="stereo_link">
+                                                <property name="halign">center</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">2</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">0</property>
+                                                        <property name="upper">100</property>
+                                                        <property name="value">100</property>
+                                                        <property name="step-increment">0.01</property>
+                                                        <property name="page-increment">0.1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">6</property>
+                                                    <property name="row">1</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <relation name="labelled-by">stereo_link_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="spacing">24</property>
+                                        <child>
+                                            <object class="GtkToggleButton" id="external_sidechain">
+                                                <property name="valign">center</property>
+                                                <property name="label" translatable="yes">External Sidechain</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkDropDown" id="dropdown_input_devices">
+                                                <property name="valign">center</property>
+                                                <property name="sensitive" bind-source="external_sidechain" bind-property="active" bind-flags="sync-create" />
+                                                <property name="factory">
+                                                    <object class="GtkBuilderListItemFactory">
+                                                        <property name="resource">/com/github/wwmm/easyeffects/ui/factory_input_device_dropdown.ui</property>
+                                                    </object>
+                                                </property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">External Sidechain Source</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkGrid" id="alr_grid">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="row-spacing">6</property>
+                                        <property name="column-spacing">12</property>
+
+                                        <child>
+                                            <object class="GtkToggleButton" id="alr">
+                                                <property name="margin-end">12</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="label" translatable="yes">Auto Leveling</property>
+                                                <layout>
+                                                    <property name="column">0</property>
+                                                    <property name="row">1</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="label" translatable="yes">Attack</property>
+
+                                                <layout>
+                                                    <property name="column">1</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="alr_attack">
+                                                <property name="halign">center</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">2</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="sensitive" bind-source="alr" bind-property="active" bind-flags="sync-create" />
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">0.1</property>
+                                                        <property name="upper">200</property>
+                                                        <property name="value">5</property>
+                                                        <property name="step-increment">0.01</property>
+                                                        <property name="page-increment">0.1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">1</property>
+                                                    <property name="row">1</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Auto Leveling Attack</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="label" translatable="yes">Release</property>
+                                                <layout>
+                                                    <property name="column">2</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="alr_release">
+                                                <property name="halign">center</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="width-chars">11</property>
+                                                <property name="digits">2</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="sensitive" bind-source="alr" bind-property="active" bind-flags="sync-create" />
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">10</property>
+                                                        <property name="upper">1000</property>
+                                                        <property name="value">50</property>
+                                                        <property name="step-increment">0.01</property>
+                                                        <property name="page-increment">0.1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">2</property>
+                                                    <property name="row">1</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Auto Leveling Release</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="label" translatable="yes">Knee</property>
+                                                <layout>
+                                                    <property name="column">3</property>
+                                                    <property name="row">0</property>
+                                                </layout>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkSpinButton" id="alr_knee">
+                                                <property name="halign">center</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">1</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="sensitive" bind-source="alr" bind-property="active" bind-flags="sync-create" />
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-12</property>
+                                                        <property name="upper">12</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <layout>
+                                                    <property name="column">3</property>
+                                                    <property name="row">1</property>
+                                                </layout>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Auto Leveling Knee</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
                             </object>
                         </child>
+
                         <child>
                             <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="output_gain">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="margin-top">4</property>
+                                <property name="margin-bottom">4</property>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <child>
+                                            <object class="GtkLabel" id="gain_left_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Gain Left</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel" id="gain_left">
+                                                <property name="halign">center</property>
+                                                <property name="width-chars">6</property>
+                                                <property name="label">0</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">start</property>
+                                                <property name="label">db</property>
+                                            </object>
+                                        </child>
                                     </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <child>
+                                            <object class="GtkLabel" id="gain_right_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Gain Right</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel" id="gain_right">
+                                                <property name="halign">center</property>
+                                                <property name="width-chars">6</property>
+                                                <property name="label">0</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">start</property>
+                                                <property name="label">db</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <child>
+                                            <object class="GtkLabel" id="sidechain_left_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Sidechain Left</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel" id="sidechain_left">
+                                                <property name="halign">center</property>
+                                                <property name="width-chars">6</property>
+                                                <property name="label">0</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">start</property>
+                                                <property name="label">db</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <child>
+                                            <object class="GtkLabel" id="sidechain_right_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Sidechain Right</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel" id="sidechain_right">
+                                                <property name="halign">center</property>
+                                                <property name="width-chars">6</property>
+                                                <property name="label">0</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">start</property>
+                                                <property name="label">db</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="LimiterBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Linux Studio Plugins</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="LimiterBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">Linux Studio Plugins</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/loudness.ui
+++ b/data/ui/loudness.ui
@@ -5,355 +5,369 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
-
         <child>
-            <object class="GtkGrid">
-                <property name="margin-bottom">6</property>
-                <property name="halign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">24</property>
-
-                <child>
-                    <object class="GtkLabel" id="standard_label">
-                        <property name="label" translatable="yes">Standard</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
-                <child>
-                    <object class="GtkComboBoxText" id="standard">
-                        <property name="halign">center</property>
-                        <items>
-                            <item translatable="yes" id="Flat">Flat</item>
-                            <item id="ISO226-2003">ISO 226:2003</item>
-                            <item id="Fletcher-Munson">Fletcher-Munson</item>
-                            <item id="Robinson-Dadson">Robinson-Dadson</item>
-                        </items>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">standard_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel">
-                        <property name="label" translatable="yes">FFT Size</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkComboBoxText" id="fft_size">
-                        <property name="halign">center</property>
-                        <items>
-                            <item id="256">256</item>
-                            <item id="512">512</item>
-                            <item id="1024">1024</item>
-                            <item id="2048">2048</item>
-                            <item id="4096">4096</item>
-                            <item id="8192">8192</item>
-                            <item id="16384">16384</item>
-                        </items>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <property name="label" translatable="yes">Fast Fourier Transform Size</property>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="volume_label">
-                        <property name="label" translatable="yes">Output Volume</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkSpinButton" id="volume">
-                        <property name="halign">center</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-83</property>
-                                <property name="upper">7</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">volume_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkCheckButton" id="clipping">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="label" translatable="yes">Clipping</property>
-                        <layout>
-                            <property name="column">3</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkSpinButton" id="clipping_range">
-                        <property name="halign">center</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">0</property>
-                                <property name="upper">24</property>
-                                <property name="value">6</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">3</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <property name="label" translatable="yes">Clipping Range</property>
-                        </accessibility>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
                 <child>
                     <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
-                                <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
+                        <property name="spacing">12</property>
                         <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
+                            <object class="GtkGrid">
+                                <property name="margin-bottom">6</property>
+                                <property name="halign">center</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">24</property>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
+                                <child>
+                                    <object class="GtkLabel" id="standard_label">
+                                        <property name="label" translatable="yes">Standard</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkComboBoxText" id="standard">
+                                        <property name="halign">center</property>
+                                        <items>
+                                            <item translatable="yes" id="Flat">Flat</item>
+                                            <item id="ISO226-2003">ISO 226:2003</item>
+                                            <item id="Fletcher-Munson">Fletcher-Munson</item>
+                                            <item id="Robinson-Dadson">Robinson-Dadson</item>
+                                        </items>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">standard_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="label" translatable="yes">FFT Size</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkComboBoxText" id="fft_size">
+                                        <property name="halign">center</property>
+                                        <items>
+                                            <item id="256">256</item>
+                                            <item id="512">512</item>
+                                            <item id="1024">1024</item>
+                                            <item id="2048">2048</item>
+                                            <item id="4096">4096</item>
+                                            <item id="8192">8192</item>
+                                            <item id="16384">16384</item>
+                                        </items>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">Fast Fourier Transform Size</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="volume_label">
+                                        <property name="label" translatable="yes">Output Volume</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkSpinButton" id="volume">
+                                        <property name="halign">center</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-83</property>
+                                                <property name="upper">7</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">volume_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkCheckButton" id="clipping">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="label" translatable="yes">Clipping</property>
+                                        <layout>
+                                            <property name="column">3</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkSpinButton" id="clipping_range">
+                                        <property name="halign">center</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">0</property>
+                                                <property name="upper">24</property>
+                                                <property name="value">6</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">3</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <property name="label" translatable="yes">Clipping Range</property>
+                                        </accessibility>
+                                    </object>
+                                </child>
                             </object>
                         </child>
+
                         <child>
-                            <object class="GtkScale" id="output_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="LoudnessBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Linux Studio Plugins</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="LoudnessBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">Linux Studio Plugins</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/maximizer.ui
+++ b/data/ui/maximizer.ui
@@ -5,356 +5,370 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
-
         <child>
-            <object class="GtkGrid">
-                <property name="margin-bottom">6</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">48</property>
-                <child>
-                    <object class="GtkLabel" id="threshold_label">
-                        <property name="label" translatable="yes">Threshold</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="threshold">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-30</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">threshold_label</relation>
-                        </accessibility>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
-                <child>
-                    <object class="GtkLabel" id="ceiling_label">
-                        <property name="label" translatable="yes">Ceiling</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="ceiling">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-30</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">ceiling_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="release_label">
-                        <property name="label" translatable="yes">Release</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="release">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">2</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">1</property>
-                                <property name="upper">100</property>
-                                <property name="value">25</property>
-                                <property name="step-increment">0.01</property>
-                                <property name="page-increment">0.1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">release_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
                 <child>
                     <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
+                        <property name="spacing">12</property>
+                        <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
-                                <property name="hexpand">1</property>
+                            <object class="GtkGrid">
+                                <property name="margin-bottom">6</property>
+                                <property name="halign">center</property>
                                 <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">48</property>
                                 <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
+                                    <object class="GtkLabel" id="threshold_label">
+                                        <property name="label" translatable="yes">Threshold</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
                                     </object>
                                 </child>
                                 <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
+                                    <object class="GtkSpinButton" id="threshold">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-30</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">threshold_label</relation>
+                                        </accessibility>
                                     </object>
                                 </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
+                                <child>
+                                    <object class="GtkLabel" id="ceiling_label">
+                                        <property name="label" translatable="yes">Ceiling</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="ceiling">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-30</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">ceiling_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="release_label">
+                                        <property name="label" translatable="yes">Release</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="release">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">2</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">1</property>
+                                                <property name="upper">100</property>
+                                                <property name="value">25</property>
+                                                <property name="step-increment">0.01</property>
+                                                <property name="page-increment">0.1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">release_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
                             </object>
                         </child>
+
                         <child>
-                            <object class="GtkScale" id="output_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkLabel" id="reduction_title">
+                                        <property name="halign">end</property>
+                                        <property name="xalign">1</property>
+                                        <property name="label" translatable="yes">Reduction</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLevelBar" id="reduction_levelbar">
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">1</property>
+                                        <property name="min-value">0</property>
+                                        <property name="max-value">40</property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="reduction_label">
+                                        <property name="halign">end</property>
+                                        <property name="width-chars">4</property>
+                                        <property name="label">0</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="MaximizerBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">ZamAudio Plugins</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkLabel" id="reduction_title">
-                        <property name="halign">end</property>
-                        <property name="xalign">1</property>
-                        <property name="label" translatable="yes">Reduction</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLevelBar" id="reduction_levelbar">
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="min-value">0</property>
-                        <property name="max-value">40</property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="reduction_label">
-                        <property name="halign">end</property>
-                        <property name="width-chars">4</property>
-                        <property name="label">0</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="MaximizerBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">ZamAudio Plugins</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/multiband_compressor.ui
+++ b/data/ui/multiband_compressor.ui
@@ -5,631 +5,646 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">24</property>
         <property name="orientation">vertical</property>
         <child>
-            <object class="GtkBox">
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="spacing">24</property>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
+                    </object>
+                </child>
 
                 <child>
                     <object class="GtkBox">
-                        <property name="halign">center</property>
-                        <property name="valign">start</property>
                         <property name="spacing">24</property>
                         <property name="orientation">vertical</property>
-
                         <child>
-                            <object class="GtkGrid">
-                                <property name="halign">center</property>
-                                <property name="valign">start</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">24</property>
-                                <child>
-                                    <object class="GtkLabel" id="envelope_boost_label">
-                                        <property name="label" translatable="yes">Sidechain Boost</property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkComboBoxText" id="envelope_boost">
-                                        <property name="halign">center</property>
-                                        <items>
-                                            <item translatable="yes" id="None">None</item>
-                                            <item translatable="yes" id="Pink BT">Pink BT</item>
-                                            <item translatable="yes" id="Pink MT">Pink MT</item>
-                                            <item translatable="yes" id="Brown BT">Brown BT</item>
-                                            <item translatable="yes" id="Brown MT">Brown MT</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">envelope_boost_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="label" translatable="yes">Sidechain Source</property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkDropDown" id="dropdown_input_devices">
-                                        <property name="halign">center</property>
-                                        <property name="factory">
-                                            <object class="GtkBuilderListItemFactory">
-                                                <property name="resource">/com/github/wwmm/easyeffects/ui/factory_input_device_dropdown.ui</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <property name="label" translatable="yes">External Sidechain Source</property>
-                                        </accessibility>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkGrid">
-                                <property name="halign">center</property>
-                                <property name="valign">start</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">24</property>
-                                <child>
-                                    <object class="GtkLabel" id="compressor_mode_label">
-                                        <property name="label" translatable="yes">Operating Mode</property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkComboBoxText" id="compressor_mode">
-                                        <property name="halign">center</property>
-                                        <items>
-                                            <item translatable="yes" id="Classic">Classic</item>
-                                            <item translatable="yes" id="Modern">Modern</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">compressor_mode_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel" id="dry_label">
-                                        <property name="label" translatable="yes">Dry Level</property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkSpinButton" id="dry">
-                                        <property name="valign">center</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">-100</property>
-                                                <property name="upper">20</property>
-                                                <property name="value">-100</property>
-                                                <property name="step-increment">0.1</property>
-                                                <property name="page-increment">1</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">dry_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel" id="wet_label">
-                                        <property name="label" translatable="yes">Wet Level</property>
-                                        <layout>
-                                            <property name="column">2</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkSpinButton" id="wet">
-                                        <property name="valign">center</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">-100</property>
-                                                <property name="upper">20</property>
-                                                <property name="step-increment">0.1</property>
-                                                <property name="page-increment">1</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">2</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">wet_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkStack" id="stack">
-                                <property name="hexpand">1</property>
-                                <property name="halign">center</property>
-                                <property name="valign">start</property>
-                                <property name="hhomogeneous">0</property>
-                                <property name="vhomogeneous">0</property>
-                                <property name="transition-duration">250</property>
-                                <property name="transition-type">slide-left-right</property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkFrame">
-                        <property name="halign">center</property>
-                        <property name="valign">start</property>
-                        <child>
-                            <object class="GtkListBox" id="listbox">
+                            <object class="GtkBox">
                                 <property name="halign">center</property>
                                 <property name="valign">center</property>
-                                <property name="selection-mode">single</property>
-                                <property name="show-separators">1</property>
-                                <signal name="row-selected" handler="on_listbox_row_selected" object="MultibandCompressorBox" />
-
-
-                                <accessibility>
-                                    <property name="label" translatable="yes">Bands List</property>
-                                </accessibility>
+                                <property name="spacing">24</property>
 
                                 <child>
-                                    <object class="GtkListBoxRow">
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <property name="valign">start</property>
+                                        <property name="spacing">24</property>
+                                        <property name="orientation">vertical</property>
+
                                         <child>
-                                            <object class="GtkBox">
+                                            <object class="GtkGrid">
+                                                <property name="halign">center</property>
+                                                <property name="valign">start</property>
+                                                <property name="row-spacing">6</property>
+                                                <property name="column-spacing">24</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="envelope_boost_label">
+                                                        <property name="label" translatable="yes">Sidechain Boost</property>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkComboBoxText" id="envelope_boost">
+                                                        <property name="halign">center</property>
+                                                        <items>
+                                                            <item translatable="yes" id="None">None</item>
+                                                            <item translatable="yes" id="Pink BT">Pink BT</item>
+                                                            <item translatable="yes" id="Pink MT">Pink MT</item>
+                                                            <item translatable="yes" id="Brown BT">Brown BT</item>
+                                                            <item translatable="yes" id="Brown MT">Brown MT</item>
+                                                        </items>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">envelope_boost_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
                                                 <child>
                                                     <object class="GtkLabel">
-                                                        <property name="label" translatable="yes">Band 1</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="hexpand">1</property>
+                                                        <property name="label" translatable="yes">Sidechain Source</property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
                                                     </object>
                                                 </child>
+                                                <child>
+                                                    <object class="GtkDropDown" id="dropdown_input_devices">
+                                                        <property name="halign">center</property>
+                                                        <property name="factory">
+                                                            <object class="GtkBuilderListItemFactory">
+                                                                <property name="resource">/com/github/wwmm/easyeffects/ui/factory_input_device_dropdown.ui</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <property name="label" translatable="yes">External Sidechain Source</property>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkGrid">
+                                                <property name="halign">center</property>
+                                                <property name="valign">start</property>
+                                                <property name="row-spacing">6</property>
+                                                <property name="column-spacing">24</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="compressor_mode_label">
+                                                        <property name="label" translatable="yes">Operating Mode</property>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkComboBoxText" id="compressor_mode">
+                                                        <property name="halign">center</property>
+                                                        <items>
+                                                            <item translatable="yes" id="Classic">Classic</item>
+                                                            <item translatable="yes" id="Modern">Modern</item>
+                                                        </items>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">compressor_mode_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="dry_label">
+                                                        <property name="label" translatable="yes">Dry Level</property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkSpinButton" id="dry">
+                                                        <property name="valign">center</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="digits">1</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">-100</property>
+                                                                <property name="upper">20</property>
+                                                                <property name="value">-100</property>
+                                                                <property name="step-increment">0.1</property>
+                                                                <property name="page-increment">1</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">dry_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="wet_label">
+                                                        <property name="label" translatable="yes">Wet Level</property>
+                                                        <layout>
+                                                            <property name="column">2</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkSpinButton" id="wet">
+                                                        <property name="valign">center</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="digits">1</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">-100</property>
+                                                                <property name="upper">20</property>
+                                                                <property name="step-increment">0.1</property>
+                                                                <property name="page-increment">1</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">2</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">wet_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkStack" id="stack">
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">start</property>
+                                                <property name="hhomogeneous">0</property>
+                                                <property name="vhomogeneous">0</property>
+                                                <property name="transition-duration">250</property>
+                                                <property name="transition-type">slide-left-right</property>
                                             </object>
                                         </child>
                                     </object>
                                 </child>
 
                                 <child>
-                                    <object class="GtkListBoxRow">
+                                    <object class="GtkFrame">
+                                        <property name="halign">center</property>
+                                        <property name="valign">start</property>
                                         <child>
-                                            <object class="GtkBox">
+                                            <object class="GtkListBox" id="listbox">
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="selection-mode">single</property>
+                                                <property name="show-separators">1</property>
+                                                <signal name="row-selected" handler="on_listbox_row_selected" object="MultibandCompressorBox" />
+
+
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Bands List</property>
+                                                </accessibility>
+
                                                 <child>
-                                                    <object class="GtkLabel" id="enable_band1_label">
-                                                        <property name="label" translatable="yes">Band 2</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="hexpand">1</property>
+                                                    <object class="GtkListBoxRow">
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">Band 1</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="hexpand">1</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
                                                     </object>
                                                 </child>
+
                                                 <child>
-                                                    <object class="GtkCheckButton" id="enable_band1">
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">enable_band1_label</relation>
-                                                        </accessibility>
+                                                    <object class="GtkListBoxRow">
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <child>
+                                                                    <object class="GtkLabel" id="enable_band1_label">
+                                                                        <property name="label" translatable="yes">Band 2</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="hexpand">1</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkCheckButton" id="enable_band1">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">enable_band1_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
                                                     </object>
                                                 </child>
+
+                                                <child>
+                                                    <object class="GtkListBoxRow">
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <child>
+                                                                    <object class="GtkLabel" id="enable_band2_label">
+                                                                        <property name="label" translatable="yes">Band 3</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="hexpand">1</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkCheckButton" id="enable_band2">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">enable_band2_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkListBoxRow">
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <child>
+                                                                    <object class="GtkLabel" id="enable_band3_label">
+                                                                        <property name="label" translatable="yes">Band 4</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="hexpand">1</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkCheckButton" id="enable_band3">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">enable_band3_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkListBoxRow">
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <child>
+                                                                    <object class="GtkLabel" id="enable_band4_label">
+                                                                        <property name="label" translatable="yes">Band 5</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="hexpand">1</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkCheckButton" id="enable_band4">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">enable_band4_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkListBoxRow">
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <child>
+                                                                    <object class="GtkLabel" id="enable_band5_label">
+                                                                        <property name="label" translatable="yes">Band 6</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="hexpand">1</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkCheckButton" id="enable_band5">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">enable_band5_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkListBoxRow">
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <child>
+                                                                    <object class="GtkLabel" id="enable_band6_label">
+                                                                        <property name="label" translatable="yes">Band 7</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="hexpand">1</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkCheckButton" id="enable_band6">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">enable_band6_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkListBoxRow">
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <child>
+                                                                    <object class="GtkLabel" id="enable_band7_label">
+                                                                        <property name="label" translatable="yes">Band 8</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="hexpand">1</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkCheckButton" id="enable_band7">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">enable_band7_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <style>
+                                                    <class name="rich-list" />
+                                                </style>
                                             </object>
                                         </child>
                                     </object>
                                 </child>
-
-                                <child>
-                                    <object class="GtkListBoxRow">
-                                        <child>
-                                            <object class="GtkBox">
-                                                <child>
-                                                    <object class="GtkLabel" id="enable_band2_label">
-                                                        <property name="label" translatable="yes">Band 3</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="hexpand">1</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkCheckButton" id="enable_band2">
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">enable_band2_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkListBoxRow">
-                                        <child>
-                                            <object class="GtkBox">
-                                                <child>
-                                                    <object class="GtkLabel" id="enable_band3_label">
-                                                        <property name="label" translatable="yes">Band 4</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="hexpand">1</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkCheckButton" id="enable_band3">
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">enable_band3_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkListBoxRow">
-                                        <child>
-                                            <object class="GtkBox">
-                                                <child>
-                                                    <object class="GtkLabel" id="enable_band4_label">
-                                                        <property name="label" translatable="yes">Band 5</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="hexpand">1</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkCheckButton" id="enable_band4">
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">enable_band4_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkListBoxRow">
-                                        <child>
-                                            <object class="GtkBox">
-                                                <child>
-                                                    <object class="GtkLabel" id="enable_band5_label">
-                                                        <property name="label" translatable="yes">Band 6</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="hexpand">1</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkCheckButton" id="enable_band5">
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">enable_band5_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkListBoxRow">
-                                        <child>
-                                            <object class="GtkBox">
-                                                <child>
-                                                    <object class="GtkLabel" id="enable_band6_label">
-                                                        <property name="label" translatable="yes">Band 7</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="hexpand">1</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkCheckButton" id="enable_band6">
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">enable_band6_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkListBoxRow">
-                                        <child>
-                                            <object class="GtkBox">
-                                                <child>
-                                                    <object class="GtkLabel" id="enable_band7_label">
-                                                        <property name="label" translatable="yes">Band 8</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="hexpand">1</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkCheckButton" id="enable_band7">
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">enable_band7_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-
-                                <style>
-                                    <class name="rich-list" />
-                                </style>
                             </object>
                         </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
                         <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
                                 <property name="spacing">6</property>
                                 <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
+                                    <object class="GtkBox">
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
                                 <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
                             </object>
                         </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
                         <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="output_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="MultibandCompressorBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Linux Studio Plugins</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="MultibandCompressorBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">Linux Studio Plugins</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/multiband_gate.ui
+++ b/data/ui/multiband_gate.ui
@@ -5,631 +5,646 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">24</property>
         <property name="orientation">vertical</property>
         <child>
-            <object class="GtkBox">
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="spacing">24</property>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
+                    </object>
+                </child>
 
                 <child>
                     <object class="GtkBox">
-                        <property name="halign">center</property>
-                        <property name="valign">start</property>
                         <property name="spacing">24</property>
                         <property name="orientation">vertical</property>
-
                         <child>
-                            <object class="GtkGrid">
-                                <property name="halign">center</property>
-                                <property name="valign">start</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">24</property>
-                                <child>
-                                    <object class="GtkLabel" id="envelope_boost_label">
-                                        <property name="label" translatable="yes">Sidechain Boost</property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkComboBoxText" id="envelope_boost">
-                                        <property name="halign">center</property>
-                                        <items>
-                                            <item translatable="yes" id="None">None</item>
-                                            <item translatable="yes" id="Pink BT">Pink BT</item>
-                                            <item translatable="yes" id="Pink MT">Pink MT</item>
-                                            <item translatable="yes" id="Brown BT">Brown BT</item>
-                                            <item translatable="yes" id="Brown MT">Brown MT</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">envelope_boost_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="label" translatable="yes">Sidechain Source</property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkDropDown" id="dropdown_input_devices">
-                                        <property name="halign">center</property>
-                                        <property name="factory">
-                                            <object class="GtkBuilderListItemFactory">
-                                                <property name="resource">/com/github/wwmm/easyeffects/ui/factory_input_device_dropdown.ui</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <property name="label" translatable="yes">External Sidechain Source</property>
-                                        </accessibility>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkGrid">
-                                <property name="halign">center</property>
-                                <property name="valign">start</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">24</property>
-                                <child>
-                                    <object class="GtkLabel" id="gate_mode_label">
-                                        <property name="label" translatable="yes">Operating Mode</property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkComboBoxText" id="gate_mode">
-                                        <property name="halign">center</property>
-                                        <items>
-                                            <item translatable="yes" id="Classic">Classic</item>
-                                            <item translatable="yes" id="Modern">Modern</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">gate_mode_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel" id="dry_label">
-                                        <property name="label" translatable="yes">Dry Level</property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkSpinButton" id="dry">
-                                        <property name="valign">center</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">-100</property>
-                                                <property name="upper">20</property>
-                                                <property name="value">-100</property>
-                                                <property name="step-increment">0.1</property>
-                                                <property name="page-increment">1</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">dry_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel" id="wet_label">
-                                        <property name="label" translatable="yes">Wet Level</property>
-                                        <layout>
-                                            <property name="column">2</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkSpinButton" id="wet">
-                                        <property name="valign">center</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">-100</property>
-                                                <property name="upper">20</property>
-                                                <property name="step-increment">0.1</property>
-                                                <property name="page-increment">1</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">2</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">wet_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkStack" id="stack">
-                                <property name="hexpand">1</property>
-                                <property name="halign">center</property>
-                                <property name="valign">start</property>
-                                <property name="hhomogeneous">0</property>
-                                <property name="vhomogeneous">0</property>
-                                <property name="transition-duration">250</property>
-                                <property name="transition-type">slide-left-right</property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkFrame">
-                        <property name="halign">center</property>
-                        <property name="valign">start</property>
-                        <child>
-                            <object class="GtkListBox" id="listbox">
+                            <object class="GtkBox">
                                 <property name="halign">center</property>
                                 <property name="valign">center</property>
-                                <property name="selection-mode">single</property>
-                                <property name="show-separators">1</property>
-                                <signal name="row-selected" handler="on_listbox_row_selected" object="MultibandGateBox" />
-
-
-                                <accessibility>
-                                    <property name="label" translatable="yes">Bands List</property>
-                                </accessibility>
+                                <property name="spacing">24</property>
 
                                 <child>
-                                    <object class="GtkListBoxRow">
+                                    <object class="GtkBox">
+                                        <property name="halign">center</property>
+                                        <property name="valign">start</property>
+                                        <property name="spacing">24</property>
+                                        <property name="orientation">vertical</property>
+
                                         <child>
-                                            <object class="GtkBox">
+                                            <object class="GtkGrid">
+                                                <property name="halign">center</property>
+                                                <property name="valign">start</property>
+                                                <property name="row-spacing">6</property>
+                                                <property name="column-spacing">24</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="envelope_boost_label">
+                                                        <property name="label" translatable="yes">Sidechain Boost</property>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkComboBoxText" id="envelope_boost">
+                                                        <property name="halign">center</property>
+                                                        <items>
+                                                            <item translatable="yes" id="None">None</item>
+                                                            <item translatable="yes" id="Pink BT">Pink BT</item>
+                                                            <item translatable="yes" id="Pink MT">Pink MT</item>
+                                                            <item translatable="yes" id="Brown BT">Brown BT</item>
+                                                            <item translatable="yes" id="Brown MT">Brown MT</item>
+                                                        </items>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">envelope_boost_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
                                                 <child>
                                                     <object class="GtkLabel">
-                                                        <property name="label" translatable="yes">Band 1</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="hexpand">1</property>
+                                                        <property name="label" translatable="yes">Sidechain Source</property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
                                                     </object>
                                                 </child>
+                                                <child>
+                                                    <object class="GtkDropDown" id="dropdown_input_devices">
+                                                        <property name="halign">center</property>
+                                                        <property name="factory">
+                                                            <object class="GtkBuilderListItemFactory">
+                                                                <property name="resource">/com/github/wwmm/easyeffects/ui/factory_input_device_dropdown.ui</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <property name="label" translatable="yes">External Sidechain Source</property>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkGrid">
+                                                <property name="halign">center</property>
+                                                <property name="valign">start</property>
+                                                <property name="row-spacing">6</property>
+                                                <property name="column-spacing">24</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="gate_mode_label">
+                                                        <property name="label" translatable="yes">Operating Mode</property>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkComboBoxText" id="gate_mode">
+                                                        <property name="halign">center</property>
+                                                        <items>
+                                                            <item translatable="yes" id="Classic">Classic</item>
+                                                            <item translatable="yes" id="Modern">Modern</item>
+                                                        </items>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">gate_mode_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="dry_label">
+                                                        <property name="label" translatable="yes">Dry Level</property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkSpinButton" id="dry">
+                                                        <property name="valign">center</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="digits">1</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">-100</property>
+                                                                <property name="upper">20</property>
+                                                                <property name="value">-100</property>
+                                                                <property name="step-increment">0.1</property>
+                                                                <property name="page-increment">1</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">dry_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="wet_label">
+                                                        <property name="label" translatable="yes">Wet Level</property>
+                                                        <layout>
+                                                            <property name="column">2</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkSpinButton" id="wet">
+                                                        <property name="valign">center</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="digits">1</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">-100</property>
+                                                                <property name="upper">20</property>
+                                                                <property name="step-increment">0.1</property>
+                                                                <property name="page-increment">1</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">2</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">wet_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkStack" id="stack">
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">start</property>
+                                                <property name="hhomogeneous">0</property>
+                                                <property name="vhomogeneous">0</property>
+                                                <property name="transition-duration">250</property>
+                                                <property name="transition-type">slide-left-right</property>
                                             </object>
                                         </child>
                                     </object>
                                 </child>
 
                                 <child>
-                                    <object class="GtkListBoxRow">
+                                    <object class="GtkFrame">
+                                        <property name="halign">center</property>
+                                        <property name="valign">start</property>
                                         <child>
-                                            <object class="GtkBox">
+                                            <object class="GtkListBox" id="listbox">
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="selection-mode">single</property>
+                                                <property name="show-separators">1</property>
+                                                <signal name="row-selected" handler="on_listbox_row_selected" object="MultibandGateBox" />
+
+
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Bands List</property>
+                                                </accessibility>
+
                                                 <child>
-                                                    <object class="GtkLabel" id="enable_band1_label">
-                                                        <property name="label" translatable="yes">Band 2</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="hexpand">1</property>
+                                                    <object class="GtkListBoxRow">
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">Band 1</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="hexpand">1</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
                                                     </object>
                                                 </child>
+
                                                 <child>
-                                                    <object class="GtkCheckButton" id="enable_band1">
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">enable_band1_label</relation>
-                                                        </accessibility>
+                                                    <object class="GtkListBoxRow">
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <child>
+                                                                    <object class="GtkLabel" id="enable_band1_label">
+                                                                        <property name="label" translatable="yes">Band 2</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="hexpand">1</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkCheckButton" id="enable_band1">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">enable_band1_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
                                                     </object>
                                                 </child>
+
+                                                <child>
+                                                    <object class="GtkListBoxRow">
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <child>
+                                                                    <object class="GtkLabel" id="enable_band2_label">
+                                                                        <property name="label" translatable="yes">Band 3</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="hexpand">1</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkCheckButton" id="enable_band2">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">enable_band2_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkListBoxRow">
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <child>
+                                                                    <object class="GtkLabel" id="enable_band3_label">
+                                                                        <property name="label" translatable="yes">Band 4</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="hexpand">1</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkCheckButton" id="enable_band3">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">enable_band3_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkListBoxRow">
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <child>
+                                                                    <object class="GtkLabel" id="enable_band4_label">
+                                                                        <property name="label" translatable="yes">Band 5</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="hexpand">1</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkCheckButton" id="enable_band4">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">enable_band4_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkListBoxRow">
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <child>
+                                                                    <object class="GtkLabel" id="enable_band5_label">
+                                                                        <property name="label" translatable="yes">Band 6</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="hexpand">1</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkCheckButton" id="enable_band5">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">enable_band5_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkListBoxRow">
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <child>
+                                                                    <object class="GtkLabel" id="enable_band6_label">
+                                                                        <property name="label" translatable="yes">Band 7</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="hexpand">1</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkCheckButton" id="enable_band6">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">enable_band6_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkListBoxRow">
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <child>
+                                                                    <object class="GtkLabel" id="enable_band7_label">
+                                                                        <property name="label" translatable="yes">Band 8</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="hexpand">1</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkCheckButton" id="enable_band7">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">enable_band7_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <style>
+                                                    <class name="rich-list" />
+                                                </style>
                                             </object>
                                         </child>
                                     </object>
                                 </child>
-
-                                <child>
-                                    <object class="GtkListBoxRow">
-                                        <child>
-                                            <object class="GtkBox">
-                                                <child>
-                                                    <object class="GtkLabel" id="enable_band2_label">
-                                                        <property name="label" translatable="yes">Band 3</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="hexpand">1</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkCheckButton" id="enable_band2">
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">enable_band2_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkListBoxRow">
-                                        <child>
-                                            <object class="GtkBox">
-                                                <child>
-                                                    <object class="GtkLabel" id="enable_band3_label">
-                                                        <property name="label" translatable="yes">Band 4</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="hexpand">1</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkCheckButton" id="enable_band3">
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">enable_band3_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkListBoxRow">
-                                        <child>
-                                            <object class="GtkBox">
-                                                <child>
-                                                    <object class="GtkLabel" id="enable_band4_label">
-                                                        <property name="label" translatable="yes">Band 5</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="hexpand">1</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkCheckButton" id="enable_band4">
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">enable_band4_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkListBoxRow">
-                                        <child>
-                                            <object class="GtkBox">
-                                                <child>
-                                                    <object class="GtkLabel" id="enable_band5_label">
-                                                        <property name="label" translatable="yes">Band 6</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="hexpand">1</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkCheckButton" id="enable_band5">
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">enable_band5_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkListBoxRow">
-                                        <child>
-                                            <object class="GtkBox">
-                                                <child>
-                                                    <object class="GtkLabel" id="enable_band6_label">
-                                                        <property name="label" translatable="yes">Band 7</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="hexpand">1</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkCheckButton" id="enable_band6">
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">enable_band6_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkListBoxRow">
-                                        <child>
-                                            <object class="GtkBox">
-                                                <child>
-                                                    <object class="GtkLabel" id="enable_band7_label">
-                                                        <property name="label" translatable="yes">Band 8</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="hexpand">1</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkCheckButton" id="enable_band7">
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">enable_band7_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-
-                                <style>
-                                    <class name="rich-list" />
-                                </style>
                             </object>
                         </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
                         <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
                                 <property name="spacing">6</property>
                                 <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
+                                    <object class="GtkBox">
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
                                 <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
                             </object>
                         </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
                         <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="output_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="MultibandGateBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Linux Studio Plugins</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="MultibandGateBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">Linux Studio Plugins</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/pitch.ui
+++ b/data/ui/pitch.ui
@@ -488,7 +488,7 @@
                                         <child>
                                             <object class="GtkLabel">
                                                 <property name="halign">end</property>
-                                                <property name="label">RubberBand</property>
+                                                <property name="label">Rubber Band</property>
                                                 <attributes>
                                                     <attribute name="weight" value="bold" />
                                                 </attributes>

--- a/data/ui/pitch.ui
+++ b/data/ui/pitch.ui
@@ -5,483 +5,497 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
-
         <child>
-            <object class="GtkGrid">
-                <property name="margin-bottom">12</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">24</property>
-                <property name="column-homogeneous">1</property>
-
-                <child>
-                    <object class="GtkLabel" id="mode_label">
-                        <property name="label" translatable="yes">Mode</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkComboBoxText" id="mode">
-                        <property name="valign">center</property>
-                        <items>
-                            <item translatable="yes" id="HighSpeed">High Speed</item>
-                            <item translatable="yes" id="HighQuality">High Quality</item>
-                            <item translatable="yes" id="HighConsistency">High Consistency</item>
-                        </items>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">mode_label</relation>
-                        </accessibility>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
-                <child>
-                    <object class="GtkLabel" id="formant_label">
-                        <property name="label" translatable="yes">Formant</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkComboBoxText" id="formant">
-                        <property name="valign">center</property>
-                        <items>
-                            <item translatable="yes" id="Shifted">Shifted</item>
-                            <item translatable="yes" id="Preserved">Preserved</item>
-                        </items>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">formant_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkGrid">
-                <property name="margin-top">6</property>
-                <property name="margin-bottom">12</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">48</property>
-                <property name="column-homogeneous">1</property>
-
-                <child>
-                    <object class="GtkLabel" id="transients_label">
-                        <property name="label" translatable="yes">Transients</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkComboBoxText" id="transients">
-                        <property name="valign">center</property>
-                        <items>
-                            <item translatable="yes" id="Crisp">Crisp</item>
-                            <item translatable="yes" id="Mixed">Mixed</item>
-                            <item translatable="yes" id="Smooth">Smooth</item>
-                        </items>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">transients_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="detector_label">
-                        <property name="label" translatable="yes">Detector</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkComboBoxText" id="detector">
-                        <property name="valign">center</property>
-                        <items>
-                            <item translatable="yes" id="Compound">Compound</item>
-                            <item translatable="yes" id="Percussive">Percussive</item>
-                            <item translatable="yes" id="Soft">Soft</item>
-                        </items>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">detector_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="phase_label">
-                        <property name="label" translatable="yes">Phase</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkComboBoxText" id="phase">
-                        <property name="valign">center</property>
-                        <items>
-                            <item translatable="yes" id="Laminar">Laminar</item>
-                            <item translatable="yes" id="Independent">Independent</item>
-                        </items>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">phase_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkGrid">
-                <property name="margin-top">6</property>
-                <property name="margin-bottom">12</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">48</property>
-
-                <child>
-                    <object class="GtkLabel" id="cents_label">
-                        <property name="label" translatable="yes">Cents</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="cents">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">0</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-100</property>
-                                <property name="upper">100</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">10</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">cents_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="semitones_label">
-                        <property name="label" translatable="yes">Semitones</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="semitones">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">0</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-12</property>
-                                <property name="upper">12</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">semitones_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="octaves_label">
-                        <property name="label" translatable="yes">Octaves</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="octaves">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">0</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-3</property>
-                                <property name="upper">3</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">octaves_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
                 <child>
                     <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
+                        <property name="spacing">12</property>
+                        <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
-                                <property name="hexpand">1</property>
+                            <object class="GtkGrid">
+                                <property name="margin-bottom">12</property>
+                                <property name="halign">center</property>
                                 <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">24</property>
+                                <property name="column-homogeneous">1</property>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
+                                <child>
+                                    <object class="GtkLabel" id="mode_label">
+                                        <property name="label" translatable="yes">Mode</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkComboBoxText" id="mode">
+                                        <property name="valign">center</property>
+                                        <items>
+                                            <item translatable="yes" id="HighSpeed">High Speed</item>
+                                            <item translatable="yes" id="HighQuality">High Quality</item>
+                                            <item translatable="yes" id="HighConsistency">High Consistency</item>
+                                        </items>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">mode_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="formant_label">
+                                        <property name="label" translatable="yes">Formant</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkComboBoxText" id="formant">
+                                        <property name="valign">center</property>
+                                        <items>
+                                            <item translatable="yes" id="Shifted">Shifted</item>
+                                            <item translatable="yes" id="Preserved">Preserved</item>
+                                        </items>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">formant_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
                             </object>
                         </child>
+
                         <child>
-                            <object class="GtkScale" id="output_gain">
-                                <property name="hexpand">1</property>
+                            <object class="GtkGrid">
+                                <property name="margin-top">6</property>
+                                <property name="margin-bottom">12</property>
+                                <property name="halign">center</property>
                                 <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">48</property>
+                                <property name="column-homogeneous">1</property>
+
+                                <child>
+                                    <object class="GtkLabel" id="transients_label">
+                                        <property name="label" translatable="yes">Transients</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
                                     </object>
+                                </child>
+                                <child>
+                                    <object class="GtkComboBoxText" id="transients">
+                                        <property name="valign">center</property>
+                                        <items>
+                                            <item translatable="yes" id="Crisp">Crisp</item>
+                                            <item translatable="yes" id="Mixed">Mixed</item>
+                                            <item translatable="yes" id="Smooth">Smooth</item>
+                                        </items>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">transients_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="detector_label">
+                                        <property name="label" translatable="yes">Detector</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkComboBoxText" id="detector">
+                                        <property name="valign">center</property>
+                                        <items>
+                                            <item translatable="yes" id="Compound">Compound</item>
+                                            <item translatable="yes" id="Percussive">Percussive</item>
+                                            <item translatable="yes" id="Soft">Soft</item>
+                                        </items>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">detector_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="phase_label">
+                                        <property name="label" translatable="yes">Phase</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkComboBoxText" id="phase">
+                                        <property name="valign">center</property>
+                                        <items>
+                                            <item translatable="yes" id="Laminar">Laminar</item>
+                                            <item translatable="yes" id="Independent">Independent</item>
+                                        </items>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">phase_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkGrid">
+                                <property name="margin-top">6</property>
+                                <property name="margin-bottom">12</property>
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">48</property>
+
+                                <child>
+                                    <object class="GtkLabel" id="cents_label">
+                                        <property name="label" translatable="yes">Cents</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="cents">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">0</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-100</property>
+                                                <property name="upper">100</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">10</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">cents_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="semitones_label">
+                                        <property name="label" translatable="yes">Semitones</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="semitones">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">0</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-12</property>
+                                                <property name="upper">12</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">semitones_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="octaves_label">
+                                        <property name="label" translatable="yes">Octaves</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="octaves">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">0</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-3</property>
+                                                <property name="upper">3</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">octaves_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="PitchBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">RubberBand</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="PitchBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">RubberBand</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/reverb.ui
+++ b/data/ui/reverb.ui
@@ -5,539 +5,554 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
         <child>
-            <object class="GtkMenuButton">
-                <property name="halign">center</property>
-                <property name="popover">popover_presets</property>
-                <property name="label" translatable="yes">Presets</property>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox" id="box_room_size">
-                <property name="margin-top">6</property>
-                <property name="halign">center</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">48</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="spacing">6</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkLabel" id="hf_damp_label">
-                                <property name="label" translatable="yes">High Frequency Damping</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkSpinButton" id="hf_damp">
-                                <property name="width-chars">10</property>
-                                <property name="digits">0</property>
-                                <property name="update-policy">if-valid</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">2000</property>
-                                        <property name="upper">20000</property>
-                                        <property name="value">5000</property>
-                                        <property name="step-increment">1</property>
-                                        <property name="page-increment">100</property>
-                                    </object>
-                                </property>
-                                <accessibility>
-                                    <relation name="labelled-by">hf_damp_label</relation>
-                                </accessibility>
-                            </object>
-                        </child>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
                 <child>
                     <object class="GtkBox">
-                        <property name="spacing">6</property>
+                        <property name="spacing">12</property>
                         <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkLabel" id="room_size_label">
-                                <property name="label" translatable="yes">Room Size</property>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkComboBoxText" id="room_size">
+                            <object class="GtkMenuButton">
                                 <property name="halign">center</property>
-                                <items>
-                                    <item translatable="yes" id="Small">Small</item>
-                                    <item translatable="yes" id="Medium">Medium</item>
-                                    <item translatable="yes" id="Large">Large</item>
-                                    <item translatable="yes" id="Tunnel-like">Tunnel</item>
-                                    <item translatable="yes" id="Large/smooth">Large/smooth</item>
-                                    <item translatable="yes" id="Experimental">Experimental</item>
-                                </items>
-                                <accessibility>
-                                    <relation name="labelled-by">room_size_label</relation>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="spacing">6</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkLabel" id="diffusion_label">
-                                <property name="label" translatable="yes">Diffusion</property>
+                                <property name="popover">popover_presets</property>
+                                <property name="label" translatable="yes">Presets</property>
                             </object>
                         </child>
 
                         <child>
-                            <object class="GtkSpinButton" id="diffusion">
+                            <object class="GtkBox" id="box_room_size">
+                                <property name="margin-top">6</property>
                                 <property name="halign">center</property>
-                                <property name="width-chars">10</property>
-                                <property name="digits">2</property>
-                                <property name="update-policy">if-valid</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="upper">1</property>
-                                        <property name="value">0.5</property>
-                                        <property name="step-increment">0.01</property>
-                                        <property name="page-increment">0.1</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">48</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="spacing">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkLabel" id="hf_damp_label">
+                                                <property name="label" translatable="yes">High Frequency Damping</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkSpinButton" id="hf_damp">
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">0</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">2000</property>
+                                                        <property name="upper">20000</property>
+                                                        <property name="value">5000</property>
+                                                        <property name="step-increment">1</property>
+                                                        <property name="page-increment">100</property>
+                                                    </object>
+                                                </property>
+                                                <accessibility>
+                                                    <relation name="labelled-by">hf_damp_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
-                                </property>
-                                <accessibility>
-                                    <relation name="labelled-by">diffusion_label</relation>
-                                </accessibility>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="spacing">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkLabel" id="room_size_label">
+                                                <property name="label" translatable="yes">Room Size</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkComboBoxText" id="room_size">
+                                                <property name="halign">center</property>
+                                                <items>
+                                                    <item translatable="yes" id="Small">Small</item>
+                                                    <item translatable="yes" id="Medium">Medium</item>
+                                                    <item translatable="yes" id="Large">Large</item>
+                                                    <item translatable="yes" id="Tunnel-like">Tunnel</item>
+                                                    <item translatable="yes" id="Large/smooth">Large/smooth</item>
+                                                    <item translatable="yes" id="Experimental">Experimental</item>
+                                                </items>
+                                                <accessibility>
+                                                    <relation name="labelled-by">room_size_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="halign">end</property>
+                                        <property name="spacing">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkLabel" id="diffusion_label">
+                                                <property name="label" translatable="yes">Diffusion</property>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="GtkSpinButton" id="diffusion">
+                                                <property name="halign">center</property>
+                                                <property name="width-chars">10</property>
+                                                <property name="digits">2</property>
+                                                <property name="update-policy">if-valid</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="upper">1</property>
+                                                        <property name="value">0.5</property>
+                                                        <property name="step-increment">0.01</property>
+                                                        <property name="page-increment">0.1</property>
+                                                    </object>
+                                                </property>
+                                                <accessibility>
+                                                    <relation name="labelled-by">diffusion_label</relation>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
                             </object>
                         </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkGrid" id="grid_spinbox">
-                <property name="margin-bottom">12</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row-spacing">6</property>
-                <property name="column-spacing">24</property>
-                <child>
-                    <object class="GtkLabel" id="predelay_label">
-                        <property name="label" translatable="yes">Pre Delay</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="predelay">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">2</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="upper">500</property>
-                                <property name="step-increment">0.01</property>
-                                <property name="page-increment">0.1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">predelay_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="decay_time_label">
-                        <property name="label" translatable="yes">Decay Time</property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="decay_time">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">2</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">0.4</property>
-                                <property name="upper">15</property>
-                                <property name="value">1.5</property>
-                                <property name="step-increment">0.01</property>
-                                <property name="page-increment">0.1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">1</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">decay_time_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="dry_label">
-                        <property name="label" translatable="yes">Dry Level</property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="dry">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-100</property>
-                                <property name="upper">6</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">2</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">dry_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="wet_label">
-                        <property name="label" translatable="yes">Wet Level</property>
-                        <layout>
-                            <property name="column">3</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="wet">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">-100</property>
-                                <property name="upper">6</property>
-                                <property name="value">-12</property>
-                                <property name="step-increment">0.1</property>
-                                <property name="page-increment">1</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">3</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">wet_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="bass_cut_label">
-                        <property name="label" translatable="yes">Bass Cut</property>
-                        <layout>
-                            <property name="column">4</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="bass_cut">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">0</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">20</property>
-                                <property name="upper">20000</property>
-                                <property name="value">300</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">100</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">4</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">bass_cut_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkLabel" id="treble_cut_label">
-                        <property name="label" translatable="yes">Treble Cut</property>
-                        <layout>
-                            <property name="column">5</property>
-                            <property name="row">0</property>
-                        </layout>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSpinButton" id="treble_cut">
-                        <property name="halign">center</property>
-                        <property name="orientation">vertical</property>
-                        <property name="width-chars">10</property>
-                        <property name="digits">0</property>
-                        <property name="update-policy">if-valid</property>
-                        <property name="adjustment">
-                            <object class="GtkAdjustment">
-                                <property name="lower">20</property>
-                                <property name="upper">20000</property>
-                                <property name="value">5000</property>
-                                <property name="step-increment">1</property>
-                                <property name="page-increment">100</property>
-                            </object>
-                        </property>
-                        <layout>
-                            <property name="column">5</property>
-                            <property name="row">1</property>
-                        </layout>
-                        <accessibility>
-                            <relation name="labelled-by">treble_cut_label</relation>
-                        </accessibility>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
                         <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
-                                <property name="hexpand">1</property>
+                            <object class="GtkGrid" id="grid_spinbox">
+                                <property name="margin-bottom">12</property>
+                                <property name="halign">center</property>
                                 <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">24</property>
                                 <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
+                                    <object class="GtkLabel" id="predelay_label">
+                                        <property name="label" translatable="yes">Pre Delay</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
                                     </object>
                                 </child>
                                 <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
+                                    <object class="GtkSpinButton" id="predelay">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">2</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="upper">500</property>
+                                                <property name="step-increment">0.01</property>
+                                                <property name="page-increment">0.1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">predelay_label</relation>
+                                        </accessibility>
                                     </object>
                                 </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
 
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
+                                <child>
+                                    <object class="GtkLabel" id="decay_time_label">
+                                        <property name="label" translatable="yes">Decay Time</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="decay_time">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">2</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">0.4</property>
+                                                <property name="upper">15</property>
+                                                <property name="value">1.5</property>
+                                                <property name="step-increment">0.01</property>
+                                                <property name="page-increment">0.1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">decay_time_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="dry_label">
+                                        <property name="label" translatable="yes">Dry Level</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="dry">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-100</property>
+                                                <property name="upper">6</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">dry_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="wet_label">
+                                        <property name="label" translatable="yes">Wet Level</property>
+                                        <layout>
+                                            <property name="column">3</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="wet">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-100</property>
+                                                <property name="upper">6</property>
+                                                <property name="value">-12</property>
+                                                <property name="step-increment">0.1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">3</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">wet_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="bass_cut_label">
+                                        <property name="label" translatable="yes">Bass Cut</property>
+                                        <layout>
+                                            <property name="column">4</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="bass_cut">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">0</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">20</property>
+                                                <property name="upper">20000</property>
+                                                <property name="value">300</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">100</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">4</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">bass_cut_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="treble_cut_label">
+                                        <property name="label" translatable="yes">Treble Cut</property>
+                                        <layout>
+                                            <property name="column">5</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="treble_cut">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">0</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">20</property>
+                                                <property name="upper">20000</property>
+                                                <property name="value">5000</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">100</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">5</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">treble_cut_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
                             </object>
                         </child>
+
                         <child>
-                            <object class="GtkScale" id="output_gain">
+                            <object class="GtkBox">
                                 <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
                                     </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
                                 </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
+
                                 <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
+                                    <object class="GtkButton" id="reset_button">
+                                        <property name="halign">center</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="ReverbBox" />
                                     </object>
                                 </child>
+
                                 <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
                                         <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Calf Studio Gear</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="ReverbBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">Calf Studio Gear</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/data/ui/stereo_tools.ui
+++ b/data/ui/stereo_tools.ui
@@ -5,732 +5,746 @@
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
-
         <child>
-            <object class="GtkStackSwitcher" id="stack_switcher">
-                <property name="halign">center</property>
-                <property name="stack">stack</property>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkStack" id="stack">
-                <property name="margin-bottom">12</property>
-                <property name="hexpand">1</property>
-                <property name="hhomogeneous">0</property>
-                <property name="vhomogeneous">0</property>
-                <property name="transition-duration">250</property>
-                <property name="transition-type">slide-left-right</property>
-
-                <child>
-                    <object class="GtkStackPage">
-                        <property name="name">page_input</property>
-                        <property name="title" translatable="yes">Input</property>
-                        <property name="child">
-                            <object class="GtkGrid">
-                                <property name="margin-top">6</property>
-                                <property name="margin-bottom">6</property>
-                                <property name="halign">center</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">48</property>
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="halign">center</property>
-                                        <property name="valign">center</property>
-                                        <property name="label" translatable="yes">Balance</property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkSpinButton" id="balance_in">
-                                        <property name="halign">center</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">-1</property>
-                                                <property name="upper">1</property>
-                                                <property name="step-increment">0.01</property>
-                                                <property name="page-increment">0.1</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <property name="label" translatable="yes">Input Balance</property>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkToggleButton" id="softclip">
-                                        <property name="halign">center</property>
-                                        <property name="valign">center</property>
-                                        <property name="label" translatable="yes">Softclip</property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkSpinButton" id="sc_level">
-                                        <property name="halign">center</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">1</property>
-                                                <property name="upper">100</property>
-                                                <property name="value">1</property>
-                                                <property name="step-increment">0.01</property>
-                                                <property name="page-increment">0.1</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <property name="label" translatable="yes">Softclip Level</property>
-                                        </accessibility>
-                                    </object>
-                                </child>
-                            </object>
-                        </property>
+            <object class="GtkOverlay" id="overlay">
+                <child type="overlay">
+                    <object class="AdwToastOverlay" id="toast_overlay">
+                        <property name="valign">start</property>
                     </object>
                 </child>
 
                 <child>
-                    <object class="GtkStackPage">
-                        <property name="name">page_stereo_matrix</property>
-                        <property name="title" translatable="yes">Stereo Matrix</property>
-                        <property name="child">
-                            <object class="GtkBox">
+                    <object class="GtkBox">
+                        <property name="spacing">12</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                            <object class="GtkStackSwitcher" id="stack_switcher">
                                 <property name="halign">center</property>
-                                <property name="spacing">12</property>
-                                <property name="orientation">vertical</property>
+                                <property name="stack">stack</property>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkStack" id="stack">
+                                <property name="margin-bottom">12</property>
+                                <property name="hexpand">1</property>
+                                <property name="hhomogeneous">0</property>
+                                <property name="vhomogeneous">0</property>
+                                <property name="transition-duration">250</property>
+                                <property name="transition-type">slide-left-right</property>
+
                                 <child>
-                                    <object class="GtkComboBoxText" id="mode">
+                                    <object class="GtkStackPage">
+                                        <property name="name">page_input</property>
+                                        <property name="title" translatable="yes">Input</property>
+                                        <property name="child">
+                                            <object class="GtkGrid">
+                                                <property name="margin-top">6</property>
+                                                <property name="margin-bottom">6</property>
+                                                <property name="halign">center</property>
+                                                <property name="row-spacing">6</property>
+                                                <property name="column-spacing">48</property>
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="halign">center</property>
+                                                        <property name="valign">center</property>
+                                                        <property name="label" translatable="yes">Balance</property>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkSpinButton" id="balance_in">
+                                                        <property name="halign">center</property>
+                                                        <property name="orientation">vertical</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="digits">2</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">-1</property>
+                                                                <property name="upper">1</property>
+                                                                <property name="step-increment">0.01</property>
+                                                                <property name="page-increment">0.1</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <property name="label" translatable="yes">Input Balance</property>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkToggleButton" id="softclip">
+                                                        <property name="halign">center</property>
+                                                        <property name="valign">center</property>
+                                                        <property name="label" translatable="yes">Softclip</property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkSpinButton" id="sc_level">
+                                                        <property name="halign">center</property>
+                                                        <property name="orientation">vertical</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="digits">2</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">1</property>
+                                                                <property name="upper">100</property>
+                                                                <property name="value">1</property>
+                                                                <property name="step-increment">0.01</property>
+                                                                <property name="page-increment">0.1</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <property name="label" translatable="yes">Softclip Level</property>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkStackPage">
+                                        <property name="name">page_stereo_matrix</property>
+                                        <property name="title" translatable="yes">Stereo Matrix</property>
+                                        <property name="child">
+                                            <object class="GtkBox">
+                                                <property name="halign">center</property>
+                                                <property name="spacing">12</property>
+                                                <property name="orientation">vertical</property>
+                                                <child>
+                                                    <object class="GtkComboBoxText" id="mode">
+                                                        <property name="halign">center</property>
+                                                        <items>
+                                                            <item translatable="yes" id="LR > LR (Stereo Default)">LR &gt; LR (Stereo Default)</item>
+                                                            <item translatable="yes" id="LR > MS (Stereo to Mid-Side)">LR &gt; MS (Stereo to Mid-Side)</item>
+                                                            <item translatable="yes" id="MS > LR (Mid-Side to Stereo)">MS &gt; LR (Mid-Side to Stereo)</item>
+                                                            <item translatable="yes" id="LR > LL (Mono Left Channel)">LR &gt; LL (Mono Left Channel)</item>
+                                                            <item translatable="yes" id="LR > RR (Mono Right Channel)">LR &gt; RR (Mono Right Channel)</item>
+                                                            <item translatable="yes" id="LR > L+R (Mono Sum L+R)">LR &gt; L+R (Mono Sum L+R)</item>
+                                                            <item translatable="yes" id="LR > RL (Stereo Flip Channels)">LR &gt; RL (Stereo Flip Channels)</item>
+                                                        </items>
+                                                        <accessibility>
+                                                            <property name="label" translatable="yes">Stereo Mode</property>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkBox">
+                                                        <property name="halign">center</property>
+                                                        <property name="homogeneous">1</property>
+                                                        <property name="spacing">8</property>
+                                                        <child>
+                                                            <object class="GtkLabel" id="left_channel_label">
+                                                                <property name="halign">end</property>
+                                                                <property name="xalign">1</property>
+                                                                <property name="label" translatable="yes">Left</property>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="margin-end">20</property>
+                                                                <property name="spacing">6</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <child>
+                                                                    <object class="GtkToggleButton" id="mutel">
+                                                                        <property name="label" translatable="yes">Mute</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">left_channel_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkToggleButton" id="phasel">
+                                                                        <property name="label" translatable="yes">Invert Phase</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">left_channel_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="margin-start">20</property>
+                                                                <property name="spacing">6</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <child>
+                                                                    <object class="GtkToggleButton" id="muter">
+                                                                        <property name="label" translatable="yes">Mute</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">right_channel_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkToggleButton" id="phaser">
+                                                                        <property name="label" translatable="yes">Invert Phase</property>
+                                                                        <accessibility>
+                                                                            <relation name="labelled-by">right_channel_label</relation>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkLabel" id="right_channel_label">
+                                                                <property name="halign">start</property>
+                                                                <property name="label" translatable="yes">Right</property>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkGrid">
+                                                        <property name="halign">center</property>
+                                                        <property name="valign">center</property>
+                                                        <property name="row-spacing">6</property>
+                                                        <property name="column-spacing">48</property>
+                                                        <child>
+                                                            <object class="GtkLabel" id="slev_label">
+                                                                <property name="halign">center</property>
+                                                                <property name="valign">center</property>
+                                                                <property name="label" translatable="yes">Side Level</property>
+                                                                <layout>
+                                                                    <property name="column">0</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="slev">
+                                                                <property name="halign">center</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">1</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-36</property>
+                                                                        <property name="upper">36</property>
+                                                                        <property name="step-increment">0.1</property>
+                                                                        <property name="page-increment">1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">0</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">slev_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkLabel" id="sbal_label">
+                                                                <property name="halign">center</property>
+                                                                <property name="valign">center</property>
+                                                                <property name="label" translatable="yes">Side Balance</property>
+                                                                <layout>
+                                                                    <property name="column">1</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="sbal">
+                                                                <property name="halign">center</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">2</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-1</property>
+                                                                        <property name="upper">1</property>
+                                                                        <property name="step-increment">0.01</property>
+                                                                        <property name="page-increment">0.1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">1</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">sbal_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkLabel" id="mlev_label">
+                                                                <property name="halign">center</property>
+                                                                <property name="valign">center</property>
+                                                                <property name="label" translatable="yes">Middle Level</property>
+                                                                <layout>
+                                                                    <property name="column">2</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="mlev">
+                                                                <property name="halign">center</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">1</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-36</property>
+                                                                        <property name="upper">36</property>
+                                                                        <property name="step-increment">0.1</property>
+                                                                        <property name="page-increment">1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">2</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">mlev_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkLabel" id="mpan_label">
+                                                                <property name="halign">center</property>
+                                                                <property name="valign">center</property>
+                                                                <property name="label" translatable="yes">Middle Panorama</property>
+                                                                <layout>
+                                                                    <property name="column">3</property>
+                                                                    <property name="row">0</property>
+                                                                </layout>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="mpan">
+                                                                <property name="halign">center</property>
+                                                                <property name="orientation">vertical</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">2</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-1</property>
+                                                                        <property name="upper">1</property>
+                                                                        <property name="step-increment">0.01</property>
+                                                                        <property name="page-increment">0.1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <layout>
+                                                                    <property name="column">3</property>
+                                                                    <property name="row">1</property>
+                                                                </layout>
+                                                                <accessibility>
+                                                                    <relation name="labelled-by">mpan_label</relation>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </property>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkStackPage">
+                                        <property name="name">page_output</property>
+                                        <property name="title" translatable="yes">Output</property>
+                                        <property name="child">
+                                            <object class="GtkGrid">
+                                                <property name="margin-top">6</property>
+                                                <property name="margin-bottom">6</property>
+                                                <property name="halign">center</property>
+                                                <property name="row-spacing">6</property>
+                                                <property name="column-spacing">48</property>
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="halign">center</property>
+                                                        <property name="valign">center</property>
+                                                        <property name="label" translatable="yes">Balance</property>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkSpinButton" id="balance_out">
+                                                        <property name="halign">center</property>
+                                                        <property name="orientation">vertical</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="digits">2</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">-1</property>
+                                                                <property name="upper">1</property>
+                                                                <property name="step-increment">0.01</property>
+                                                                <property name="page-increment">0.1</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <property name="label" translatable="yes">Output Balance</property>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="halign">center</property>
+                                                        <property name="valign">center</property>
+                                                        <property name="label" translatable="yes">Delay L/R</property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkSpinButton" id="delay">
+                                                        <property name="halign">center</property>
+                                                        <property name="orientation">vertical</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="digits">2</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">-20</property>
+                                                                <property name="upper">20</property>
+                                                                <property name="step-increment">0.01</property>
+                                                                <property name="page-increment">0.1</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <property name="label" translatable="yes">Delay Left Right</property>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="stereo_base_label">
+                                                        <property name="halign">center</property>
+                                                        <property name="valign">center</property>
+                                                        <property name="label" translatable="yes">Stereo Base</property>
+                                                        <layout>
+                                                            <property name="column">2</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkSpinButton" id="stereo_base">
+                                                        <property name="halign">center</property>
+                                                        <property name="orientation">vertical</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="digits">2</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="lower">-1</property>
+                                                                <property name="upper">1</property>
+                                                                <property name="step-increment">0.01</property>
+                                                                <property name="page-increment">0.1</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">2</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">stereo_base_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="stereo_phase_label">
+                                                        <property name="halign">center</property>
+                                                        <property name="valign">center</property>
+                                                        <property name="label" translatable="yes">Stereo Phase</property>
+                                                        <layout>
+                                                            <property name="column">3</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkSpinButton" id="stereo_phase">
+                                                        <property name="halign">center</property>
+                                                        <property name="orientation">vertical</property>
+                                                        <property name="width-chars">10</property>
+                                                        <property name="digits">2</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="adjustment">
+                                                            <object class="GtkAdjustment">
+                                                                <property name="upper">360</property>
+                                                                <property name="step-increment">0.01</property>
+                                                                <property name="page-increment">0.1</property>
+                                                            </object>
+                                                        </property>
+                                                        <layout>
+                                                            <property name="column">3</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                        <accessibility>
+                                                            <relation name="labelled-by">stereo_phase_label</relation>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </property>
+                                    </object>
+                                </child>
+
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="input_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Input</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="input_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Input Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="input_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="input_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="homogeneous">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="output_level_title">
+                                                <property name="halign">end</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Output</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkScale" id="output_gain">
+                                                <property name="hexpand">1</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">
+                                                    <object class="GtkAdjustment">
+                                                        <property name="lower">-36</property>
+                                                        <property name="upper">36</property>
+                                                        <property name="step-increment">0.1</property>
+                                                        <property name="page-increment">1</property>
+                                                    </object>
+                                                </property>
+                                                <property name="draw-value">1</property>
+                                                <property name="digits">1</property>
+                                                <property name="value-pos">right</property>
+                                                <accessibility>
+                                                    <property name="label" translatable="yes">Plugin Output Gain</property>
+                                                </accessibility>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_left">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_left_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox">
+                                                <property name="spacing">6</property>
+                                                <child>
+                                                    <object class="GtkLevelBar" id="output_level_right">
+                                                        <property name="valign">center</property>
+                                                        <property name="hexpand">1</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel" id="output_level_right_label">
+                                                        <property name="halign">end</property>
+                                                        <property name="width-chars">4</property>
+                                                        <property name="label">0</property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
+                                </property>
+
+                                <child>
+                                    <object class="GtkButton" id="reset_button">
                                         <property name="halign">center</property>
-                                        <items>
-                                            <item translatable="yes" id="LR > LR (Stereo Default)">LR &gt; LR (Stereo Default)</item>
-                                            <item translatable="yes" id="LR > MS (Stereo to Mid-Side)">LR &gt; MS (Stereo to Mid-Side)</item>
-                                            <item translatable="yes" id="MS > LR (Mid-Side to Stereo)">MS &gt; LR (Mid-Side to Stereo)</item>
-                                            <item translatable="yes" id="LR > LL (Mono Left Channel)">LR &gt; LL (Mono Left Channel)</item>
-                                            <item translatable="yes" id="LR > RR (Mono Right Channel)">LR &gt; RR (Mono Right Channel)</item>
-                                            <item translatable="yes" id="LR > L+R (Mono Sum L+R)">LR &gt; L+R (Mono Sum L+R)</item>
-                                            <item translatable="yes" id="LR > RL (Stereo Flip Channels)">LR &gt; RL (Stereo Flip Channels)</item>
-                                        </items>
-                                        <accessibility>
-                                            <property name="label" translatable="yes">Stereo Mode</property>
-                                        </accessibility>
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">1</property>
+                                        <property name="label" translatable="yes">Reset</property>
+                                        <signal name="clicked" handler="on_reset" object="StereoToolsBox" />
                                     </object>
                                 </child>
 
                                 <child>
                                     <object class="GtkBox">
-                                        <property name="halign">center</property>
-                                        <property name="homogeneous">1</property>
-                                        <property name="spacing">8</property>
+                                        <property name="halign">end</property>
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
                                         <child>
-                                            <object class="GtkLabel" id="left_channel_label">
+                                            <object class="GtkLabel">
                                                 <property name="halign">end</property>
-                                                <property name="xalign">1</property>
-                                                <property name="label" translatable="yes">Left</property>
+                                                <property name="label" translatable="yes">Using</property>
                                             </object>
                                         </child>
                                         <child>
-                                            <object class="GtkBox">
-                                                <property name="margin-end">20</property>
-                                                <property name="spacing">6</property>
-                                                <property name="orientation">vertical</property>
-                                                <child>
-                                                    <object class="GtkToggleButton" id="mutel">
-                                                        <property name="label" translatable="yes">Mute</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">left_channel_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-
-                                                <child>
-                                                    <object class="GtkToggleButton" id="phasel">
-                                                        <property name="label" translatable="yes">Invert Phase</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">left_channel_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="margin-start">20</property>
-                                                <property name="spacing">6</property>
-                                                <property name="orientation">vertical</property>
-                                                <child>
-                                                    <object class="GtkToggleButton" id="muter">
-                                                        <property name="label" translatable="yes">Mute</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">right_channel_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-
-                                                <child>
-                                                    <object class="GtkToggleButton" id="phaser">
-                                                        <property name="label" translatable="yes">Invert Phase</property>
-                                                        <accessibility>
-                                                            <relation name="labelled-by">right_channel_label</relation>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkLabel" id="right_channel_label">
-                                                <property name="halign">start</property>
-                                                <property name="label" translatable="yes">Right</property>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Calf Studio Gear</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
                                             </object>
                                         </child>
                                     </object>
                                 </child>
-
-                                <child>
-                                    <object class="GtkGrid">
-                                        <property name="halign">center</property>
-                                        <property name="valign">center</property>
-                                        <property name="row-spacing">6</property>
-                                        <property name="column-spacing">48</property>
-                                        <child>
-                                            <object class="GtkLabel" id="slev_label">
-                                                <property name="halign">center</property>
-                                                <property name="valign">center</property>
-                                                <property name="label" translatable="yes">Side Level</property>
-                                                <layout>
-                                                    <property name="column">0</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="slev">
-                                                <property name="halign">center</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">1</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">-36</property>
-                                                        <property name="upper">36</property>
-                                                        <property name="step-increment">0.1</property>
-                                                        <property name="page-increment">1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">0</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">slev_label</relation>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel" id="sbal_label">
-                                                <property name="halign">center</property>
-                                                <property name="valign">center</property>
-                                                <property name="label" translatable="yes">Side Balance</property>
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="sbal">
-                                                <property name="halign">center</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">2</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">-1</property>
-                                                        <property name="upper">1</property>
-                                                        <property name="step-increment">0.01</property>
-                                                        <property name="page-increment">0.1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">1</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">sbal_label</relation>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel" id="mlev_label">
-                                                <property name="halign">center</property>
-                                                <property name="valign">center</property>
-                                                <property name="label" translatable="yes">Middle Level</property>
-                                                <layout>
-                                                    <property name="column">2</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="mlev">
-                                                <property name="halign">center</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">1</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">-36</property>
-                                                        <property name="upper">36</property>
-                                                        <property name="step-increment">0.1</property>
-                                                        <property name="page-increment">1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">2</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">mlev_label</relation>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="GtkLabel" id="mpan_label">
-                                                <property name="halign">center</property>
-                                                <property name="valign">center</property>
-                                                <property name="label" translatable="yes">Middle Panorama</property>
-                                                <layout>
-                                                    <property name="column">3</property>
-                                                    <property name="row">0</property>
-                                                </layout>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkSpinButton" id="mpan">
-                                                <property name="halign">center</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="width-chars">10</property>
-                                                <property name="digits">2</property>
-                                                <property name="update-policy">if-valid</property>
-                                                <property name="adjustment">
-                                                    <object class="GtkAdjustment">
-                                                        <property name="lower">-1</property>
-                                                        <property name="upper">1</property>
-                                                        <property name="step-increment">0.01</property>
-                                                        <property name="page-increment">0.1</property>
-                                                    </object>
-                                                </property>
-                                                <layout>
-                                                    <property name="column">3</property>
-                                                    <property name="row">1</property>
-                                                </layout>
-                                                <accessibility>
-                                                    <relation name="labelled-by">mpan_label</relation>
-                                                </accessibility>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-                            </object>
-                        </property>
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkStackPage">
-                        <property name="name">page_output</property>
-                        <property name="title" translatable="yes">Output</property>
-                        <property name="child">
-                            <object class="GtkGrid">
-                                <property name="margin-top">6</property>
-                                <property name="margin-bottom">6</property>
-                                <property name="halign">center</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">48</property>
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="halign">center</property>
-                                        <property name="valign">center</property>
-                                        <property name="label" translatable="yes">Balance</property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkSpinButton" id="balance_out">
-                                        <property name="halign">center</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">-1</property>
-                                                <property name="upper">1</property>
-                                                <property name="step-increment">0.01</property>
-                                                <property name="page-increment">0.1</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <property name="label" translatable="yes">Output Balance</property>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="halign">center</property>
-                                        <property name="valign">center</property>
-                                        <property name="label" translatable="yes">Delay L/R</property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkSpinButton" id="delay">
-                                        <property name="halign">center</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">-20</property>
-                                                <property name="upper">20</property>
-                                                <property name="step-increment">0.01</property>
-                                                <property name="page-increment">0.1</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <property name="label" translatable="yes">Delay Left Right</property>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel" id="stereo_base_label">
-                                        <property name="halign">center</property>
-                                        <property name="valign">center</property>
-                                        <property name="label" translatable="yes">Stereo Base</property>
-                                        <layout>
-                                            <property name="column">2</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkSpinButton" id="stereo_base">
-                                        <property name="halign">center</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">-1</property>
-                                                <property name="upper">1</property>
-                                                <property name="step-increment">0.01</property>
-                                                <property name="page-increment">0.1</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">2</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">stereo_base_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel" id="stereo_phase_label">
-                                        <property name="halign">center</property>
-                                        <property name="valign">center</property>
-                                        <property name="label" translatable="yes">Stereo Phase</property>
-                                        <layout>
-                                            <property name="column">3</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkSpinButton" id="stereo_phase">
-                                        <property name="halign">center</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="upper">360</property>
-                                                <property name="step-increment">0.01</property>
-                                                <property name="page-increment">0.1</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">3</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">stereo_phase_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-                            </object>
-                        </property>
-                    </object>
-                </child>
-
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="input_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Input</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="input_gain">
-                                <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Input Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="input_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="input_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel" id="output_level_title">
-                                <property name="halign">end</property>
-                                <property name="xalign">1</property>
-                                <property name="label" translatable="yes">Output</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkScale" id="output_gain">
-                                <property name="hexpand">1</property>
-                                <property name="valign">center</property>
-                                <property name="adjustment">
-                                    <object class="GtkAdjustment">
-                                        <property name="lower">-36</property>
-                                        <property name="upper">36</property>
-                                        <property name="step-increment">0.1</property>
-                                        <property name="page-increment">1</property>
-                                    </object>
-                                </property>
-                                <property name="draw-value">1</property>
-                                <property name="digits">1</property>
-                                <property name="value-pos">right</property>
-                                <accessibility>
-                                    <property name="label" translatable="yes">Plugin Output Gain</property>
-                                </accessibility>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_left">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_left_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                    <object class="GtkLevelBar" id="output_level_right">
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel" id="output_level_right_label">
-                                        <property name="halign">end</property>
-                                        <property name="width-chars">4</property>
-                                        <property name="label">0</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
-
-        <child>
-            <object class="GtkBox">
-                <property name="hexpand">1</property>
-                <property name="vexpand">0</property>
-                <property name="layout-manager">
-                    <object class="GtkBinLayout"></object>
-                </property>
-
-                <child>
-                    <object class="GtkButton" id="reset_button">
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset</property>
-                        <signal name="clicked" handler="on_reset" object="StereoToolsBox" />
-                    </object>
-                </child>
-
-                <child>
-                    <object class="GtkBox">
-                        <property name="halign">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">0</property>
-                        <property name="spacing">6</property>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Using</property>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkLabel">
-                                <property name="halign">end</property>
-                                <property name="label">Calf Studio Gear</property>
-                                <attributes>
-                                    <attribute name="weight" value="bold" />
-                                </attributes>
                             </object>
                         </child>
                     </object>

--- a/include/gate.hpp
+++ b/include/gate.hpp
@@ -45,7 +45,8 @@ class Gate : public PluginBase {
   void update_probe_links() override;
 
   sigc::signal<void(const float)> attack_zone_start, attack_threshold, release_zone_start, release_threshold, reduction,
-      sidechain, curve, envelope, gating;
+      sidechain, curve, envelope;
+  sigc::signal<void(const double)> gating;
 
   float attack_zone_start_port_value = 0.0F;
   float attack_threshold_port_value = 0.0F;
@@ -55,8 +56,8 @@ class Gate : public PluginBase {
   float sidechain_port_value = 0.0F;
   float curve_port_value = 0.0F;
   float envelope_port_value = 0.0F;
-  float gating_port_value = 0.0F;
   float latency_port_value = 0.0F;
+  double gating_port_value = 0.0F;
 
  private:
   uint latency_n_frames = 0U;

--- a/include/multiband_gate.hpp
+++ b/include/multiband_gate.hpp
@@ -50,7 +50,8 @@ class MultibandGate : public PluginBase {
 
   void update_probe_links() override;
 
-  sigc::signal<void(const std::array<float, n_bands>)> reduction, envelope, curve, frequency_range, gating;
+  sigc::signal<void(const std::array<float, n_bands>)> reduction, envelope, curve, frequency_range;
+  sigc::signal<void(const std::array<double, n_bands>)> gating;
 
   float latency_port_value = 0.0F;
 
@@ -58,7 +59,7 @@ class MultibandGate : public PluginBase {
   std::array<float, n_bands> envelope_port_array = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
   std::array<float, n_bands> curve_port_array = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
   std::array<float, n_bands> reduction_port_array = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
-  std::array<float, n_bands> gating_array = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
+  std::array<double, n_bands> gating_array = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
  private:
   uint latency_n_frames = 0U;

--- a/include/plugin_base.hpp
+++ b/include/plugin_base.hpp
@@ -31,6 +31,7 @@ class PluginBase {
  public:
   PluginBase(std::string tag,
              std::string plugin_name,
+             std::string plugin_package,
              const std::string& schema,
              const std::string& schema_path,
              PipeManager* pipe_manager,
@@ -62,7 +63,7 @@ class PluginBase {
 
   const std::string log_tag;
 
-  std::string name;
+  std::string name, package;
 
   pw_filter* filter = nullptr;
 
@@ -73,6 +74,8 @@ class PluginBase {
   uint rate = 0U;
 
   float buffer_duration = 0.0F;
+
+  bool package_installed = true;
 
   bool bypass = false;
 

--- a/include/rnnoise.hpp
+++ b/include/rnnoise.hpp
@@ -45,6 +45,10 @@ class RNNoise : public PluginBase {
 
   auto get_latency_seconds() -> float override;
 
+#ifndef RNNOISE_AVAILABLE
+  bool package_installed = false;
+#endif
+
   float latency_value = 0.0F;
 
   bool standard_model = true;

--- a/include/tags_plugin_name.hpp
+++ b/include/tags_plugin_name.hpp
@@ -24,6 +24,32 @@
 #include <iostream>
 #include <map>
 
+namespace tags::plugin_package {
+
+inline constexpr auto bs2b = "bs2b";
+
+inline constexpr auto calf = "Calf Studio Gear";
+
+inline constexpr auto ebur128 = "libebur128";
+
+inline constexpr auto ee = "EasyEffects";
+
+inline constexpr auto lsp = "Linux Studio Plugins";
+
+inline constexpr auto mda = "MDA";
+
+inline constexpr auto rnnoise = "RNNoise";
+
+inline constexpr auto rubber = "Rubber Band";
+
+inline constexpr auto speex = "SpeexDSP";
+
+inline constexpr auto zam = "ZamAudio";
+
+inline constexpr auto zita = "Zita";
+
+}  // namespace tags::plugin_package
+
 namespace tags::plugin_name {
 
 inline constexpr auto autogain = "autogain";

--- a/include/ui_helpers.hpp
+++ b/include/ui_helpers.hpp
@@ -37,10 +37,13 @@ namespace ui {
 void show_fixed_toast(AdwToastOverlay* toast_overlay,
                       const std::string& text,
                       const AdwToastPriority& priority = ADW_TOAST_PRIORITY_HIGH);
+
 void show_autohiding_toast(AdwToastOverlay* toast_overlay,
                            const std::string& text,
                            const uint& timeout = 5U,
                            const AdwToastPriority& priority = ADW_TOAST_PRIORITY_HIGH);
+
+void missing_plugin_toast(AdwToastOverlay* toast_overlay, const std::string& package);
 
 void show_simple_message_dialog(GtkWidget* parent, const std::string& title, const std::string& descr);
 

--- a/include/ui_helpers.hpp
+++ b/include/ui_helpers.hpp
@@ -30,6 +30,7 @@
 #include <string>
 #include "string_literal_wrapper.hpp"
 #include "tags_app.hpp"
+#include "tags_plugin_name.hpp"
 #include "util.hpp"
 
 namespace ui {
@@ -43,7 +44,7 @@ void show_autohiding_toast(AdwToastOverlay* toast_overlay,
                            const uint& timeout = 5U,
                            const AdwToastPriority& priority = ADW_TOAST_PRIORITY_HIGH);
 
-void missing_plugin_toast(AdwToastOverlay* toast_overlay, const std::string& package);
+auto missing_plugin_box(const std::string& name, const std::string& package) -> GtkWidget*;
 
 void show_simple_message_dialog(GtkWidget* parent, const std::string& title, const std::string& descr);
 

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -50,7 +50,7 @@ void critical(const std::string& s, std::source_location location = std::source_
 void warning(const std::string& s, std::source_location location = std::source_location::current());
 void info(const std::string& s, std::source_location location = std::source_location::current());
 
-auto normalize(const float& x, const float& max, const float& min = 1.0F) -> float;
+auto normalize(const double& x, const double& max, const double& min = 1.0) -> double;
 
 auto logspace(const float& start, const float& stop, const uint& npoints) -> std::vector<float>;
 auto linspace(const float& start, const float& stop, const uint& npoints) -> std::vector<float>;

--- a/src/autogain.cpp
+++ b/src/autogain.cpp
@@ -23,7 +23,7 @@ AutoGain::AutoGain(const std::string& tag,
                    const std::string& schema,
                    const std::string& schema_path,
                    PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::autogain, schema, schema_path, pipe_manager) {
+    : PluginBase(tag, tags::plugin_name::autogain, tags::plugin_package::ebur128, schema, schema_path, pipe_manager) {
   target = g_settings_get_double(settings, "target");
 
   reference = parse_reference_key(util::gsettings_get_string(settings, "reference"));

--- a/src/autogain_ui.cpp
+++ b/src/autogain_ui.cpp
@@ -85,7 +85,7 @@ void setup(AutogainBox* self, std::shared_ptr<AutoGain> autogain, const std::str
 
   autogain->set_post_messages(true);
 
-  self->data->connections.push_back(autogain->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(autogain->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -96,7 +96,7 @@ void setup(AutogainBox* self, std::shared_ptr<AutoGain> autogain, const std::str
     });
   }));
 
-  self->data->connections.push_back(autogain->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(autogain->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/autogain_ui.cpp
+++ b/src/autogain_ui.cpp
@@ -108,8 +108,8 @@ void setup(AutogainBox* self, std::shared_ptr<AutoGain> autogain, const std::str
   }));
 
   self->data->connections.push_back(autogain->results.connect(
-      [=](const double& loudness, const double& gain, const double& momentary, const double& shortterm,
-          const double& integrated, const double& relative, const double& range) {
+      [=](const double loudness, const double gain, const double momentary, const double shortterm,
+          const double integrated, const double relative, const double range) {
         util::idle_add([=]() {
           if (get_ignore_filter_idle_add(serial)) {
             return;

--- a/src/bass_enhancer.cpp
+++ b/src/bass_enhancer.cpp
@@ -23,9 +23,11 @@ BassEnhancer::BassEnhancer(const std::string& tag,
                            const std::string& schema,
                            const std::string& schema_path,
                            PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::bass_enhancer, schema, schema_path, pipe_manager),
+    : PluginBase(tag, tags::plugin_name::bass_enhancer, tags::plugin_package::calf, schema, schema_path, pipe_manager),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://calf.sourceforge.net/plugins/BassEnhancer")) {
-  if (!lv2_wrapper->found_plugin) {
+  package_installed = lv2_wrapper->found_plugin;
+
+  if (!package_installed) {
     util::debug(log_tag + "http://calf.sourceforge.net/plugins/BassEnhancer is not installed");
   }
 

--- a/src/bass_enhancer_ui.cpp
+++ b/src/bass_enhancer_ui.cpp
@@ -37,8 +37,6 @@ struct Data {
 struct _BassEnhancerBox {
   GtkBox parent_instance;
 
-  AdwToastOverlay* toast_overlay;
-
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -169,7 +167,6 @@ void bass_enhancer_box_class_init(BassEnhancerBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::bass_enhancer_ui);
 
-  gtk_widget_class_bind_template_child(widget_class, BassEnhancerBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, BassEnhancerBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, BassEnhancerBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, BassEnhancerBox, input_level_left);

--- a/src/bass_enhancer_ui.cpp
+++ b/src/bass_enhancer_ui.cpp
@@ -37,6 +37,8 @@ struct Data {
 struct _BassEnhancerBox {
   GtkBox parent_instance;
 
+  AdwToastOverlay* toast_overlay;
+
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -167,6 +169,7 @@ void bass_enhancer_box_class_init(BassEnhancerBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::bass_enhancer_ui);
 
+  gtk_widget_class_bind_template_child(widget_class, BassEnhancerBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, BassEnhancerBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, BassEnhancerBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, BassEnhancerBox, input_level_left);

--- a/src/bass_enhancer_ui.cpp
+++ b/src/bass_enhancer_ui.cpp
@@ -81,7 +81,7 @@ void setup(BassEnhancerBox* self, std::shared_ptr<BassEnhancer> bass_enhancer, c
 
   bass_enhancer->set_post_messages(true);
 
-  self->data->connections.push_back(bass_enhancer->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(bass_enhancer->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -92,7 +92,7 @@ void setup(BassEnhancerBox* self, std::shared_ptr<BassEnhancer> bass_enhancer, c
     });
   }));
 
-  self->data->connections.push_back(bass_enhancer->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(bass_enhancer->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/bass_loudness.cpp
+++ b/src/bass_loudness.cpp
@@ -23,9 +23,11 @@ BassLoudness::BassLoudness(const std::string& tag,
                            const std::string& schema,
                            const std::string& schema_path,
                            PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::bass_loudness, schema, schema_path, pipe_manager),
+    : PluginBase(tag, tags::plugin_name::bass_loudness, tags::plugin_package::mda, schema, schema_path, pipe_manager),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://drobilla.net/plugins/mda/Loudness")) {
-  if (!lv2_wrapper->found_plugin) {
+  package_installed = lv2_wrapper->found_plugin;
+
+  if (!package_installed) {
     util::debug(log_tag + "http://drobilla.net/plugins/mda/Loudness is not installed");
   }
 

--- a/src/bass_loudness_ui.cpp
+++ b/src/bass_loudness_ui.cpp
@@ -73,7 +73,7 @@ void setup(BassLoudnessBox* self, std::shared_ptr<BassLoudness> bass_loudness, c
 
   bass_loudness->set_post_messages(true);
 
-  self->data->connections.push_back(bass_loudness->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(bass_loudness->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -84,7 +84,7 @@ void setup(BassLoudnessBox* self, std::shared_ptr<BassLoudness> bass_loudness, c
     });
   }));
 
-  self->data->connections.push_back(bass_loudness->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(bass_loudness->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/bass_loudness_ui.cpp
+++ b/src/bass_loudness_ui.cpp
@@ -37,6 +37,8 @@ struct Data {
 struct _BassLoudnessBox {
   GtkBox parent_instance;
 
+  AdwToastOverlay* toast_overlay;
+
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -142,6 +144,7 @@ void bass_loudness_box_class_init(BassLoudnessBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::bass_loudness_ui);
 
+  gtk_widget_class_bind_template_child(widget_class, BassLoudnessBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, BassLoudnessBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, BassLoudnessBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, BassLoudnessBox, input_level_left);

--- a/src/bass_loudness_ui.cpp
+++ b/src/bass_loudness_ui.cpp
@@ -37,8 +37,6 @@ struct Data {
 struct _BassLoudnessBox {
   GtkBox parent_instance;
 
-  AdwToastOverlay* toast_overlay;
-
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -144,7 +142,6 @@ void bass_loudness_box_class_init(BassLoudnessBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::bass_loudness_ui);
 
-  gtk_widget_class_bind_template_child(widget_class, BassLoudnessBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, BassLoudnessBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, BassLoudnessBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, BassLoudnessBox, input_level_left);

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -23,9 +23,17 @@ Compressor::Compressor(const std::string& tag,
                        const std::string& schema,
                        const std::string& schema_path,
                        PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::compressor, schema, schema_path, pipe_manager, true),
+    : PluginBase(tag,
+                 tags::plugin_name::compressor,
+                 tags::plugin_package::lsp,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 true),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/sc_compressor_stereo")) {
-  if (!lv2_wrapper->found_plugin) {
+  package_installed = lv2_wrapper->found_plugin;
+
+  if (!package_installed) {
     util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/sc_compressor_stereo is not installed");
   }
 

--- a/src/compressor_ui.cpp
+++ b/src/compressor_ui.cpp
@@ -37,8 +37,6 @@ struct Data {
 struct _CompressorBox {
   GtkBox parent_instance;
 
-  AdwToastOverlay* toast_overlay;
-
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -372,7 +370,6 @@ void compressor_box_class_init(CompressorBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::compressor_ui);
 
-  gtk_widget_class_bind_template_child(widget_class, CompressorBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, CompressorBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, CompressorBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, CompressorBox, input_level_left);

--- a/src/compressor_ui.cpp
+++ b/src/compressor_ui.cpp
@@ -172,7 +172,7 @@ void setup(CompressorBox* self,
     });
   }));
 
-  self->data->connections.push_back(compressor->reduction.connect([=](const double& value) {
+  self->data->connections.push_back(compressor->reduction.connect([=](const float value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -186,7 +186,7 @@ void setup(CompressorBox* self,
     });
   }));
 
-  self->data->connections.push_back(compressor->envelope.connect([=](const double& value) {
+  self->data->connections.push_back(compressor->envelope.connect([=](const float value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -200,7 +200,7 @@ void setup(CompressorBox* self,
     });
   }));
 
-  self->data->connections.push_back(compressor->sidechain.connect([=](const double& value) {
+  self->data->connections.push_back(compressor->sidechain.connect([=](const float value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -214,7 +214,7 @@ void setup(CompressorBox* self,
     });
   }));
 
-  self->data->connections.push_back(compressor->curve.connect([=](const double& value) {
+  self->data->connections.push_back(compressor->curve.connect([=](const float value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/compressor_ui.cpp
+++ b/src/compressor_ui.cpp
@@ -37,6 +37,8 @@ struct Data {
 struct _CompressorBox {
   GtkBox parent_instance;
 
+  AdwToastOverlay* toast_overlay;
+
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -370,6 +372,7 @@ void compressor_box_class_init(CompressorBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::compressor_ui);
 
+  gtk_widget_class_bind_template_child(widget_class, CompressorBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, CompressorBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, CompressorBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, CompressorBox, input_level_left);

--- a/src/compressor_ui.cpp
+++ b/src/compressor_ui.cpp
@@ -150,7 +150,7 @@ void setup(CompressorBox* self,
     }
   }
 
-  self->data->connections.push_back(compressor->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(compressor->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -161,7 +161,7 @@ void setup(CompressorBox* self,
     });
   }));
 
-  self->data->connections.push_back(compressor->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(compressor->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/convolver.cpp
+++ b/src/convolver.cpp
@@ -31,7 +31,7 @@ Convolver::Convolver(const std::string& tag,
                      const std::string& schema,
                      const std::string& schema_path,
                      PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::convolver, schema, schema_path, pipe_manager) {
+    : PluginBase(tag, tags::plugin_name::convolver, tags::plugin_package::zita, schema, schema_path, pipe_manager) {
   do_autogain = g_settings_get_boolean(settings, "autogain") != 0;
 
   ir_width = g_settings_get_int(settings, "ir-width");

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -479,7 +479,7 @@ void setup(ConvolverBox* self,
 
   ui::convolver_menu_impulses::setup(self->impulses_menu, schema_path, application);
 
-  self->data->connections.push_back(convolver->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(convolver->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -490,7 +490,7 @@ void setup(ConvolverBox* self,
     });
   }));
 
-  self->data->connections.push_back(convolver->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(convolver->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/crossfeed.cpp
+++ b/src/crossfeed.cpp
@@ -23,7 +23,7 @@ Crossfeed::Crossfeed(const std::string& tag,
                      const std::string& schema,
                      const std::string& schema_path,
                      PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::crossfeed, schema, schema_path, pipe_manager) {
+    : PluginBase(tag, tags::plugin_name::crossfeed, tags::plugin_package::bs2b, schema, schema_path, pipe_manager) {
   bs2b.set_level_fcut(g_settings_get_int(settings, "fcut"));
 
   bs2b.set_level_feed(10 * static_cast<int>(g_settings_get_double(settings, "feed")));

--- a/src/crossfeed_ui.cpp
+++ b/src/crossfeed_ui.cpp
@@ -86,7 +86,7 @@ void setup(CrossfeedBox* self, std::shared_ptr<Crossfeed> crossfeed, const std::
 
   crossfeed->set_post_messages(true);
 
-  self->data->connections.push_back(crossfeed->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(crossfeed->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -97,7 +97,7 @@ void setup(CrossfeedBox* self, std::shared_ptr<Crossfeed> crossfeed, const std::
     });
   }));
 
-  self->data->connections.push_back(crossfeed->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(crossfeed->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/crystalizer.cpp
+++ b/src/crystalizer.cpp
@@ -23,7 +23,7 @@ Crystalizer::Crystalizer(const std::string& tag,
                          const std::string& schema,
                          const std::string& schema_path,
                          PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::crystalizer, schema, schema_path, pipe_manager) {
+    : PluginBase(tag, tags::plugin_name::crystalizer, tags::plugin_package::ee, schema, schema_path, pipe_manager) {
   for (uint n = 0U; n < nbands; n++) {
     filters.at(n) = std::make_unique<FirFilterBandpass>(log_tag + name + " band" + util::to_string(n));
   }

--- a/src/crystalizer_ui.cpp
+++ b/src/crystalizer_ui.cpp
@@ -148,7 +148,7 @@ void setup(CrystalizerBox* self, std::shared_ptr<Crystalizer> crystalizer, const
 
   build_bands(self);
 
-  self->data->connections.push_back(crystalizer->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(crystalizer->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -159,7 +159,7 @@ void setup(CrystalizerBox* self, std::shared_ptr<Crystalizer> crystalizer, const
     });
   }));
 
-  self->data->connections.push_back(crystalizer->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(crystalizer->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/deesser.cpp
+++ b/src/deesser.cpp
@@ -23,9 +23,11 @@ Deesser::Deesser(const std::string& tag,
                  const std::string& schema,
                  const std::string& schema_path,
                  PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::deesser, schema, schema_path, pipe_manager),
+    : PluginBase(tag, tags::plugin_name::deesser, tags::plugin_package::lsp, schema, schema_path, pipe_manager),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://calf.sourceforge.net/plugins/Deesser")) {
-  if (!lv2_wrapper->found_plugin) {
+  package_installed = lv2_wrapper->found_plugin;
+
+  if (!package_installed) {
     util::debug(log_tag + "http://calf.sourceforge.net/plugins/Deesser is not installed");
   }
 

--- a/src/deesser_ui.cpp
+++ b/src/deesser_ui.cpp
@@ -103,7 +103,7 @@ void setup(DeesserBox* self, std::shared_ptr<Deesser> deesser, const std::string
     });
   }));
 
-  self->data->connections.push_back(deesser->detected.connect([=](const double& value) {
+  self->data->connections.push_back(deesser->detected.connect([=](const double value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -118,7 +118,7 @@ void setup(DeesserBox* self, std::shared_ptr<Deesser> deesser, const std::string
     });
   }));
 
-  self->data->connections.push_back(deesser->compression.connect([=](const double& value) {
+  self->data->connections.push_back(deesser->compression.connect([=](const double value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/deesser_ui.cpp
+++ b/src/deesser_ui.cpp
@@ -37,6 +37,8 @@ struct Data {
 struct _DeesserBox {
   GtkBox parent_instance;
 
+  AdwToastOverlay* toast_overlay;
+
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -210,6 +212,7 @@ void deesser_box_class_init(DeesserBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::deesser_ui);
 
+  gtk_widget_class_bind_template_child(widget_class, DeesserBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, DeesserBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, DeesserBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, DeesserBox, input_level_left);

--- a/src/deesser_ui.cpp
+++ b/src/deesser_ui.cpp
@@ -81,7 +81,7 @@ void setup(DeesserBox* self, std::shared_ptr<Deesser> deesser, const std::string
 
   deesser->set_post_messages(true);
 
-  self->data->connections.push_back(deesser->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(deesser->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -92,7 +92,7 @@ void setup(DeesserBox* self, std::shared_ptr<Deesser> deesser, const std::string
     });
   }));
 
-  self->data->connections.push_back(deesser->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(deesser->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/deesser_ui.cpp
+++ b/src/deesser_ui.cpp
@@ -37,8 +37,6 @@ struct Data {
 struct _DeesserBox {
   GtkBox parent_instance;
 
-  AdwToastOverlay* toast_overlay;
-
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -212,7 +210,6 @@ void deesser_box_class_init(DeesserBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::deesser_ui);
 
-  gtk_widget_class_bind_template_child(widget_class, DeesserBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, DeesserBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, DeesserBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, DeesserBox, input_level_left);

--- a/src/delay.cpp
+++ b/src/delay.cpp
@@ -23,9 +23,11 @@ Delay::Delay(const std::string& tag,
              const std::string& schema,
              const std::string& schema_path,
              PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::delay, schema, schema_path, pipe_manager),
+    : PluginBase(tag, tags::plugin_name::delay, tags::plugin_package::lsp, schema, schema_path, pipe_manager),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/comp_delay_x2_stereo")) {
-  if (!lv2_wrapper->found_plugin) {
+  package_installed = lv2_wrapper->found_plugin;
+
+  if (!package_installed) {
     util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/comp_delay_x2_stereo is not installed");
   }
 

--- a/src/delay_ui.cpp
+++ b/src/delay_ui.cpp
@@ -37,8 +37,6 @@ struct Data {
 struct _DelayBox {
   GtkBox parent_instance;
 
-  AdwToastOverlay* toast_overlay;
-
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -162,7 +160,6 @@ void delay_box_class_init(DelayBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::delay_ui);
 
-  gtk_widget_class_bind_template_child(widget_class, DelayBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, DelayBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, DelayBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, DelayBox, input_level_left);

--- a/src/delay_ui.cpp
+++ b/src/delay_ui.cpp
@@ -75,7 +75,7 @@ void setup(DelayBox* self, std::shared_ptr<Delay> delay, const std::string& sche
 
   delay->set_post_messages(true);
 
-  self->data->connections.push_back(delay->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(delay->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -86,7 +86,7 @@ void setup(DelayBox* self, std::shared_ptr<Delay> delay, const std::string& sche
     });
   }));
 
-  self->data->connections.push_back(delay->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(delay->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/delay_ui.cpp
+++ b/src/delay_ui.cpp
@@ -37,6 +37,8 @@ struct Data {
 struct _DelayBox {
   GtkBox parent_instance;
 
+  AdwToastOverlay* toast_overlay;
+
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -160,6 +162,7 @@ void delay_box_class_init(DelayBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::delay_ui);
 
+  gtk_widget_class_bind_template_child(widget_class, DelayBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, DelayBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, DelayBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, DelayBox, input_level_left);

--- a/src/echo_canceller.cpp
+++ b/src/echo_canceller.cpp
@@ -23,7 +23,13 @@ EchoCanceller::EchoCanceller(const std::string& tag,
                              const std::string& schema,
                              const std::string& schema_path,
                              PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::echo_canceller, schema, schema_path, pipe_manager, true) {
+    : PluginBase(tag,
+                 tags::plugin_name::echo_canceller,
+                 tags::plugin_package::speex,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 true) {
   gconnections.push_back(g_signal_connect(settings, "changed::frame-size",
                                           G_CALLBACK(+[](GSettings* settings, char* key, gpointer user_data) {
                                             auto self = static_cast<EchoCanceller*>(user_data);

--- a/src/echo_canceller_ui.cpp
+++ b/src/echo_canceller_ui.cpp
@@ -71,7 +71,7 @@ void setup(EchoCancellerBox* self, std::shared_ptr<EchoCanceller> echo_canceller
 
   echo_canceller->set_post_messages(true);
 
-  self->data->connections.push_back(echo_canceller->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(echo_canceller->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -82,7 +82,7 @@ void setup(EchoCancellerBox* self, std::shared_ptr<EchoCanceller> echo_canceller
     });
   }));
 
-  self->data->connections.push_back(echo_canceller->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(echo_canceller->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/effects_box.cpp
+++ b/src/effects_box.cpp
@@ -317,7 +317,7 @@ void setup(EffectsBox* self, app::Application* application, PipelineType pipelin
   // output level
 
   self->data->connections.push_back(
-      self->data->effects_base->output_level->output_level.connect([=](const float& left, const float& right) {
+      self->data->effects_base->output_level->output_level.connect([=](const float left, const float right) {
         self->data->global_output_level_left = left;
         self->data->global_output_level_right = right;
 

--- a/src/equalizer.cpp
+++ b/src/equalizer.cpp
@@ -28,11 +28,13 @@ Equalizer::Equalizer(const std::string& tag,
                      const std::string& schema_channel_left_path,
                      const std::string& schema_channel_right_path,
                      PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::equalizer, schema, schema_path, pipe_manager),
+    : PluginBase(tag, tags::plugin_name::equalizer, tags::plugin_package::lsp, schema, schema_path, pipe_manager),
       settings_left(g_settings_new_with_path(schema_channel.c_str(), schema_channel_left_path.c_str())),
       settings_right(g_settings_new_with_path(schema_channel.c_str(), schema_channel_right_path.c_str())),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/para_equalizer_x32_lr")) {
-  if (!lv2_wrapper->found_plugin) {
+  package_installed = lv2_wrapper->found_plugin;
+
+  if (!package_installed) {
     util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/para_equalizer_x32_lr is not installed");
   }
 

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -473,7 +473,7 @@ void setup(EqualizerBox* self,
 
   build_all_bands(self);
 
-  self->data->connections.push_back(equalizer->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(equalizer->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -484,7 +484,7 @@ void setup(EqualizerBox* self,
     });
   }));
 
-  self->data->connections.push_back(equalizer->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(equalizer->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -58,8 +58,6 @@ struct Data {
 struct _EqualizerBox {
   GtkBox parent_instance;
 
-  GtkOverlay* overlay;
-
   AdwToastOverlay* toast_overlay;
 
   GtkScale *input_gain, *output_gain;
@@ -584,9 +582,7 @@ void equalizer_box_class_init(EqualizerBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::equalizer_ui);
 
-  gtk_widget_class_bind_template_child(widget_class, EqualizerBox, overlay);
   gtk_widget_class_bind_template_child(widget_class, EqualizerBox, toast_overlay);
-
   gtk_widget_class_bind_template_child(widget_class, EqualizerBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, EqualizerBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, EqualizerBox, input_level_left);

--- a/src/exciter.cpp
+++ b/src/exciter.cpp
@@ -23,9 +23,11 @@ Exciter::Exciter(const std::string& tag,
                  const std::string& schema,
                  const std::string& schema_path,
                  PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::exciter, schema, schema_path, pipe_manager),
+    : PluginBase(tag, tags::plugin_name::exciter, tags::plugin_package::calf, schema, schema_path, pipe_manager),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://calf.sourceforge.net/plugins/Exciter")) {
-  if (!lv2_wrapper->found_plugin) {
+  package_installed = lv2_wrapper->found_plugin;
+
+  if (!package_installed) {
     util::debug(log_tag + "http://calf.sourceforge.net/plugins/Exciter is not installed");
   }
 

--- a/src/exciter_ui.cpp
+++ b/src/exciter_ui.cpp
@@ -81,7 +81,7 @@ void setup(ExciterBox* self, std::shared_ptr<Exciter> exciter, const std::string
 
   exciter->set_post_messages(true);
 
-  self->data->connections.push_back(exciter->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(exciter->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -92,7 +92,7 @@ void setup(ExciterBox* self, std::shared_ptr<Exciter> exciter, const std::string
     });
   }));
 
-  self->data->connections.push_back(exciter->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(exciter->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/exciter_ui.cpp
+++ b/src/exciter_ui.cpp
@@ -37,6 +37,8 @@ struct Data {
 struct _ExciterBox {
   GtkBox parent_instance;
 
+  AdwToastOverlay* toast_overlay;
+
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -176,6 +178,7 @@ void exciter_box_class_init(ExciterBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::exciter_ui);
 
+  gtk_widget_class_bind_template_child(widget_class, ExciterBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, ExciterBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, ExciterBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, ExciterBox, input_level_left);

--- a/src/exciter_ui.cpp
+++ b/src/exciter_ui.cpp
@@ -103,7 +103,7 @@ void setup(ExciterBox* self, std::shared_ptr<Exciter> exciter, const std::string
     });
   }));
 
-  self->data->connections.push_back(exciter->harmonics.connect([=](const double& value) {
+  self->data->connections.push_back(exciter->harmonics.connect([=](const double value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/exciter_ui.cpp
+++ b/src/exciter_ui.cpp
@@ -37,8 +37,6 @@ struct Data {
 struct _ExciterBox {
   GtkBox parent_instance;
 
-  AdwToastOverlay* toast_overlay;
-
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -178,7 +176,6 @@ void exciter_box_class_init(ExciterBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::exciter_ui);
 
-  gtk_widget_class_bind_template_child(widget_class, ExciterBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, ExciterBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, ExciterBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, ExciterBox, input_level_left);

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -23,9 +23,11 @@ Filter::Filter(const std::string& tag,
                const std::string& schema,
                const std::string& schema_path,
                PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::filter, schema, schema_path, pipe_manager),
+    : PluginBase(tag, tags::plugin_name::filter, tags::plugin_package::calf, schema, schema_path, pipe_manager),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://calf.sourceforge.net/plugins/Filter")) {
-  if (!lv2_wrapper->found_plugin) {
+  package_installed = lv2_wrapper->found_plugin;
+
+  if (!package_installed) {
     util::debug(log_tag + "http://calf.sourceforge.net/plugins/Filter is not installed");
   }
 

--- a/src/filter_ui.cpp
+++ b/src/filter_ui.cpp
@@ -37,6 +37,8 @@ struct Data {
 struct _FilterBox {
   GtkBox parent_instance;
 
+  AdwToastOverlay* toast_overlay;
+
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -153,6 +155,7 @@ void filter_box_class_init(FilterBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::filter_ui);
 
+  gtk_widget_class_bind_template_child(widget_class, FilterBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, FilterBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, FilterBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, FilterBox, input_level_left);

--- a/src/filter_ui.cpp
+++ b/src/filter_ui.cpp
@@ -37,8 +37,6 @@ struct Data {
 struct _FilterBox {
   GtkBox parent_instance;
 
-  AdwToastOverlay* toast_overlay;
-
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -155,7 +153,6 @@ void filter_box_class_init(FilterBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::filter_ui);
 
-  gtk_widget_class_bind_template_child(widget_class, FilterBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, FilterBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, FilterBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, FilterBox, input_level_left);

--- a/src/filter_ui.cpp
+++ b/src/filter_ui.cpp
@@ -75,7 +75,7 @@ void setup(FilterBox* self, std::shared_ptr<Filter> filter, const std::string& s
 
   filter->set_post_messages(true);
 
-  self->data->connections.push_back(filter->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(filter->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -86,7 +86,7 @@ void setup(FilterBox* self, std::shared_ptr<Filter> filter, const std::string& s
     });
   }));
 
-  self->data->connections.push_back(filter->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(filter->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -189,8 +189,9 @@ void Gate::process(std::span<float>& left_in,
 
       // Normalize the current gain reduction amount as a percentage,
       // where 0% is no gating, and 100% is a fully closed gate.
-      const float max_reduction_port_value = lv2_wrapper->get_control_port_value("gr");
-      // no reduction defaults to 1.0F; aka db_to_linear(0 dB);
+      // Double needed for the level bar widget.
+      const double max_reduction_port_value = static_cast<double>(lv2_wrapper->get_control_port_value("gr"));
+      // no reduction defaults to 1.0; aka db_to_linear(0 dB);
       gating_port_value = util::normalize(reduction_port_value, max_reduction_port_value);
 
       attack_zone_start.emit(attack_zone_start_port_value);

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -20,9 +20,11 @@
 #include "gate.hpp"
 
 Gate::Gate(const std::string& tag, const std::string& schema, const std::string& schema_path, PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::gate, schema, schema_path, pipe_manager, true),
+    : PluginBase(tag, tags::plugin_name::gate, tags::plugin_package::lsp, schema, schema_path, pipe_manager, true),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/sc_gate_stereo")) {
-  if (!lv2_wrapper->found_plugin) {
+  package_installed = lv2_wrapper->found_plugin;
+
+  if (!package_installed) {
     util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/sc_gate_stereo is not installed");
   }
 

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -37,8 +37,6 @@ struct Data {
 struct _GateBox {
   GtkBox parent_instance;
 
-  AdwToastOverlay* toast_overlay;
-
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -430,7 +428,6 @@ void gate_box_class_init(GateBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::gate_ui);
 
-  gtk_widget_class_bind_template_child(widget_class, GateBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, GateBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, GateBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, GateBox, input_level_left);

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -157,7 +157,7 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
     });
   }));
 
-  self->data->connections.push_back(gate->attack_zone_start.connect([=](const double& value) {
+  self->data->connections.push_back(gate->attack_zone_start.connect([=](const float value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -172,7 +172,7 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
     });
   }));
 
-  self->data->connections.push_back(gate->attack_threshold.connect([=](const double& value) {
+  self->data->connections.push_back(gate->attack_threshold.connect([=](const float value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -187,7 +187,7 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
     });
   }));
 
-  self->data->connections.push_back(gate->release_zone_start.connect([=](const double& value) {
+  self->data->connections.push_back(gate->release_zone_start.connect([=](const float value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -202,7 +202,7 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
     });
   }));
 
-  self->data->connections.push_back(gate->release_threshold.connect([=](const double& value) {
+  self->data->connections.push_back(gate->release_threshold.connect([=](const float value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -217,7 +217,7 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
     });
   }));
 
-  self->data->connections.push_back(gate->reduction.connect([=](const double& value) {
+  self->data->connections.push_back(gate->reduction.connect([=](const float value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -232,7 +232,7 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
     });
   }));
 
-  self->data->connections.push_back(gate->gating.connect([=](const double& value) {
+  self->data->connections.push_back(gate->gating.connect([=](const double value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -246,7 +246,7 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
     });
   }));
 
-  self->data->connections.push_back(gate->envelope.connect([=](const double& value) {
+  self->data->connections.push_back(gate->envelope.connect([=](const float value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -260,7 +260,7 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
     });
   }));
 
-  self->data->connections.push_back(gate->sidechain.connect([=](const double& value) {
+  self->data->connections.push_back(gate->sidechain.connect([=](const float value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -274,7 +274,7 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
     });
   }));
 
-  self->data->connections.push_back(gate->curve.connect([=](const double& value) {
+  self->data->connections.push_back(gate->curve.connect([=](const float value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -37,6 +37,8 @@ struct Data {
 struct _GateBox {
   GtkBox parent_instance;
 
+  AdwToastOverlay* toast_overlay;
+
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -428,6 +430,7 @@ void gate_box_class_init(GateBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::gate_ui);
 
+  gtk_widget_class_bind_template_child(widget_class, GateBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, GateBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, GateBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, GateBox, input_level_left);

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -135,7 +135,7 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
     }
   }
 
-  self->data->connections.push_back(gate->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(gate->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -146,7 +146,7 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
     });
   }));
 
-  self->data->connections.push_back(gate->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(gate->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/limiter.cpp
+++ b/src/limiter.cpp
@@ -23,9 +23,11 @@ Limiter::Limiter(const std::string& tag,
                  const std::string& schema,
                  const std::string& schema_path,
                  PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::limiter, schema, schema_path, pipe_manager, true),
+    : PluginBase(tag, tags::plugin_name::limiter, tags::plugin_package::lsp, schema, schema_path, pipe_manager, true),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/sc_limiter_stereo")) {
-  if (!lv2_wrapper->found_plugin) {
+  package_installed = lv2_wrapper->found_plugin;
+
+  if (!package_installed) {
     util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/sc_limiter_stereo is not installed");
   }
 

--- a/src/limiter_ui.cpp
+++ b/src/limiter_ui.cpp
@@ -143,7 +143,7 @@ void setup(LimiterBox* self, std::shared_ptr<Limiter> limiter, const std::string
     });
   }));
 
-  self->data->connections.push_back(limiter->gain_left.connect([=](const double& value) {
+  self->data->connections.push_back(limiter->gain_left.connect([=](const float value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -157,7 +157,7 @@ void setup(LimiterBox* self, std::shared_ptr<Limiter> limiter, const std::string
     });
   }));
 
-  self->data->connections.push_back(limiter->gain_right.connect([=](const double& value) {
+  self->data->connections.push_back(limiter->gain_right.connect([=](const float value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -171,7 +171,7 @@ void setup(LimiterBox* self, std::shared_ptr<Limiter> limiter, const std::string
     });
   }));
 
-  self->data->connections.push_back(limiter->sidechain_left.connect([=](const double& value) {
+  self->data->connections.push_back(limiter->sidechain_left.connect([=](const float value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -185,7 +185,7 @@ void setup(LimiterBox* self, std::shared_ptr<Limiter> limiter, const std::string
     });
   }));
 
-  self->data->connections.push_back(limiter->sidechain_right.connect([=](const double& value) {
+  self->data->connections.push_back(limiter->sidechain_right.connect([=](const float value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/limiter_ui.cpp
+++ b/src/limiter_ui.cpp
@@ -37,6 +37,8 @@ struct Data {
 struct _LimiterBox {
   GtkBox parent_instance;
 
+  AdwToastOverlay* toast_overlay;
+
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -321,6 +323,7 @@ void limiter_box_class_init(LimiterBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::limiter_ui);
 
+  gtk_widget_class_bind_template_child(widget_class, LimiterBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, LimiterBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, LimiterBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, LimiterBox, input_level_left);

--- a/src/limiter_ui.cpp
+++ b/src/limiter_ui.cpp
@@ -121,7 +121,7 @@ void setup(LimiterBox* self, std::shared_ptr<Limiter> limiter, const std::string
     }
   }
 
-  self->data->connections.push_back(limiter->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(limiter->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -132,7 +132,7 @@ void setup(LimiterBox* self, std::shared_ptr<Limiter> limiter, const std::string
     });
   }));
 
-  self->data->connections.push_back(limiter->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(limiter->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/limiter_ui.cpp
+++ b/src/limiter_ui.cpp
@@ -37,8 +37,6 @@ struct Data {
 struct _LimiterBox {
   GtkBox parent_instance;
 
-  AdwToastOverlay* toast_overlay;
-
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -323,7 +321,6 @@ void limiter_box_class_init(LimiterBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::limiter_ui);
 
-  gtk_widget_class_bind_template_child(widget_class, LimiterBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, LimiterBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, LimiterBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, LimiterBox, input_level_left);

--- a/src/loudness.cpp
+++ b/src/loudness.cpp
@@ -23,9 +23,11 @@ Loudness::Loudness(const std::string& tag,
                    const std::string& schema,
                    const std::string& schema_path,
                    PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::loudness, schema, schema_path, pipe_manager),
+    : PluginBase(tag, tags::plugin_name::loudness, tags::plugin_package::lsp, schema, schema_path, pipe_manager),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/loud_comp_stereo")) {
-  if (!lv2_wrapper->found_plugin) {
+  package_installed = lv2_wrapper->found_plugin;
+
+  if (!package_installed) {
     util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/loud_comp_stereo is not installed");
   }
 

--- a/src/loudness_ui.cpp
+++ b/src/loudness_ui.cpp
@@ -37,6 +37,8 @@ struct Data {
 struct _LoudnessBox {
   GtkBox parent_instance;
 
+  AdwToastOverlay* toast_overlay;
+
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -156,6 +158,7 @@ void loudness_box_class_init(LoudnessBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::loudness_ui);
 
+  gtk_widget_class_bind_template_child(widget_class, LoudnessBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, LoudnessBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, LoudnessBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, LoudnessBox, input_level_left);

--- a/src/loudness_ui.cpp
+++ b/src/loudness_ui.cpp
@@ -77,7 +77,7 @@ void setup(LoudnessBox* self, std::shared_ptr<Loudness> loudness, const std::str
 
   loudness->set_post_messages(true);
 
-  self->data->connections.push_back(loudness->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(loudness->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -88,7 +88,7 @@ void setup(LoudnessBox* self, std::shared_ptr<Loudness> loudness, const std::str
     });
   }));
 
-  self->data->connections.push_back(loudness->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(loudness->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/loudness_ui.cpp
+++ b/src/loudness_ui.cpp
@@ -37,8 +37,6 @@ struct Data {
 struct _LoudnessBox {
   GtkBox parent_instance;
 
-  AdwToastOverlay* toast_overlay;
-
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -158,7 +156,6 @@ void loudness_box_class_init(LoudnessBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::loudness_ui);
 
-  gtk_widget_class_bind_template_child(widget_class, LoudnessBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, LoudnessBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, LoudnessBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, LoudnessBox, input_level_left);

--- a/src/maximizer.cpp
+++ b/src/maximizer.cpp
@@ -23,9 +23,11 @@ Maximizer::Maximizer(const std::string& tag,
                      const std::string& schema,
                      const std::string& schema_path,
                      PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::maximizer, schema, schema_path, pipe_manager),
+    : PluginBase(tag, tags::plugin_name::maximizer, tags::plugin_package::zam, schema, schema_path, pipe_manager),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("urn:zamaudio:ZaMaximX2")) {
-  if (!lv2_wrapper->found_plugin) {
+  package_installed = lv2_wrapper->found_plugin;
+
+  if (!package_installed) {
     util::debug(log_tag + "urn:zamaudio:ZaMaximX2 is not installed");
   }
 

--- a/src/maximizer_ui.cpp
+++ b/src/maximizer_ui.cpp
@@ -99,7 +99,7 @@ void setup(MaximizerBox* self, std::shared_ptr<Maximizer> maximizer, const std::
     });
   }));
 
-  self->data->connections.push_back(maximizer->reduction.connect([=](const double& value) {
+  self->data->connections.push_back(maximizer->reduction.connect([=](const double value) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/maximizer_ui.cpp
+++ b/src/maximizer_ui.cpp
@@ -37,8 +37,6 @@ struct Data {
 struct _MaximizerBox {
   GtkBox parent_instance;
 
-  AdwToastOverlay* toast_overlay;
-
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -168,7 +166,6 @@ void maximizer_box_class_init(MaximizerBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::maximizer_ui);
 
-  gtk_widget_class_bind_template_child(widget_class, MaximizerBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, MaximizerBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, MaximizerBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, MaximizerBox, input_level_left);

--- a/src/maximizer_ui.cpp
+++ b/src/maximizer_ui.cpp
@@ -37,6 +37,8 @@ struct Data {
 struct _MaximizerBox {
   GtkBox parent_instance;
 
+  AdwToastOverlay* toast_overlay;
+
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -166,6 +168,7 @@ void maximizer_box_class_init(MaximizerBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::maximizer_ui);
 
+  gtk_widget_class_bind_template_child(widget_class, MaximizerBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, MaximizerBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, MaximizerBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, MaximizerBox, input_level_left);

--- a/src/maximizer_ui.cpp
+++ b/src/maximizer_ui.cpp
@@ -77,7 +77,7 @@ void setup(MaximizerBox* self, std::shared_ptr<Maximizer> maximizer, const std::
 
   maximizer->set_post_messages(true);
 
-  self->data->connections.push_back(maximizer->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(maximizer->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -88,7 +88,7 @@ void setup(MaximizerBox* self, std::shared_ptr<Maximizer> maximizer, const std::
     });
   }));
 
-  self->data->connections.push_back(maximizer->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(maximizer->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/multiband_compressor.cpp
+++ b/src/multiband_compressor.cpp
@@ -23,9 +23,17 @@ MultibandCompressor::MultibandCompressor(const std::string& tag,
                                          const std::string& schema,
                                          const std::string& schema_path,
                                          PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::multiband_compressor, schema, schema_path, pipe_manager, true),
+    : PluginBase(tag,
+                 tags::plugin_name::multiband_compressor,
+                 tags::plugin_package::lsp,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 true),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/sc_mb_compressor_stereo")) {
-  if (!lv2_wrapper->found_plugin) {
+  package_installed = lv2_wrapper->found_plugin;
+
+  if (!package_installed) {
     util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/sc_mb_compressor_stereo is not installed");
   }
 

--- a/src/multiband_compressor_ui.cpp
+++ b/src/multiband_compressor_ui.cpp
@@ -172,7 +172,7 @@ void setup(MultibandCompressorBox* self,
   }
 
   self->data->connections.push_back(
-      multiband_compressor->input_level.connect([=](const float& left, const float& right) {
+      multiband_compressor->input_level.connect([=](const float left, const float right) {
         util::idle_add([=]() {
           if (get_ignore_filter_idle_add(serial)) {
             return;
@@ -184,7 +184,7 @@ void setup(MultibandCompressorBox* self,
       }));
 
   self->data->connections.push_back(
-      multiband_compressor->output_level.connect([=](const float& left, const float& right) {
+      multiband_compressor->output_level.connect([=](const float left, const float right) {
         util::idle_add([=]() {
           if (get_ignore_filter_idle_add(serial)) {
             return;

--- a/src/multiband_compressor_ui.cpp
+++ b/src/multiband_compressor_ui.cpp
@@ -41,8 +41,6 @@ struct Data {
 struct _MultibandCompressorBox {
   GtkBox parent_instance;
 
-  AdwToastOverlay* toast_overlay;
-
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -171,17 +169,16 @@ void setup(MultibandCompressorBox* self,
     }
   }
 
-  self->data->connections.push_back(
-      multiband_compressor->input_level.connect([=](const float left, const float right) {
-        util::idle_add([=]() {
-          if (get_ignore_filter_idle_add(serial)) {
-            return;
-          }
+  self->data->connections.push_back(multiband_compressor->input_level.connect([=](const float left, const float right) {
+    util::idle_add([=]() {
+      if (get_ignore_filter_idle_add(serial)) {
+        return;
+      }
 
-          update_level(self->input_level_left, self->input_level_left_label, self->input_level_right,
-                       self->input_level_right_label, left, right);
-        });
-      }));
+      update_level(self->input_level_left, self->input_level_left_label, self->input_level_right,
+                   self->input_level_right_label, left, right);
+    });
+  }));
 
   self->data->connections.push_back(
       multiband_compressor->output_level.connect([=](const float left, const float right) {
@@ -347,7 +344,6 @@ void multiband_compressor_box_class_init(MultibandCompressorBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::multiband_compressor_ui);
 
-  gtk_widget_class_bind_template_child(widget_class, MultibandCompressorBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, MultibandCompressorBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, MultibandCompressorBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, MultibandCompressorBox, input_level_left);

--- a/src/multiband_compressor_ui.cpp
+++ b/src/multiband_compressor_ui.cpp
@@ -196,7 +196,7 @@ void setup(MultibandCompressorBox* self,
       }));
 
   self->data->connections.push_back(
-      multiband_compressor->frequency_range.connect([=](const std::array<float, n_bands>& values) {
+      multiband_compressor->frequency_range.connect([=](const std::array<float, n_bands> values) {
         util::idle_add([=]() {
           if (get_ignore_filter_idle_add(serial)) {
             return;
@@ -209,7 +209,7 @@ void setup(MultibandCompressorBox* self,
       }));
 
   self->data->connections.push_back(
-      multiband_compressor->envelope.connect([=](const std::array<float, n_bands>& values) {
+      multiband_compressor->envelope.connect([=](const std::array<float, n_bands> values) {
         util::idle_add([=]() {
           if (get_ignore_filter_idle_add(serial)) {
             return;
@@ -221,7 +221,7 @@ void setup(MultibandCompressorBox* self,
         });
       }));
 
-  self->data->connections.push_back(multiband_compressor->curve.connect([=](const std::array<float, n_bands>& values) {
+  self->data->connections.push_back(multiband_compressor->curve.connect([=](const std::array<float, n_bands> values) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -234,7 +234,7 @@ void setup(MultibandCompressorBox* self,
   }));
 
   self->data->connections.push_back(
-      multiband_compressor->reduction.connect([=](const std::array<float, n_bands>& values) {
+      multiband_compressor->reduction.connect([=](const std::array<float, n_bands> values) {
         util::idle_add([=]() {
           if (get_ignore_filter_idle_add(serial)) {
             return;

--- a/src/multiband_compressor_ui.cpp
+++ b/src/multiband_compressor_ui.cpp
@@ -41,6 +41,8 @@ struct Data {
 struct _MultibandCompressorBox {
   GtkBox parent_instance;
 
+  AdwToastOverlay* toast_overlay;
+
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -345,6 +347,7 @@ void multiband_compressor_box_class_init(MultibandCompressorBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::multiband_compressor_ui);
 
+  gtk_widget_class_bind_template_child(widget_class, MultibandCompressorBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, MultibandCompressorBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, MultibandCompressorBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, MultibandCompressorBox, input_level_left);

--- a/src/multiband_gate.cpp
+++ b/src/multiband_gate.cpp
@@ -23,9 +23,17 @@ MultibandGate::MultibandGate(const std::string& tag,
                              const std::string& schema,
                              const std::string& schema_path,
                              PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::multiband_gate, schema, schema_path, pipe_manager, true),
+    : PluginBase(tag,
+                 tags::plugin_name::multiband_gate,
+                 tags::plugin_package::lsp,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 true),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/sc_mb_gate_stereo")) {
-  if (!lv2_wrapper->found_plugin) {
+  package_installed = lv2_wrapper->found_plugin;
+
+  if (!package_installed) {
     util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/sc_mb_gate_stereo is not installed");
   }
 

--- a/src/multiband_gate.cpp
+++ b/src/multiband_gate.cpp
@@ -155,8 +155,10 @@ void MultibandGate::process(std::span<float>& left_in,
 
         // Normalize the current band gain reduction amount as a percentage,
         // where 0% is no gating, and 100% is a fully closed gate.
-        const float band_max_reduction_port_value = lv2_wrapper->get_control_port_value("gr_" + nstr);
-        // no reduction defaults to 1.0F; aka db_to_linear(0 dB)
+        // Double needed for the level bar widget.
+        const double band_max_reduction_port_value =
+            static_cast<double>(lv2_wrapper->get_control_port_value("gr_" + nstr));
+        // no reduction defaults to 1.0; aka db_to_linear(0 dB)
         gating_array.at(n) = util::normalize(reduction_port_array.at(n), band_max_reduction_port_value);
       }
 

--- a/src/multiband_gate_ui.cpp
+++ b/src/multiband_gate_ui.cpp
@@ -41,8 +41,6 @@ struct Data {
 struct _MultibandGateBox {
   GtkBox parent_instance;
 
-  AdwToastOverlay* toast_overlay;
-
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -355,7 +353,6 @@ void multiband_gate_box_class_init(MultibandGateBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::multiband_gate_ui);
 
-  gtk_widget_class_bind_template_child(widget_class, MultibandGateBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, MultibandGateBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, MultibandGateBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, MultibandGateBox, input_level_left);

--- a/src/multiband_gate_ui.cpp
+++ b/src/multiband_gate_ui.cpp
@@ -194,7 +194,7 @@ void setup(MultibandGateBox* self,
   }));
 
   self->data->connections.push_back(
-      multiband_gate->frequency_range.connect([=](const std::array<float, n_bands>& values) {
+      multiband_gate->frequency_range.connect([=](const std::array<float, n_bands> values) {
         util::idle_add([=]() {
           if (get_ignore_filter_idle_add(serial)) {
             return;
@@ -206,7 +206,7 @@ void setup(MultibandGateBox* self,
         });
       }));
 
-  self->data->connections.push_back(multiband_gate->envelope.connect([=](const std::array<float, n_bands>& values) {
+  self->data->connections.push_back(multiband_gate->envelope.connect([=](const std::array<float, n_bands> values) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -218,7 +218,7 @@ void setup(MultibandGateBox* self,
     });
   }));
 
-  self->data->connections.push_back(multiband_gate->curve.connect([=](const std::array<float, n_bands>& values) {
+  self->data->connections.push_back(multiband_gate->curve.connect([=](const std::array<float, n_bands> values) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -230,7 +230,7 @@ void setup(MultibandGateBox* self,
     });
   }));
 
-  self->data->connections.push_back(multiband_gate->reduction.connect([=](const std::array<float, n_bands>& values) {
+  self->data->connections.push_back(multiband_gate->reduction.connect([=](const std::array<float, n_bands> values) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -242,7 +242,7 @@ void setup(MultibandGateBox* self,
     });
   }));
 
-  self->data->connections.push_back(multiband_gate->gating.connect([=](const std::array<float, n_bands>& values) {
+  self->data->connections.push_back(multiband_gate->gating.connect([=](const std::array<double, n_bands> values) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/multiband_gate_ui.cpp
+++ b/src/multiband_gate_ui.cpp
@@ -41,6 +41,8 @@ struct Data {
 struct _MultibandGateBox {
   GtkBox parent_instance;
 
+  AdwToastOverlay* toast_overlay;
+
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -353,6 +355,7 @@ void multiband_gate_box_class_init(MultibandGateBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::multiband_gate_ui);
 
+  gtk_widget_class_bind_template_child(widget_class, MultibandGateBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, MultibandGateBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, MultibandGateBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, MultibandGateBox, input_level_left);

--- a/src/multiband_gate_ui.cpp
+++ b/src/multiband_gate_ui.cpp
@@ -171,7 +171,7 @@ void setup(MultibandGateBox* self,
     }
   }
 
-  self->data->connections.push_back(multiband_gate->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(multiband_gate->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -182,7 +182,7 @@ void setup(MultibandGateBox* self,
     });
   }));
 
-  self->data->connections.push_back(multiband_gate->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(multiband_gate->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/output_level.cpp
+++ b/src/output_level.cpp
@@ -23,7 +23,7 @@ OutputLevel::OutputLevel(const std::string& tag,
                          const std::string& schema,
                          const std::string& schema_path,
                          PipeManager* pipe_manager)
-    : PluginBase(tag, "output_level", schema, schema_path, pipe_manager) {}
+    : PluginBase(tag, "output_level", tags::plugin_package::ee, schema, schema_path, pipe_manager) {}
 
 OutputLevel::~OutputLevel() {
   if (connected_to_pw) {

--- a/src/pitch.cpp
+++ b/src/pitch.cpp
@@ -23,7 +23,7 @@ Pitch::Pitch(const std::string& tag,
              const std::string& schema,
              const std::string& schema_path,
              PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::pitch, schema, schema_path, pipe_manager) {
+    : PluginBase(tag, tags::plugin_name::pitch, tags::plugin_package::rubber, schema, schema_path, pipe_manager) {
   mode = parse_mode_key(util::gsettings_get_string(settings, "mode"));
   formant = parse_formant_key(util::gsettings_get_string(settings, "formant"));
   transients = parse_transients_key(util::gsettings_get_string(settings, "transients"));

--- a/src/pitch_ui.cpp
+++ b/src/pitch_ui.cpp
@@ -73,7 +73,7 @@ void setup(PitchBox* self, std::shared_ptr<Pitch> pitch, const std::string& sche
 
   pitch->set_post_messages(true);
 
-  self->data->connections.push_back(pitch->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(pitch->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -84,7 +84,7 @@ void setup(PitchBox* self, std::shared_ptr<Pitch> pitch, const std::string& sche
     });
   }));
 
-  self->data->connections.push_back(pitch->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(pitch->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/plugin_base.cpp
+++ b/src/plugin_base.cpp
@@ -105,12 +105,14 @@ const struct pw_filter_events filter_events = {.process = on_process};
 
 PluginBase::PluginBase(std::string tag,
                        std::string plugin_name,
+                       std::string package,
                        const std::string& schema,
                        const std::string& schema_path,
                        PipeManager* pipe_manager,
                        const bool& enable_probe)
     : log_tag(std::move(tag)),
       name(std::move(plugin_name)),
+      package(std::move(package)),
       enable_probe(enable_probe),
       settings(g_settings_new_with_path(schema.c_str(), schema_path.c_str())),
       pm(pipe_manager) {

--- a/src/plugins_box.cpp
+++ b/src/plugins_box.cpp
@@ -107,89 +107,120 @@ void add_plugins_to_stack(PluginsBox* self) {
 
   for (const auto& name : plugins_list) {
     if (name.starts_with(tags::plugin_name::autogain)) {
-      auto* box = ui::autogain_box::create();
-
       auto plugin_ptr = effects_base->get_plugin_instance<AutoGain>(name);
+
+      auto* box = ui::autogain_box::create();
 
       ui::autogain_box::setup(box, plugin_ptr, self->data->schema_path + name + "/");
 
       gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::bass_enhancer)) {
-      auto* box = ui::bass_enhancer_box::create();
-
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::bass_enhancer)) {
       auto plugin_ptr = effects_base->get_plugin_instance<BassEnhancer>(name);
 
-      auto path = name + "/";
+      if (plugin_ptr->package_installed) {
+        auto path = name + "/";
 
-      path.erase(std::remove(path.begin(), path.end(), '_'), path.end());
+        path.erase(std::remove(path.begin(), path.end(), '_'), path.end());
 
-      ui::bass_enhancer_box::setup(box, plugin_ptr, self->data->schema_path + path);
+        auto plugin_box = ui::bass_enhancer_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::bass_loudness)) {
-      auto* box = ui::bass_loudness_box::create();
+        ui::bass_enhancer_box::setup(plugin_box, plugin_ptr, self->data->schema_path + path);
 
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::bass_loudness)) {
       auto plugin_ptr = effects_base->get_plugin_instance<BassLoudness>(name);
 
-      auto path = name + "/";
+      if (plugin_ptr->package_installed) {
+        auto path = name + "/";
 
-      path.erase(std::remove(path.begin(), path.end(), '_'), path.end());
+        path.erase(std::remove(path.begin(), path.end(), '_'), path.end());
 
-      ui::bass_loudness_box::setup(box, plugin_ptr, self->data->schema_path + path);
+        auto plugin_box = ui::bass_loudness_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::compressor)) {
-      auto* box = ui::compressor_box::create();
+        ui::bass_loudness_box::setup(plugin_box, plugin_ptr, self->data->schema_path + path);
 
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::compressor)) {
       auto plugin_ptr = effects_base->get_plugin_instance<Compressor>(name);
 
-      ui::compressor_box::setup(box, plugin_ptr, self->data->schema_path + name + "/", self->data->application->pm);
+      if (plugin_ptr->package_installed) {
+        auto plugin_box = ui::compressor_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
+        ui::compressor_box::setup(plugin_box, plugin_ptr, self->data->schema_path + name + "/",
+                                  self->data->application->pm);
+
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
     } else if (name.starts_with(tags::plugin_name::convolver)) {
-      auto* box = ui::convolver_box::create();
-
       auto plugin_ptr = effects_base->get_plugin_instance<Convolver>(name);
+
+      auto* box = ui::convolver_box::create();
 
       ui::convolver_box::setup(box, plugin_ptr, self->data->schema_path + name + "/", self->data->application);
 
       gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
     } else if (name.starts_with(tags::plugin_name::crossfeed)) {
-      auto* box = ui::crossfeed_box::create();
-
       auto plugin_ptr = effects_base->get_plugin_instance<Crossfeed>(name);
+
+      auto* box = ui::crossfeed_box::create();
 
       ui::crossfeed_box::setup(box, plugin_ptr, self->data->schema_path + name + "/");
 
       gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
     } else if (name.starts_with(tags::plugin_name::crystalizer)) {
-      auto* box = ui::crystalizer_box::create();
-
       auto plugin_ptr = effects_base->get_plugin_instance<Crystalizer>(name);
+
+      auto* box = ui::crystalizer_box::create();
 
       ui::crystalizer_box::setup(box, plugin_ptr, self->data->schema_path + name + "/");
 
       gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::deesser)) {
-      auto* box = ui::deesser_box::create();
-
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::deesser)) {
       auto plugin_ptr = effects_base->get_plugin_instance<Deesser>(name);
 
-      ui::deesser_box::setup(box, plugin_ptr, self->data->schema_path + name + "/");
+      if (plugin_ptr->package_installed) {
+        auto plugin_box = ui::deesser_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::delay)) {
-      auto* box = ui::delay_box::create();
+        ui::deesser_box::setup(plugin_box, plugin_ptr, self->data->schema_path + name + "/");
 
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::delay)) {
       auto plugin_ptr = effects_base->get_plugin_instance<Delay>(name);
 
-      ui::delay_box::setup(box, plugin_ptr, self->data->schema_path + name + "/");
+      if (plugin_ptr->package_installed) {
+        auto plugin_box = ui::delay_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
+        ui::delay_box::setup(plugin_box, plugin_ptr, self->data->schema_path + name + "/");
+
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
     } else if (name.starts_with(tags::plugin_name::echo_canceller)) {
-      auto* box = ui::echo_canceller_box::create();
-
       auto plugin_ptr = effects_base->get_plugin_instance<EchoCanceller>(name);
+
+      auto* box = ui::echo_canceller_box::create();
 
       auto path = name + "/";
 
@@ -198,122 +229,197 @@ void add_plugins_to_stack(PluginsBox* self) {
       ui::echo_canceller_box::setup(box, plugin_ptr, self->data->schema_path + path);
 
       gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::exciter)) {
-      auto* box = ui::exciter_box::create();
-
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::exciter)) {
       auto plugin_ptr = effects_base->get_plugin_instance<Exciter>(name);
 
-      ui::exciter_box::setup(box, plugin_ptr, self->data->schema_path + name + "/");
+      if (plugin_ptr->package_installed) {
+        auto plugin_box = ui::exciter_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::equalizer)) {
-      auto* box = ui::equalizer_box::create();
+        ui::exciter_box::setup(plugin_box, plugin_ptr, self->data->schema_path + name + "/");
 
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::equalizer)) {
       auto plugin_ptr = effects_base->get_plugin_instance<Equalizer>(name);
 
-      ui::equalizer_box::setup(box, plugin_ptr, self->data->schema_path + name + "/", self->data->application);
+      if (plugin_ptr->package_installed) {
+        auto plugin_box = ui::equalizer_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::filter)) {
-      auto* box = ui::filter_box::create();
+        ui::equalizer_box::setup(plugin_box, plugin_ptr, self->data->schema_path + name + "/", self->data->application);
 
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::filter)) {
       auto plugin_ptr = effects_base->get_plugin_instance<Filter>(name);
 
-      ui::filter_box::setup(box, plugin_ptr, self->data->schema_path + name + "/");
+      if (plugin_ptr->package_installed) {
+        auto plugin_box = ui::filter_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::gate)) {
-      auto* box = ui::gate_box::create();
+        ui::filter_box::setup(plugin_box, plugin_ptr, self->data->schema_path + name + "/");
 
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::gate)) {
       auto plugin_ptr = effects_base->get_plugin_instance<Gate>(name);
 
-      ui::gate_box::setup(box, plugin_ptr, self->data->schema_path + name + "/", self->data->application->pm);
+      if (plugin_ptr->package_installed) {
+        auto plugin_box = ui::gate_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::limiter)) {
-      auto* box = ui::limiter_box::create();
+        ui::gate_box::setup(plugin_box, plugin_ptr, self->data->schema_path + name + "/", self->data->application->pm);
 
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::limiter)) {
       auto plugin_ptr = effects_base->get_plugin_instance<Limiter>(name);
 
-      ui::limiter_box::setup(box, plugin_ptr, self->data->schema_path + name + "/", self->data->application->pm);
+      if (plugin_ptr->package_installed) {
+        auto plugin_box = ui::limiter_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::loudness)) {
-      auto* box = ui::loudness_box::create();
+        ui::limiter_box::setup(plugin_box, plugin_ptr, self->data->schema_path + name + "/",
+                               self->data->application->pm);
 
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::loudness)) {
       auto plugin_ptr = effects_base->get_plugin_instance<Loudness>(name);
 
-      ui::loudness_box::setup(box, plugin_ptr, self->data->schema_path + name + "/");
+      if (plugin_ptr->package_installed) {
+        auto plugin_box = ui::loudness_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::maximizer)) {
-      auto* box = ui::maximizer_box::create();
+        ui::loudness_box::setup(plugin_box, plugin_ptr, self->data->schema_path + name + "/");
 
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::maximizer)) {
       auto plugin_ptr = effects_base->get_plugin_instance<Maximizer>(name);
 
-      ui::maximizer_box::setup(box, plugin_ptr, self->data->schema_path + name + "/");
+      if (plugin_ptr->package_installed) {
+        auto plugin_box = ui::maximizer_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::multiband_compressor)) {
-      auto* box = ui::multiband_compressor_box::create();
+        ui::maximizer_box::setup(plugin_box, plugin_ptr, self->data->schema_path + name + "/");
 
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::multiband_compressor)) {
       auto plugin_ptr = effects_base->get_plugin_instance<MultibandCompressor>(name);
 
-      auto path = name + "/";
+      if (plugin_ptr->package_installed) {
+        auto path = name + "/";
 
-      path.erase(std::remove(path.begin(), path.end(), '_'), path.end());
+        path.erase(std::remove(path.begin(), path.end(), '_'), path.end());
 
-      ui::multiband_compressor_box::setup(box, plugin_ptr, self->data->schema_path + path, self->data->application->pm);
+        auto plugin_box = ui::multiband_compressor_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::multiband_gate)) {
-      auto* box = ui::multiband_gate_box::create();
+        ui::multiband_compressor_box::setup(plugin_box, plugin_ptr, self->data->schema_path + path,
+                                            self->data->application->pm);
 
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::multiband_gate)) {
       auto plugin_ptr = effects_base->get_plugin_instance<MultibandGate>(name);
 
-      auto path = name + "/";
+      if (plugin_ptr->package_installed) {
+        auto path = name + "/";
 
-      path.erase(std::remove(path.begin(), path.end(), '_'), path.end());
+        path.erase(std::remove(path.begin(), path.end(), '_'), path.end());
 
-      ui::multiband_gate_box::setup(box, plugin_ptr, self->data->schema_path + path, self->data->application->pm);
+        auto plugin_box = ui::multiband_gate_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
+        ui::multiband_gate_box::setup(plugin_box, plugin_ptr, self->data->schema_path + path,
+                                      self->data->application->pm);
+
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
     } else if (name.starts_with(tags::plugin_name::pitch)) {
-      auto* box = ui::pitch_box::create();
-
       auto plugin_ptr = effects_base->get_plugin_instance<Pitch>(name);
+
+      auto* box = ui::pitch_box::create();
 
       ui::pitch_box::setup(box, plugin_ptr, self->data->schema_path + name + "/");
 
       gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::reverb)) {
-      auto* box = ui::reverb_box::create();
-
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::reverb)) {
       auto plugin_ptr = effects_base->get_plugin_instance<Reverb>(name);
 
-      ui::reverb_box::setup(box, plugin_ptr, self->data->schema_path + name + "/");
+      if (plugin_ptr->package_installed) {
+        auto plugin_box = ui::reverb_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::rnnoise)) {
-      auto* box = ui::rnnoise_box::create();
+        ui::reverb_box::setup(plugin_box, plugin_ptr, self->data->schema_path + name + "/");
 
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::rnnoise)) {
       auto plugin_ptr = effects_base->get_plugin_instance<RNNoise>(name);
 
-      ui::rnnoise_box::setup(box, plugin_ptr, self->data->schema_path + name + "/", self->data->application);
+      if (plugin_ptr->package_installed) {
+        auto plugin_box = ui::rnnoise_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
-    } else if (name.starts_with(tags::plugin_name::stereo_tools)) {
-      auto* box = ui::stereo_tools_box::create();
+        ui::rnnoise_box::setup(plugin_box, plugin_ptr, self->data->schema_path + name + "/", self->data->application);
 
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
+    } else if (GtkWidget* box = nullptr; name.starts_with(tags::plugin_name::stereo_tools)) {
       auto plugin_ptr = effects_base->get_plugin_instance<StereoTools>(name);
 
-      auto path = name + "/";
+      if (plugin_ptr->package_installed) {
+        auto path = name + "/";
 
-      path.erase(std::remove(path.begin(), path.end(), '_'), path.end());
+        path.erase(std::remove(path.begin(), path.end(), '_'), path.end());
 
-      ui::stereo_tools_box::setup(box, plugin_ptr, self->data->schema_path + path);
+        auto plugin_box = ui::stereo_tools_box::create();
 
-      gtk_stack_add_named(self->stack, GTK_WIDGET(box), name.c_str());
+        ui::stereo_tools_box::setup(plugin_box, plugin_ptr, self->data->schema_path + path);
+
+        box = GTK_WIDGET(plugin_box);
+      } else {
+        box = ui::missing_plugin_box(plugin_ptr->name, plugin_ptr->package);
+      }
+
+      gtk_stack_add_named(self->stack, box, name.c_str());
     }
   }
 

--- a/src/reverb.cpp
+++ b/src/reverb.cpp
@@ -23,9 +23,11 @@ Reverb::Reverb(const std::string& tag,
                const std::string& schema,
                const std::string& schema_path,
                PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::reverb, schema, schema_path, pipe_manager),
+    : PluginBase(tag, tags::plugin_name::reverb, tags::plugin_package::calf, schema, schema_path, pipe_manager),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://calf.sourceforge.net/plugins/Reverb")) {
-  if (!lv2_wrapper->found_plugin) {
+  package_installed = lv2_wrapper->found_plugin;
+
+  if (!package_installed) {
     util::debug(log_tag + "http://calf.sourceforge.net/plugins/Reverb is not installed");
   }
 

--- a/src/reverb_ui.cpp
+++ b/src/reverb_ui.cpp
@@ -147,7 +147,7 @@ void setup(ReverbBox* self, std::shared_ptr<Reverb> reverb, const std::string& s
 
   reverb->set_post_messages(true);
 
-  self->data->connections.push_back(reverb->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(reverb->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -158,7 +158,7 @@ void setup(ReverbBox* self, std::shared_ptr<Reverb> reverb, const std::string& s
     });
   }));
 
-  self->data->connections.push_back(reverb->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(reverb->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/reverb_ui.cpp
+++ b/src/reverb_ui.cpp
@@ -37,6 +37,8 @@ struct Data {
 struct _ReverbBox {
   GtkBox parent_instance;
 
+  AdwToastOverlay* toast_overlay;
+
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -239,6 +241,7 @@ void reverb_box_class_init(ReverbBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::reverb_ui);
 
+  gtk_widget_class_bind_template_child(widget_class, ReverbBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, ReverbBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, ReverbBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, ReverbBox, input_level_left);

--- a/src/reverb_ui.cpp
+++ b/src/reverb_ui.cpp
@@ -37,8 +37,6 @@ struct Data {
 struct _ReverbBox {
   GtkBox parent_instance;
 
-  AdwToastOverlay* toast_overlay;
-
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -241,7 +239,6 @@ void reverb_box_class_init(ReverbBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::reverb_ui);
 
-  gtk_widget_class_bind_template_child(widget_class, ReverbBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, ReverbBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, ReverbBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, ReverbBox, input_level_left);

--- a/src/rnnoise.cpp
+++ b/src/rnnoise.cpp
@@ -23,7 +23,9 @@ RNNoise::RNNoise(const std::string& tag,
                  const std::string& schema,
                  const std::string& schema_path,
                  PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::rnnoise, schema, schema_path, pipe_manager), data_L(0), data_R(0) {
+    : PluginBase(tag, tags::plugin_name::rnnoise, tags::plugin_package::rnnoise, schema, schema_path, pipe_manager),
+      data_L(0),
+      data_R(0) {
   data_L.reserve(blocksize);
   data_R.reserve(blocksize);
 

--- a/src/rnnoise_ui.cpp
+++ b/src/rnnoise_ui.cpp
@@ -204,7 +204,7 @@ void setup(RNNoiseBox* self,
     });
   }));
 
-  self->data->connections.push_back(rnnoise->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(rnnoise->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -215,7 +215,7 @@ void setup(RNNoiseBox* self,
     });
   }));
 
-  self->data->connections.push_back(rnnoise->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(rnnoise->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -23,7 +23,7 @@ Spectrum::Spectrum(const std::string& tag,
                    const std::string& schema,
                    const std::string& schema_path,
                    PipeManager* pipe_manager)
-    : PluginBase(tag, "spectrum", schema, schema_path, pipe_manager) {
+    : PluginBase(tag, "spectrum", tags::plugin_package::ee, schema, schema_path, pipe_manager) {
   real_input.resize(n_bands);
   output.resize(n_bands / 2U + 1U);
 

--- a/src/stereo_tools.cpp
+++ b/src/stereo_tools.cpp
@@ -23,9 +23,11 @@ StereoTools::StereoTools(const std::string& tag,
                          const std::string& schema,
                          const std::string& schema_path,
                          PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::stereo_tools, schema, schema_path, pipe_manager),
+    : PluginBase(tag, tags::plugin_name::stereo_tools, tags::plugin_package::calf, schema, schema_path, pipe_manager),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://calf.sourceforge.net/plugins/StereoTools")) {
-  if (!lv2_wrapper->found_plugin) {
+  package_installed = lv2_wrapper->found_plugin;
+
+  if (!package_installed) {
     util::debug(log_tag + "http://calf.sourceforge.net/plugins/StereoTools is not installed");
   }
 

--- a/src/stereo_tools_ui.cpp
+++ b/src/stereo_tools_ui.cpp
@@ -37,8 +37,6 @@ struct Data {
 struct _StereoToolsBox {
   GtkBox parent_instance;
 
-  AdwToastOverlay* toast_overlay;
-
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -184,7 +182,6 @@ void stereo_tools_box_class_init(StereoToolsBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::stereo_tools_ui);
 
-  gtk_widget_class_bind_template_child(widget_class, StereoToolsBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, StereoToolsBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, StereoToolsBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, StereoToolsBox, input_level_left);

--- a/src/stereo_tools_ui.cpp
+++ b/src/stereo_tools_ui.cpp
@@ -77,7 +77,7 @@ void setup(StereoToolsBox* self, std::shared_ptr<StereoTools> stereo_tools, cons
 
   stereo_tools->set_post_messages(true);
 
-  self->data->connections.push_back(stereo_tools->input_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(stereo_tools->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;
@@ -88,7 +88,7 @@ void setup(StereoToolsBox* self, std::shared_ptr<StereoTools> stereo_tools, cons
     });
   }));
 
-  self->data->connections.push_back(stereo_tools->output_level.connect([=](const float& left, const float& right) {
+  self->data->connections.push_back(stereo_tools->output_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {
       if (get_ignore_filter_idle_add(serial)) {
         return;

--- a/src/stereo_tools_ui.cpp
+++ b/src/stereo_tools_ui.cpp
@@ -37,6 +37,8 @@ struct Data {
 struct _StereoToolsBox {
   GtkBox parent_instance;
 
+  AdwToastOverlay* toast_overlay;
+
   GtkScale *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
@@ -182,6 +184,7 @@ void stereo_tools_box_class_init(StereoToolsBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::stereo_tools_ui);
 
+  gtk_widget_class_bind_template_child(widget_class, StereoToolsBox, toast_overlay);
   gtk_widget_class_bind_template_child(widget_class, StereoToolsBox, input_gain);
   gtk_widget_class_bind_template_child(widget_class, StereoToolsBox, output_gain);
   gtk_widget_class_bind_template_child(widget_class, StereoToolsBox, input_level_left);

--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -65,11 +65,36 @@ void show_fixed_toast(AdwToastOverlay* toast_overlay, const std::string& text, c
   show_autohiding_toast(toast_overlay, text, 0U, priority);
 }
 
-void missing_plugin_toast(AdwToastOverlay* toast_overlay, const std::string& package) {
-  // For translators: {} is replaced by the name of the package containing the plugin.
-  const auto format = fmt::runtime(_("{} Is Not Installed On The System. This Effect Is Not Available."));
+auto missing_plugin_box(const std::string& name, const std::string& package) -> GtkWidget* {
+  // For translators: {} is replaced by the effect name.
+  const auto format_title = fmt::runtime(_("{} Is Not Installed On The System"));
 
-  show_autohiding_toast(toast_overlay, fmt::format(format, package), 10U);
+  // For translators: {} is replaced by the package name.
+  const auto format_descr = fmt::runtime(_("{} Not Available"));
+
+  std::string translated_name;
+
+  try {
+    translated_name = tags::plugin_name::get_translated().at(name);
+  } catch (...) {
+  }
+
+  auto* status_page = adw_status_page_new();
+
+  adw_status_page_set_icon_name(ADW_STATUS_PAGE(status_page), "emblem-music-symbolic");
+  adw_status_page_set_title(ADW_STATUS_PAGE(status_page), fmt::format(format_title, translated_name).c_str());
+  adw_status_page_set_description(ADW_STATUS_PAGE(status_page), fmt::format(format_descr, package).c_str());
+
+  auto* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 6);
+
+  gtk_widget_set_margin_start(box, 6);
+  gtk_widget_set_margin_end(box, 6);
+  gtk_widget_set_margin_bottom(box, 6);
+  gtk_widget_set_margin_top(box, 6);
+
+  gtk_box_append(GTK_BOX(box), status_page);
+
+  return box;
 }
 
 void show_simple_message_dialog(GtkWidget* parent, const std::string& title, const std::string& descr) {

--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -190,28 +190,22 @@ void update_level(GtkLevelBar* w_left,
     return;
   }
 
-  if (auto db_value = util::db_to_linear(left); left >= -99.0) {
-    if (db_value < 0.0) {
-      db_value = 0.0;
-    } else if (db_value > 1.0) {
-      db_value = 1.0;
-    }
+  if (left >= -99.0) {
+    // Level bar widget needs double value
+    const auto linear_value = static_cast<double>(std::clamp(util::db_to_linear(left), 0.0F, 1.0F));
 
-    gtk_level_bar_set_value(w_left, db_value);
+    gtk_level_bar_set_value(w_left, linear_value);
     gtk_label_set_text(w_left_label, fmt::format("{0:.0f}", left).c_str());
   } else {
     gtk_level_bar_set_value(w_left, 0.0);
     gtk_label_set_text(w_left_label, "-99");
   }
 
-  if (auto db_value = util::db_to_linear(right); right >= -99.0) {
-    if (db_value < 0.0) {
-      db_value = 0.0;
-    } else if (db_value > 1.0) {
-      db_value = 1.0;
-    }
+  if (right >= -99.0) {
+    // Level bar widget needs double value
+    const auto linear_value = static_cast<double>(std::clamp(util::db_to_linear(right), 0.0F, 1.0F));
 
-    gtk_level_bar_set_value(w_right, db_value);
+    gtk_level_bar_set_value(w_right, linear_value);
     gtk_label_set_text(w_right_label, fmt::format("{0:.0f}", right).c_str());
   } else {
     gtk_level_bar_set_value(w_right, 0.0);

--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -65,6 +65,13 @@ void show_fixed_toast(AdwToastOverlay* toast_overlay, const std::string& text, c
   show_autohiding_toast(toast_overlay, text, 0U, priority);
 }
 
+void missing_plugin_toast(AdwToastOverlay* toast_overlay, const std::string& package) {
+  // For translators: {} is replaced by the name of the package containing the plugin.
+  const auto format = fmt::runtime(_("{} Is Not Installed On The System. This Effect Is Not Available."));
+
+  show_autohiding_toast(toast_overlay, fmt::format(format, package), 10U);
+}
+
 void show_simple_message_dialog(GtkWidget* parent, const std::string& title, const std::string& descr) {
   if (parent == nullptr) {
     return;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -53,7 +53,7 @@ void print_thread_id() {
   std::cout << "thread id: " << std::this_thread::get_id() << std::endl;
 }
 
-auto normalize(const float& x, const float& max, const float& min) -> float {
+auto normalize(const double& x, const double& max, const double& min) -> double {
   // Mainly used for gating level bar in gate effects
   return (x - min) / (max - min);
 }


### PR DESCRIPTION
What I did:
- an adw toast overlay widget has been added to all plugins ui xml: this may not be needed, but maybe in the future we would have the need to show toasts inside the plugin interface (at moment only equalizer and rnnoise show them for errors related to loading apo/model profiles), so having them already there could be useful.
- a new tag has been added for package names and the plugins are initialized with one of them so a plugin knows its name along with the package providing its functionality: this could be useful to get or emit the package name if it's missing.
- a new `package_installed` bool flag is added to plugin base so we pass it the value of `lv2_wrapper->found_plugin` and it knows if the package is installed.
- plugins which rely on external packages have a `AdwToastOverlay* toast_overlay`: this could be removed if it's not used for showing missing plugin alerts.
- a new ui helper has been added to format the text for missing plugin and showing it inside the provided toast: as I said in the ticked, to format the translated text having the package name string I had to use `fmt::runtime()` bacause gettext() does not provide a constexpr string.

Now we have to decide what to do.
* Showing an adw toast overlay with the text saying to the user that the selected plugin is not available because the specified package is not installed (I failed doing this emitting the signal when `lv2_wrapper->found_plugin` was checked false, so I removed that signal). We may find another way getting the `package_installed` bool value from user interface.
* @wwmm As you suggested, not creating the plugin controls, but showing another box with the message that the package is not available (in this case the ui helper for missing plugin toast has to be removed, and also the `AdwToastOverlay* toast_overlay` could be removed from ui c++ files, but it can remain in the xml builder for future use).

Don't know what is better. We have to decide also taking in consideration the multiple plugin instances for the future.

I also made some fixes regarding the signals which had non references binding to references or different types leading to implicit conversions, but this is not related to the missing plugin alerts.

Edit:
Fixes #1730