### PR TITLE
Fix missing plugin alerts

### DIFF
--- a/include/gate.hpp
+++ b/include/gate.hpp
@@ -57,7 +57,7 @@ class Gate : public PluginBase {
   float curve_port_value = 0.0F;
   float envelope_port_value = 0.0F;
   float latency_port_value = 0.0F;
-  double gating_port_value = 0.0F;
+  double gating_port_value = 0.0;
 
  private:
   uint latency_n_frames = 0U;

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -142,7 +142,7 @@ auto to_string(const T& num, const std::string def = "0") -> std::string {
   // number of base-10 digits that are necessary to uniquely represent all distinct
   // values of the type T (meaningful only for real numbers) +
   // room for other characters such as "+-e,."
-  const size_t max = std::numeric_limits<T>::digits10 + std::numeric_limits<T>::max_digits10 + 10u;
+  const size_t max = std::numeric_limits<T>::digits10 + std::numeric_limits<T>::max_digits10 + 10U;
 
   std::array<char, max> buffer;
 

--- a/src/autogain.cpp
+++ b/src/autogain.cpp
@@ -155,7 +155,7 @@ void AutoGain::set_maximum_history(const int& seconds) {
 
   // The value given to ebur128_set_max_history must be in milliseconds
 
-  ebur128_set_max_history(ebur_state, static_cast<ulong>(seconds) * 1000ul);
+  ebur128_set_max_history(ebur_state, static_cast<ulong>(seconds) * 1000UL);
 }
 
 void AutoGain::setup() {

--- a/src/deesser.cpp
+++ b/src/deesser.cpp
@@ -23,7 +23,7 @@ Deesser::Deesser(const std::string& tag,
                  const std::string& schema,
                  const std::string& schema_path,
                  PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::deesser, tags::plugin_package::lsp, schema, schema_path, pipe_manager),
+    : PluginBase(tag, tags::plugin_name::deesser, tags::plugin_package::calf, schema, schema_path, pipe_manager),
       lv2_wrapper(std::make_unique<lv2::Lv2Wrapper>("http://calf.sourceforge.net/plugins/Deesser")) {
   package_installed = lv2_wrapper->found_plugin;
 

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -29,9 +29,9 @@ enum Channel { left, right };
 
 struct APO_Band {
   std::string type;
-  float freq = 1000.0f;
-  float gain = 0.0f;
-  float quality = (1.0f / std::numbers::sqrt2_v<float>);
+  float freq = 1000.0F;
+  float gain = 0.0F;
+  float quality = (1.0F / std::numbers::sqrt2_v<float>);
 };
 
 std::unordered_map<std::string, std::string> const FilterTypeMap = {
@@ -239,29 +239,29 @@ auto parse_apo_config_line(const std::string& line, struct APO_Band& filter) -> 
     parse_apo_gain(line, filter);
 
     if (!parse_apo_quality(line, filter)) {
-      filter.quality = 2.0f / 3.0f;
+      filter.quality = 2.0F / 3.0F;
     }
   } else if (filter_type == "LS 6DB") {
-    filter.freq = filter.freq * 2.0f / 3.0f;
-    filter.quality = std::numbers::sqrt2_v<float> / 3.0f;
+    filter.freq = filter.freq * 2.0F / 3.0F;
+    filter.quality = std::numbers::sqrt2_v<float> / 3.0F;
 
     parse_apo_gain(line, filter);
   } else if (filter_type == "LS 12DB") {
-    filter.freq = filter.freq * 3.0f / 2.0f;
+    filter.freq = filter.freq * 3.0F / 2.0F;
 
     parse_apo_gain(line, filter);
   } else if (filter_type == "HS 6DB") {
-    filter.freq = filter.freq / (1.0f / std::numbers::sqrt2_v<float>);
-    filter.quality = std::numbers::sqrt2_v<float> / 3.0f;
+    filter.freq = filter.freq / (1.0F / std::numbers::sqrt2_v<float>);
+    filter.quality = std::numbers::sqrt2_v<float> / 3.0F;
 
     parse_apo_gain(line, filter);
   } else if (filter_type == "HS 12DB") {
-    filter.freq = filter.freq * (1.0f / std::numbers::sqrt2_v<float>);
+    filter.freq = filter.freq * (1.0F / std::numbers::sqrt2_v<float>);
 
     parse_apo_gain(line, filter);
   } else if (filter_type == "NO") {
     if (!parse_apo_quality(line, filter)) {
-      filter.quality = 100.0f / 3.0f;
+      filter.quality = 100.0F / 3.0F;
     }
   } else if (filter_type == "AP") {
     parse_apo_quality(line, filter);

--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -1060,7 +1060,7 @@ void on_registry_global(void* data,
         return;
       }
 
-      uint64_t serial = 0;
+      uint64_t serial = 0U;
 
       if (!spa_dict_get_num(props, PW_KEY_OBJECT_SERIAL, serial)) {
         util::warning(
@@ -1151,7 +1151,7 @@ void on_registry_global(void* data,
   }
 
   if (g_strcmp0(type, PW_TYPE_INTERFACE_Link) == 0) {
-    uint64_t serial = 0;
+    uint64_t serial = 0U;
 
     if (!spa_dict_get_num(props, PW_KEY_OBJECT_SERIAL, serial)) {
       util::warning(
@@ -1192,7 +1192,7 @@ void on_registry_global(void* data,
   }
 
   if (g_strcmp0(type, PW_TYPE_INTERFACE_Port) == 0) {
-    uint64_t serial = 0;
+    uint64_t serial = 0U;
 
     if (!spa_dict_get_num(props, PW_KEY_OBJECT_SERIAL, serial)) {
       util::warning(
@@ -1225,7 +1225,7 @@ void on_registry_global(void* data,
   }
 
   if (g_strcmp0(type, PW_TYPE_INTERFACE_Module) == 0) {
-    uint64_t serial = 0;
+    uint64_t serial = 0U;
 
     if (!spa_dict_get_num(props, PW_KEY_OBJECT_SERIAL, serial)) {
       util::warning(
@@ -1256,7 +1256,7 @@ void on_registry_global(void* data,
   }
 
   if (g_strcmp0(type, PW_TYPE_INTERFACE_Client) == 0) {
-    uint64_t serial = 0;
+    uint64_t serial = 0U;
 
     if (!spa_dict_get_num(props, PW_KEY_OBJECT_SERIAL, serial)) {
       util::warning(
@@ -1315,7 +1315,7 @@ void on_registry_global(void* data,
       const std::string media_class = key_media_class;
 
       if (media_class == tags::pipewire::media_class::device) {
-        uint64_t serial = 0;
+        uint64_t serial = 0U;
 
         if (!spa_dict_get_num(props, PW_KEY_OBJECT_SERIAL, serial)) {
           util::warning(

--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -66,31 +66,31 @@ void show_fixed_toast(AdwToastOverlay* toast_overlay, const std::string& text, c
 }
 
 auto missing_plugin_box(const std::string& name, const std::string& package) -> GtkWidget* {
-  // For translators: {} is replaced by the effect name.
-  const auto format_title = fmt::runtime(_("{} Is Not Installed On The System"));
-
-  // For translators: {} is replaced by the package name.
-  const auto format_descr = fmt::runtime(_("{} Not Available"));
-
-  std::string translated_name;
-
-  try {
-    translated_name = tags::plugin_name::get_translated().at(name);
-  } catch (...) {
-  }
-
-  auto* status_page = adw_status_page_new();
-
-  adw_status_page_set_icon_name(ADW_STATUS_PAGE(status_page), "emblem-music-symbolic");
-  adw_status_page_set_title(ADW_STATUS_PAGE(status_page), fmt::format(format_title, translated_name).c_str());
-  adw_status_page_set_description(ADW_STATUS_PAGE(status_page), fmt::format(format_descr, package).c_str());
-
   auto* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 6);
 
   gtk_widget_set_margin_start(box, 6);
   gtk_widget_set_margin_end(box, 6);
   gtk_widget_set_margin_bottom(box, 6);
   gtk_widget_set_margin_top(box, 6);
+  gtk_widget_set_valign(box, GTK_ALIGN_CENTER);
+
+  auto* status_page = adw_status_page_new();
+
+  try {
+    // For translators: {} is replaced by the effect name.
+    const auto format_title = fmt::runtime(_("{} Not Available"));
+
+    // For translators: {} is replaced by the package name.
+    const auto format_descr = fmt::runtime(_("{} Is Not Installed On The System"));
+
+    const std::string translated_name = tags::plugin_name::get_translated().at(name);
+
+    adw_status_page_set_title(ADW_STATUS_PAGE(status_page), fmt::format(format_title, translated_name).c_str());
+    adw_status_page_set_description(ADW_STATUS_PAGE(status_page), fmt::format(format_descr, package).c_str());
+  } catch (...) {
+  }
+
+  adw_status_page_set_icon_name(ADW_STATUS_PAGE(status_page), "emblem-music-symbolic");
 
   gtk_box_append(GTK_BOX(box), status_page);
 


### PR DESCRIPTION
Don't know why, but I inverted the format strings. Now it's fixed. No need to update the templates, the strings were only inverted.

Fixed also the vertical alignment of the status page.

Moved the string format operations inside the try-catch statement so if a translator gives a wrong format (evaluated at runtime), the exception is caught and only the icon is shown.