### PR TITLE
Portal cleanup

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -43,7 +43,7 @@ localedir = join_paths(prefix, get_option('localedir'))
 include_dir = include_directories('include')
 config_h_dir = include_directories('.')
 
-libportal = dependency('libportal', include_type: 'system', required: false)
+libportal = dependency('libportal-gtk4', include_type: 'system', required: false)
 
 status = []
 

--- a/src/libportal.cpp
+++ b/src/libportal.cpp
@@ -49,11 +49,12 @@ void on_request_background_called(GObject* source, GAsyncResult* result, gpointe
     util::warning(reason);
     util::warning(explanation);
 
-    // map to either the preferences window or the top level window
+    // TODO find a bettery way of getting the preferences window
+    // it shouldn't be possible to open the preferences window without the top level window open,
+    // so the index 1 should correspond with the preferences window
     auto* window_levels = gtk_window_get_toplevels();
-
     GtkWidget* dialog = gtk_message_dialog_new(
-      (GtkWindow*)g_list_model_get_item(window_levels, 0), GTK_DIALOG_MODAL, GTK_MESSAGE_WARNING, GTK_BUTTONS_CLOSE,
+      GTK_WINDOW(g_list_model_get_item(window_levels, 1)), GTK_DIALOG_MODAL, GTK_MESSAGE_WARNING, GTK_BUTTONS_CLOSE,
       "Unable to get background access: %s", reason.c_str());
 
     gtk_message_dialog_format_secondary_text(
@@ -201,7 +202,7 @@ void init(GtkSwitch* g_enable_autostart, GtkSwitch* g_shutdown_on_window_close) 
   }
   else {
     util::debug(std::string(
-        "not doing portal sanity check, autostart switch is disabled and shutdown switch is enabled so no background portal access is needed"));
+        "not doing portal sanity check, autostart switch should be disabled and shutdown switch should be enabled so no background portal access is needed"));
   }
 }
 

--- a/src/libportal.cpp
+++ b/src/libportal.cpp
@@ -25,10 +25,10 @@ void on_request_background_called(GObject* source, GAsyncResult* result, gpointe
   // libportal check if portal request worked
 
   if (xdp_portal_request_background_finish(portal, result, &error) == 0) {
-    util::warning(std::string("portal: a background request failed: ") + ((error) ? error->message : "unknown reason"));
-    util::warning(std::string("portal: background portal access has likely been denied"));
+    util::warning(std::string("a background request failed: ") + ((error) ? error->message : "unknown reason"));
+    util::warning(std::string("background portal access has likely been denied"));
     util::warning(
-        "portal: to let EasyEffects ask for the portal again, run flatpak permission-reset "
+        "to let EasyEffects ask for the portal again, run flatpak permission-reset "
         "com.github.wwmm.easyeffects");
 
     // this seems wrong but also works?
@@ -49,7 +49,7 @@ void on_request_background_called(GObject* source, GAsyncResult* result, gpointe
         static_cast<bool>(gtk_switch_get_state(enable_autostart))) {
       reset_autostart = true;
 
-      util::warning(std::string("portal: setting autostart state and switch to false"));
+      util::warning(std::string("setting autostart state and switch to false"));
 
       gtk_switch_set_state(enable_autostart, 0);
       gtk_switch_set_active(enable_autostart, 0);
@@ -59,7 +59,7 @@ void on_request_background_called(GObject* source, GAsyncResult* result, gpointe
         !static_cast<bool>(gtk_switch_get_state(shutdown_on_window_close))) {
       reset_shutdown = true;
 
-      util::warning(std::string("portal: setting shutdown on window close state and switch to true"));
+      util::warning(std::string("setting shutdown on window close state and switch to true"));
 
       gtk_switch_set_state(shutdown_on_window_close, 1);
       gtk_switch_set_active(shutdown_on_window_close, 1);
@@ -78,7 +78,7 @@ void on_request_background_called(GObject* source, GAsyncResult* result, gpointe
   reset_autostart = false;
   reset_shutdown = false;
 
-  util::debug("portal: a background request successfully completed");
+  util::debug("a background request successfully completed");
 }
 
 // generic portal update function
@@ -107,7 +107,7 @@ void update_background_portal(const bool& state) {
 
 auto on_enable_autostart(GtkSwitch* obj, gboolean state, gpointer user_data) -> gboolean {
   if (!reset_autostart) {
-    util::debug("portal: requesting autostart file since autostart is enabled");
+    util::debug("requesting autostart file since autostart is enabled");
 
     update_background_portal(state != 0);
   }
@@ -121,19 +121,19 @@ auto on_shutdown_on_window_close_called(GtkSwitch* btn, gboolean state, gpointer
 
     if (enable_autostart) {
       const auto* msg = (state == 0)
-                            ? "portal: requesting both background access and autostart file since autostart is enabled"
-                            : "portal: requesting autostart access since autostart enabled";
+                            ? "requesting both background access and autostart file since autostart is enabled"
+                            : "requesting autostart access since autostart enabled";
 
       util::debug(msg);
 
       update_background_portal(true);
     } else {
       if (state == 0) {
-        util::debug("portal: requesting only background access, not creating autostart file");
+        util::debug("requesting only background access, not creating autostart file");
 
         update_background_portal(false);
       } else {
-        util::debug("portal: not requesting any access since enabling shutdown on window close");
+        util::debug("not requesting any access since enabling shutdown on window close");
 
         gtk_switch_set_state(shutdown_on_window_close, gtk_switch_get_active(shutdown_on_window_close));
       }
@@ -165,16 +165,16 @@ void init(GtkSwitch* g_enable_autostart, GtkSwitch* g_shutdown_on_window_close) 
   // sanity checks in case switch(es) was somehow already set previously.
 
   if ((gtk_switch_get_active(shutdown_on_window_close) == 0) && (gtk_switch_get_active(enable_autostart) == 0)) {
-    util::debug(std::string("portal: Running portal sanity check, autostart and shutdown switches are disabled"));
+    util::debug(std::string("Running portal sanity check, autostart and shutdown switches are disabled"));
 
     update_background_portal(false);
   } else if ((gtk_switch_get_active(shutdown_on_window_close) != 0) && (gtk_switch_get_active(enable_autostart) != 0)) {
-    util::debug(std::string("portal: Running portal sanity check, autostart and shutdown switches are enabled"));
+    util::debug(std::string("Running portal sanity check, autostart and shutdown switches are enabled"));
 
     update_background_portal(true);
   } else if ((gtk_switch_get_active(shutdown_on_window_close) == 0) && (gtk_switch_get_active(enable_autostart) != 0)) {
     util::debug(std::string(
-        "portal: Running portal sanity check, autostart switch is enabled and shutdown switch is disabled"));
+        "Running portal sanity check, autostart switch is enabled and shutdown switch is disabled"));
 
     update_background_portal(true);
   }

--- a/src/preferences_general.cpp
+++ b/src/preferences_general.cpp
@@ -82,6 +82,11 @@ void dispose(GObject* object) {
 
   g_object_unref(self->settings);
 
+#ifdef USE_LIBPORTAL
+  g_settings_unbind(self->enable_autostart, "active");
+  g_settings_unbind(self->shutdown_on_window_close, "active");
+#endif
+
   util::debug("disposed");
 
   G_OBJECT_CLASS(preferences_general_parent_class)->dispose(object);

--- a/util/flatpak/easyeffects-modules.json
+++ b/util/flatpak/easyeffects-modules.json
@@ -254,8 +254,15 @@
                 {
                     "type": "git",
                     "url": "https://github.com/flatpak/libportal.git",
-                    "tag": "0.5",
-                    "commit": "467a397fd7996557f837cdc26ac07c01c62810e5"
+                    "tag": "0.6",
+                    "commit": "13df0b887a7eb7b0f9b14069561a41f62e813155",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/flatpak/libportal/releases/latest",
+                        "tag-query": ".tag_name",
+                        "version-query": "$tag | sub(\"^jq-\"; \"\")",
+                        "timestamp-query": ".published_at"
+                    }
                 }
             ]
         },


### PR DESCRIPTION
Here are some minor fixes I spotted, the only serious one was the switches not being disconnected when the preferences window was disposed. This compile flag now seems to work identically compared to the previous patch. One potential issue is existing flatpak user's autostart gsettings key will be lost since it has been moved, I am not sure if there is a good way to handle that (the gnome documentation is down so I can't even look there :D).

Note I did change some uses of `== 1` and `== 0` to be `== true` and `== false` as I thought that looked cleaner, but I don't mind if they should be changed back.