### PR TITLE
Use more human-readable node description

### DIFF
--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -1019,13 +1019,11 @@ void on_registry_global(void* data,
       if (g_strcmp0(key_media_role, "DSP") == 0) {
         if (const auto* key_media_category = spa_dict_lookup(props, PW_KEY_MEDIA_CATEGORY)) {
           if (g_strcmp0(key_media_category, "Filter") == 0) {
-            if (const auto* key_node_description = spa_dict_lookup(props, PW_KEY_NODE_DESCRIPTION)) {
-              std::string description(key_node_description);
+            if (const auto* key_node_name = spa_dict_lookup(props, PW_KEY_NODE_NAME)) {
+              std::string node_name(key_node_name);
 
-              if (description.length() > 3) {
-                if (description.substr(0, 2) == "ee_") {
-                  std::string node_name = spa_dict_lookup(props, PW_KEY_NODE_NAME);
-
+              if (node_name.length() > 3) {
+                if (node_name.substr(0, 2) == "ee_") {
                   util::debug("Filter " + node_name + " with id " + util::to_string(id) + " has been added");
                 }
               }

--- a/src/plugin_base.cpp
+++ b/src/plugin_base.cpp
@@ -142,7 +142,7 @@ PluginBase::PluginBase(std::string tag,
   pw_properties_set(props_filter, PW_KEY_APP_ID, tags::app::id);
   pw_properties_set(props_filter, PW_KEY_NODE_NAME, filter_name.c_str());
   pw_properties_set(props_filter, PW_KEY_NODE_NICK, name.c_str());
-  pw_properties_set(props_filter, PW_KEY_NODE_DESCRIPTION, filter_name.c_str());
+  pw_properties_set(props_filter, PW_KEY_NODE_DESCRIPTION, name.c_str());
   pw_properties_set(props_filter, PW_KEY_MEDIA_TYPE, "Audio");
   pw_properties_set(props_filter, PW_KEY_MEDIA_CATEGORY, "Filter");
   pw_properties_set(props_filter, PW_KEY_MEDIA_ROLE, "DSP");

--- a/src/test_signals.cpp
+++ b/src/test_signals.cpp
@@ -102,7 +102,7 @@ TestSignals::TestSignals(PipeManager* pipe_manager) : pm(pipe_manager), random_g
 
   pw_properties_set(props_filter, PW_KEY_APP_ID, tags::app::id);
   pw_properties_set(props_filter, PW_KEY_NODE_NAME, filter_name);
-  pw_properties_set(props_filter, PW_KEY_NODE_DESCRIPTION, "easyeffects_filter");
+  pw_properties_set(props_filter, PW_KEY_NODE_DESCRIPTION, "EasyEffects Filter");
   pw_properties_set(props_filter, PW_KEY_NODE_DRIVER, "true");
   pw_properties_set(props_filter, PW_KEY_MEDIA_TYPE, "Audio");
   pw_properties_set(props_filter, PW_KEY_MEDIA_CATEGORY, "Source");


### PR DESCRIPTION
We want to have more human-readable descriptions when Helvum uses them instead of the nick. [gitlab.freedesktop.org/pipewire/helvum/-/issues/38](https://gitlab.freedesktop.org/pipewire/helvum/-/issues/38)

related to #1812 

This is the first step. Maybe the descriptions can be made even more human-readable (e.g. `EasyEffects Output Level` instead of `output_level`)