### PR TITLE
build: Fix app ID name

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -73,7 +73,7 @@ app_id = 'com.github.wwmm.easyeffects@0@'.format(app_id_suffix)
 conf = configuration_data()
 
 conf.set10('IS_DEVEL_BUILD', get_option('devel'))
-conf.set_quoted('APP_NAME', 'EasyEffects' + name_suffix)
+conf.set_quoted('APP_NAME', 'Easy Effects' + name_suffix)
 
 conf.set_quoted('GETTEXT_PACKAGE', meson.project_name())
 conf.set_quoted('LOCALE_DIR', localedir)


### PR DESCRIPTION
This should be the last adjustment for the name change, the resulting app uses the right name everywhere for me.

I did see the old news entries still uses "EasyEffects" but I think that is fine since that was correct when those entries were written. 

I also thought of adding "easyeffects" to the [desktop file keywords](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html) so it can be found in case people have muscle memory to type "easyeffects", but I think it is fine.