### PR TITLE
Fix excessive whitespace on property strings

### DIFF
--- a/data/ui/application_window.ui
+++ b/data/ui/application_window.ui
@@ -59,8 +59,7 @@
 
                         <child>
                             <object class="GtkToggleButton" id="bypass_button">
-                                <property name="tooltip-text" translatable="yes">Enable/disable the
-                                    global bypass</property>
+                                <property name="tooltip-text" translatable="yes">Enable/disable the global bypass</property>
                                 <property name="halign">center</property>
                                 <property name="valign">center</property>
                                 <property name="icon-name">ee-bypass-symbolic</property>

--- a/data/ui/compressor.ui
+++ b/data/ui/compressor.ui
@@ -512,8 +512,8 @@
                                                                         <items>
                                                                             <item translatable="yes" id="Peak">Peak</item>
                                                                             <item translatable="yes" id="RMS">RMS</item>
-                                                                            <item translatable="yes" id="Low-Pass"> Low-Pass</item>
-                                                                            <item translatable="yes" id="Uniform"> Uniform</item>
+                                                                            <item translatable="yes" id="Low-Pass">Low-Pass</item>
+                                                                            <item translatable="yes" id="Uniform">Uniform</item>
                                                                         </items>
                                                                         <layout>
                                                                             <property name="column">0</property>


### PR DESCRIPTION
Without the change, the tooltip looks like this:

![image](https://user-images.githubusercontent.com/7030150/214265498-92cfe353-a85f-4af4-a265-d58ee8fe765a.png)
