### PR TITLE
Simplify toasts + Port message dialogs to libadwaita 1.2

### DIFF
--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -386,7 +386,7 @@ void on_import_apo_preset_clicked(EqualizerBox* self, GtkButton* btn) {
                        // notify error on preset loading
                        ui::show_fixed_toast(
                            self->toast_overlay,
-                           _("APO Preset Not Loaded. File Format May Be Wrong. Please Check Its Content."));
+                           _("APO Preset Not Loaded. File Format May Be Not Supported. Please Check Its Content."));
                      }
 
                      g_free(path);
@@ -563,28 +563,29 @@ void on_import_geq_preset_clicked(EqualizerBox* self, GtkButton* btn) {
 
   gtk_file_chooser_set_filter(GTK_FILE_CHOOSER(dialog), filter);
 
-  g_signal_connect(dialog, "response", G_CALLBACK(+[](GtkNativeDialog* dialog, int response, EqualizerBox* self) {
-                     if (response != GTK_RESPONSE_ACCEPT) {
-                       g_object_unref(dialog);
-                       return;
-                     }
+  g_signal_connect(
+      dialog, "response", G_CALLBACK(+[](GtkNativeDialog* dialog, int response, EqualizerBox* self) {
+        if (response != GTK_RESPONSE_ACCEPT) {
+          g_object_unref(dialog);
+          return;
+        }
 
-                     auto* chooser = GTK_FILE_CHOOSER(dialog);
-                     auto* file = gtk_file_chooser_get_file(chooser);
-                     auto* path = g_file_get_path(file);
+        auto* chooser = GTK_FILE_CHOOSER(dialog);
+        auto* file = gtk_file_chooser_get_file(chooser);
+        auto* path = g_file_get_path(file);
 
-                     if (!import_graphiceq_preset(self, path)) {
-                       // notify error on preset loading
-                       ui::show_fixed_toast(
-                           self->toast_overlay,
-                           _("GraphicEQ Preset Not Loaded. File Format May Be Wrong. Please Check Its Content."));
-                     }
+        if (!import_graphiceq_preset(self, path)) {
+          // notify error on preset loading
+          ui::show_fixed_toast(
+              self->toast_overlay,
+              _("GraphicEQ Preset Not Loaded. File Format May Be Not Supported. Please Check Its Content."));
+        }
 
-                     g_free(path);
-                     g_object_unref(file);
-                     g_object_unref(dialog);
-                   }),
-                   self);
+        g_free(path);
+        g_object_unref(file);
+        g_object_unref(dialog);
+      }),
+      self);
 
   gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(dialog), 1);
   gtk_native_dialog_show(GTK_NATIVE_DIALOG(dialog));

--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -37,24 +37,10 @@ void show_autohiding_toast(AdwToastOverlay* toast_overlay,
                            const std::string& text,
                            const uint& timeout,
                            const AdwToastPriority& priority) {
-  /* ONLY AVAILABLE FROM libAdwaita 1.2
-  // Construct a custom label because we want it
-  // to be wrapped on reduced window width
-  auto custom_title = gtk_label_new(text.c_str());
-
-  // Set wrap properties
-  gtk_label_set_wrap(GTK_LABEL(custom_title), 1);
-  gtk_label_set_wrap_mode(GTK_LABEL(custom_title), PANGO_WRAP_WORD_CHAR);
-  */
-
   // Construct AdwToast
-  auto* toast = adw_toast_new("");
-
-  // adw_toast_set_custom_title(toast, custom_title);
-  adw_toast_set_title(toast, text.c_str());
+  auto* toast = adw_toast_new(text.c_str());
 
   adw_toast_set_timeout(toast, timeout);
-
   adw_toast_set_priority(toast, priority);
 
   // Show AdwToast
@@ -102,29 +88,11 @@ void show_simple_message_dialog(GtkWidget* parent, const std::string& title, con
     return;
   }
 
-  // Modal flag prevents interaction with other windows in the same application
-  auto* dialog = gtk_message_dialog_new(GTK_WINDOW(parent),
-                                        static_cast<GtkDialogFlags>(GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL),
-                                        GTK_MESSAGE_ERROR, GTK_BUTTONS_NONE, "%s", title.c_str());
-
-  gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", descr.c_str());
-
-  // Add custom button to hint the user to press ESC to destroy the dialog.
-  // This has been introduced because multiple GTK4 dialogs shown at
-  // the same time could have issues on Wayland and the only way to
-  // close the outer one is pressing ESC, the mouse click does not work.
-  gtk_dialog_add_button(GTK_DIALOG(dialog), _("Close (Press ESC)"), 0);
-
-  // Destroy the dialog when the user responds to it
-  g_signal_connect(dialog, "response", G_CALLBACK(gtk_window_destroy), NULL);
-
-  // Keep the dialog on top of the main window, or center the dialog over the main window
-  gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(parent));
-
-  /* Version with Adw.MessageDialog available from libAdwaita 1.2
   auto* dialog = adw_message_dialog_new(GTK_WINDOW(parent), title.c_str(), descr.c_str());
 
-  adw_message_dialog_add_response(ADW_MESSAGE_DIALOG(dialog), "close", "OK"); */
+  const std::string response_id = "close";
+  adw_message_dialog_add_response(ADW_MESSAGE_DIALOG(dialog), response_id.c_str(), "Close (Press ESC)");
+  adw_message_dialog_set_default_response(ADW_MESSAGE_DIALOG(dialog), response_id.c_str());
 
   gtk_window_present(GTK_WINDOW(dialog));
 }


### PR DESCRIPTION
In the past I wanted to use the custom labels for adw toasts and adw message dialogs, but we couldn't because they were only supported for libadwaita 1.2 which was not available.

Now v1.2 is available and I tested them. I wanted custom labels for toasts because I don't like that the text is ellipsized when the toast is wider than the window. So I though we could set a custom label in wrap mode, so that the text could be wrapped, but unfortunately it's not working. When I tested, the label is coming out from the toast. I suppose it's not intended to be used like that, so we have to accept the ellipsize. So I just set the title in the constructing function.

Regarding the message dialogs, the libadwaita counterpart is perfectly working without having the need to specify modal flags and stuff like that, everything is managed by libadwaita.

I added `Close (Press ESC)` as custom label because in the past EE was showing two simultaneous dialogs when a corrupted preset was loaded at the start and they were blocking each other so the button couldn't be clicked by the mouse. They were stuck and the only way to unlock was to press ESC on the keyboard (if I don't remember wrong, that was occurring only on Wayland).

I couldn't reproduce this behavior even testing a corrupted preset loaded at startup: a single adw dialog is shown, but I generally don't trust GTK behavior so I'd say let's keep the same button label so in case it's blocking, we still suggest the user to unlock with ESC.