### PR TITLE
chore: Don't set -werror in devel mode

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -52,6 +52,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3.3.0
 
+    - name: Enable errors on warnings
+      run: | 
+        dnf install -y jq
+        jq '.modules[0]."config-opts" += ["-Dwerror=true"]' util/flatpak/com.github.wwmm.easyeffects.Devel.json
+
     - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v5
       with:
         bundle: easyeffects-flatpak-${{ needs.prepare.outputs.github_commit_desc }}.flatpak

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -39,7 +39,8 @@ pkgver() {
 
 build() {
   cd ..
-  arch-meson . build -Ddevel=true
+  # set werror to true if the CI file exists, otherwise false
+  arch-meson . build -Ddevel=true -Dwerror="$( test -f "./GITHUB_COMMIT_DESC" && echo "true" || echo "false")"
 
   ninja -C build
 }

--- a/meson.build
+++ b/meson.build
@@ -49,12 +49,10 @@ status = []
 
 if get_option('devel')
   status += [ 
-    'Using development build mode with .Devel appended to the application ID.',
-    'Also enabling -Werror.' 
+    'Using development build mode with .Devel appended to the application ID.'
   ]
   app_id_suffix = '.Devel'
   name_suffix = ' (Devel)'
-  add_project_arguments ('-Werror', language: [ 'c', 'cpp' ])
 else
   status += [ 'Using stable build mode with the standard application ID' ]
   app_id_suffix = ''


### PR DESCRIPTION
It is too annoying and unhelpful to not build in case of warnings, the important thing is just to do so in CI