### PR TITLE
chore: Update flatpak build to use master runtime temporarily

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -46,7 +46,7 @@ jobs:
       FLATPAK_BUILD_PATH: flatpak_app/files/share
     needs: prepare
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-43
+      image: bilelmoussaoui/flatpak-github-actions:gnome-nightly
       options: --privileged
     steps:
     - name: Checkout
@@ -60,7 +60,7 @@ jobs:
         jq '.modules[0]."config-opts" += ["-Dwerror=true"]' util/flatpak/com.github.wwmm.easyeffects.Devel.json > "$updated_manifest"
         mv "$updated_manifest" util/flatpak/com.github.wwmm.easyeffects.Devel.json
 
-    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v5
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v5
       with:
         bundle: easyeffects-flatpak-${{ needs.prepare.outputs.github_commit_desc }}.flatpak
         manifest-path: util/flatpak/com.github.wwmm.easyeffects.Devel.json

--- a/util/flatpak/com.github.wwmm.easyeffects.Devel.json
+++ b/util/flatpak/com.github.wwmm.easyeffects.Devel.json
@@ -1,7 +1,7 @@
 {
     "id": "com.github.wwmm.easyeffects.Devel",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "master",
     "sdk": "org.gnome.Sdk",
     "command": "easyeffects",
     "finish-args": [
@@ -10,8 +10,7 @@
         "--socket=wayland",
         "--device=dri",
         "--filesystem=xdg-run/pipewire-0:ro",
-        "--env=LV2_PATH=/app/lib/lv2:/app/extensions/Plugins/lv2",
-        "--env=LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/app/lib/pipewire-0.3/jack"
+        "--env=LV2_PATH=/app/lib/lv2:/app/extensions/Plugins/lv2"
     ],
     "cleanup": [
         "*.a",


### PR DESCRIPTION
Do this because the gnome 44 runtime is not released yet, but we need gtk 4.10.
Also remove an old hack which doesn't appear to be needed anymore