### PR TITLE
Improve development setup compile/linking speed

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -40,6 +40,7 @@ pkgver() {
 build() {
   cd ..
   # set werror to true if the CI file exists, otherwise false
+  # arch-meson sets --buildtype plain by default, so don't set -Dbuildtype=debug 
   arch-meson . build -Ddevel=true -Dwerror="$( test -f "./GITHUB_COMMIT_DESC" && echo "true" || echo "false")"
 
   ninja -C build

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -12,7 +12,7 @@ url='https://github.com/wwmm/easyeffects'
 license=('GPL3')
 depends=('libadwaita' 'pipewire-pulse' 'lilv' 'libsigc++-3.0' 'libsamplerate' 'zita-convolver' 
          'libebur128' 'rnnoise' 'rubberband' 'libbs2b' 'nlohmann-json' 'tbb' 'fmt' 'gsl' 'speexdsp' 'speex')
-makedepends=('meson' 'itstool' 'appstream-glib' 'git')
+makedepends=('meson' 'itstool' 'appstream-glib' 'git' 'mold')
 optdepends=('calf: limiter, exciter, bass enhancer and others'
             'lsp-plugins: equalizer, compressor, delay, loudness'
             'zam-plugins: maximizer'

--- a/meson.build
+++ b/meson.build
@@ -49,14 +49,18 @@ status = []
 
 if get_option('devel')
   status += [ 
-    'Using development build mode with .Devel appended to the application ID.'
+    'Using development build mode with .Devel appended to the application ID.',
+    'Also using mold linker, so make sure mold is installed on your system.'
   ]
   app_id_suffix = '.Devel'
   name_suffix = ' (Devel)'
+  # --no-as-needed temporarily necessary due to https://github.com/rui314/mold/issues/1017
+  link_args = ['-fuse-ld=mold', '-Wl,--no-as-needed']
 else
   status += [ 'Using stable build mode with the standard application ID' ]
   app_id_suffix = ''
   name_suffix = ''
+  link_args = []
 endif
 
 if get_option('enable-libportal') and libportal.found()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,6 @@
 option(
   'devel',
-  description: 'Whether to use development build mode, with .Devel appended to the application ID. For Flatpak builds, user data for development builds is stored separately from stable builds.',
+  description: 'Whether to use development build mode, with .Devel appended to the application ID. Also uses mold linker for speed, so mold must be installed. For Flatpak builds, user data for development builds is stored separately from stable builds.',
   type: 'boolean',
   value: false
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -176,5 +176,6 @@ executable(
 	easyeffects_sources,
 	include_directories : [include_dir,config_h_dir],
 	dependencies : easyeffects_deps,
-	install: true
+	install: true,
+	link_args: link_args
 )

--- a/util/flatpak/com.github.wwmm.easyeffects.Devel.json
+++ b/util/flatpak/com.github.wwmm.easyeffects.Devel.json
@@ -72,6 +72,7 @@
             "buildsystem": "meson",
             "config-opts": [
                 "-Ddevel=true",
+                "-Dbuildtype=debug",
                 "-Denable-libportal=true"
             ],
             "run-tests": true,

--- a/util/flatpak/easyeffects-modules.json
+++ b/util/flatpak/easyeffects-modules.json
@@ -296,6 +296,49 @@
                     }
                 }
             ]
+        },
+        {
+            "name": "mold",
+            "sources": [
+                {
+                    "type": "archive",
+                    "dest-filename": "mold-linux.tar.gz",
+                    "only-arches": [
+                        "x86_64"
+                    ],
+                    "url": "https://github.com/rui314/mold/releases/download/v1.10.1/mold-1.10.1-x86_64-linux.tar.gz",
+                    "sha256": "7524fe67f917d5287b2f7a7d6401e2625fa3f5f84bc6b8d9b487d6cb08876488",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 241732,
+                        "stable-only": true,
+                        "url-template": "https://github.com/rui314/mold/releases/download/v$version/mold-$version-x86_64-linux.tar.gz"
+                    }
+                },
+                {
+                    "type": "archive",
+                    "dest-filename": "mold-linux.tar.gz",
+                    "only-arches": [
+                        "aarch64"
+                    ],
+                    "url": "https://github.com/rui314/mold/releases/download/v1.10.1/mold-1.10.1-aarch64-linux.tar.gz",
+                    "sha256": "5ad793bce5c40c2fc5c8afb77188fd504cedd2a3160baee04091bd294385305b",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 241732,
+                        "stable-only": true,
+                        "url-template": "https://github.com/rui314/mold/releases/download/v$version/mold-$version-aarch64-linux.tar.gz"
+                    }
+                }
+            ],
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -m 755 bin/mold $FLATPAK_DEST/bin/mold",
+                "install -m 755 bin/ld.mold $FLATPAK_DEST/bin/ld.mold"
+            ],
+            "cleanup": [
+                "*"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Add mold as the linker when using the `devel` meson option, which speeds up linking quite a bit. Linking only took 2-3 seconds before on my machine, but this reduces that time on every recompile to well under a second.

Also use debug build type where possible to further speed up the build. It would make sense to set this along with the other devel options in meson but I couldn't find a way to do so.