### PR TITLE
Fix delayed reset of Gsettings keys and implement GtkDropDown in Reverb

### DIFF
--- a/data/ui/crystalizer.ui
+++ b/data/ui/crystalizer.ui
@@ -21,7 +21,7 @@
                         <child>
                             <object class="GtkBox" id="bands_box">
                                 <property name="halign">center</property>
-                                <property name="spacing">24</property>
+                                <property name="spacing">12</property>
                                 <style>
                                     <class name="card" />
                                 </style>

--- a/data/ui/crystalizer_band.ui
+++ b/data/ui/crystalizer_band.ui
@@ -22,8 +22,8 @@
     </object>
 
     <object class="GtkBox" id="band_box">
-        <!-- <property name="margin-start">6</property> -->
-        <!-- <property name="margin-end">6</property> -->
+        <property name="margin-start">6</property>
+        <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
         <property name="spacing">6</property>

--- a/data/ui/reverb.ui
+++ b/data/ui/reverb.ui
@@ -75,16 +75,20 @@
                                         </child>
 
                                         <child>
-                                            <object class="GtkComboBoxText" id="room_size">
+                                            <object class="GtkDropDown" id="room_size">
                                                 <property name="halign">center</property>
-                                                <items>
-                                                    <item translatable="yes" id="Small">Small</item>
-                                                    <item translatable="yes" id="Medium">Medium</item>
-                                                    <item translatable="yes" id="Large">Large</item>
-                                                    <item translatable="yes" id="Tunnel-like">Tunnel</item>
-                                                    <item translatable="yes" id="Large/smooth">Large/smooth</item>
-                                                    <item translatable="yes" id="Experimental">Experimental</item>
-                                                </items>
+                                                <property name="model">
+                                                    <object class="GtkStringList">
+                                                        <items>
+                                                            <item translatable="yes">Small</item>
+                                                            <item translatable="yes">Medium</item>
+                                                            <item translatable="yes">Large</item>
+                                                            <item translatable="yes">Tunnel</item>
+                                                            <item translatable="yes">Large/smooth</item>
+                                                            <item translatable="yes">Experimental</item>
+                                                        </items>
+                                                    </object>
+                                                </property>
                                                 <accessibility>
                                                     <relation name="labelled-by">room_size_label</relation>
                                                 </accessibility>
@@ -605,7 +609,7 @@
                         <child>
                             <object class="GtkButton" id="preset_large_empty_hall">
                                 <property name="label" translatable="yes">Large Empty Hall</property>
-                                <signal name="clicked" handler="on_preset_ambience" object="ReverbBox" />
+                                <signal name="clicked" handler="on_preset_large_empty_hall" object="ReverbBox" />
                             </object>
                         </child>
                     </object>

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -107,7 +107,9 @@ void idle_add(std::function<void()> cb);
 
 auto get_files_name(const std::filesystem::path& dir_path, const std::string& ext) -> std::vector<std::string>;
 
-void reset_all_keys_except(GSettings* settings, const std::vector<std::string>& blocklist = std::vector<std::string>());
+void reset_all_keys_except(GSettings* settings,
+                           const std::vector<std::string>& blocklist = std::vector<std::string>(),
+                           bool delay = true);
 
 auto str_contains(const std::string& haystack, const std::string& needle) -> bool;
 

--- a/src/reverb_ui.cpp
+++ b/src/reverb_ui.cpp
@@ -43,7 +43,7 @@ struct _ReverbBox {
 
   GtkLabel *input_level_left_label, *input_level_right_label, *output_level_left_label, *output_level_right_label;
 
-  GtkComboBoxText* room_size;
+  GtkDropDown* room_size;
 
   GtkSpinButton *predelay, *decay_time, *diffusion, *dry, *wet, *hf_damp, *bass_cut, *treble_cut;
 
@@ -60,45 +60,45 @@ void on_reset(ReverbBox* self, GtkButton* btn) {
 }
 
 void on_preset_room(ReverbBox* self, GtkButton* btn) {
-  gtk_spin_button_set_value(self->decay_time, 0.445945);
-  gtk_spin_button_set_value(self->hf_damp, 5508.46);
-  gtk_combo_box_set_active(GTK_COMBO_BOX(self->room_size), 4);
-  gtk_spin_button_set_value(self->diffusion, 0.54);
-  gtk_spin_button_set_value(self->wet, util::linear_to_db(0.469761));
-  gtk_spin_button_set_value(self->dry, util::linear_to_db(1.0));
-  gtk_spin_button_set_value(self->predelay, 25.0);
-  gtk_spin_button_set_value(self->bass_cut, 257.65);
-  gtk_spin_button_set_value(self->treble_cut, 20000.0);
+  g_settings_set_double(self->settings, "decay-time", 0.445945);
+  g_settings_set_double(self->settings, "hf-damp", 5508.46);
+  g_settings_set_enum(self->settings, "room-size", 4);
+  g_settings_set_double(self->settings, "diffusion", 0.54);
+  g_settings_set_double(self->settings, "amount", util::linear_to_db(0.469761));
+  g_settings_set_double(self->settings, "dry", util::linear_to_db(1.0));
+  g_settings_set_double(self->settings, "predelay", 25.0);
+  g_settings_set_double(self->settings, "bass-cut", 257.65);
+  g_settings_set_double(self->settings, "treble-cut", 20000.0);
 }
 
 void on_preset_empty_walls(ReverbBox* self, GtkButton* btn) {
-  gtk_spin_button_set_value(self->decay_time, 0.505687);
-  gtk_spin_button_set_value(self->hf_damp, 3971.64);
-  gtk_combo_box_set_active(GTK_COMBO_BOX(self->room_size), 4);
-  gtk_spin_button_set_value(self->diffusion, 0.17);
-  gtk_spin_button_set_value(self->wet, util::linear_to_db(0.198884));
-  gtk_spin_button_set_value(self->dry, util::linear_to_db(1.0));
-  gtk_spin_button_set_value(self->predelay, 13.0);
-  gtk_spin_button_set_value(self->bass_cut, 240.453);
-  gtk_spin_button_set_value(self->treble_cut, 3303.47);
+  g_settings_set_double(self->settings, "decay-time", 0.505687);
+  g_settings_set_double(self->settings, "hf-damp", 3971.64);
+  g_settings_set_enum(self->settings, "room-size", 4);
+  g_settings_set_double(self->settings, "diffusion", 0.17);
+  g_settings_set_double(self->settings, "amount", util::linear_to_db(0.198884));
+  g_settings_set_double(self->settings, "dry", util::linear_to_db(1.0));
+  g_settings_set_double(self->settings, "predelay", 13.0);
+  g_settings_set_double(self->settings, "bass-cut", 240.453);
+  g_settings_set_double(self->settings, "treble-cut", 3303.47);
 }
 
 void on_preset_ambience(ReverbBox* self, GtkButton* btn) {
-  gtk_spin_button_set_value(self->decay_time, 1.10354);
-  gtk_spin_button_set_value(self->hf_damp, 2182.58);
-  gtk_combo_box_set_active(GTK_COMBO_BOX(self->room_size), 4);
-  gtk_spin_button_set_value(self->diffusion, 0.69);
-  gtk_spin_button_set_value(self->wet, util::linear_to_db(0.291183));
-  gtk_spin_button_set_value(self->dry, util::linear_to_db(1.0));
-  gtk_spin_button_set_value(self->predelay, 6.5);
-  gtk_spin_button_set_value(self->bass_cut, 514.079);
-  gtk_spin_button_set_value(self->treble_cut, 4064.15);
+  g_settings_set_double(self->settings, "decay-time", 1.10354);
+  g_settings_set_double(self->settings, "hf-damp", 2182.58);
+  g_settings_set_enum(self->settings, "room-size", 4);
+  g_settings_set_double(self->settings, "diffusion", 0.69);
+  g_settings_set_double(self->settings, "amount", util::linear_to_db(0.291183));
+  g_settings_set_double(self->settings, "dry", util::linear_to_db(1.0));
+  g_settings_set_double(self->settings, "predelay", 6.5);
+  g_settings_set_double(self->settings, "bass-cut", 514.079);
+  g_settings_set_double(self->settings, "treble-cut", 4064.15);
 }
 
 void on_preset_large_empty_hall(ReverbBox* self, GtkButton* btn) {
-  gtk_spin_button_set_value(self->decay_time, 2.00689);
-  gtk_spin_button_set_value(self->hf_damp, 20000.0);
-  gtk_spin_button_set_value(self->wet, util::linear_to_db(0.366022));
+  g_settings_set_double(self->settings, "decay-time", 2.00689);
+  g_settings_set_double(self->settings, "hf-damp", 20000.0);
+  g_settings_set_double(self->settings, "amount", util::linear_to_db(0.366022));
   g_settings_reset(self->settings, "room-size");
   g_settings_reset(self->settings, "diffusion");
   g_settings_reset(self->settings, "dry");
@@ -108,9 +108,9 @@ void on_preset_large_empty_hall(ReverbBox* self, GtkButton* btn) {
 }
 
 void on_preset_disco(ReverbBox* self, GtkButton* btn) {
-  gtk_spin_button_set_value(self->decay_time, 1.0);
-  gtk_spin_button_set_value(self->hf_damp, 3396.49);
-  gtk_spin_button_set_value(self->wet, util::linear_to_db(0.269807));
+  g_settings_set_double(self->settings, "decay-time", 1.0);
+  g_settings_set_double(self->settings, "hf-damp", 3396.49);
+  g_settings_set_double(self->settings, "amount", util::linear_to_db(0.269807));
   g_settings_reset(self->settings, "room-size");
   g_settings_reset(self->settings, "diffusion");
   g_settings_reset(self->settings, "dry");
@@ -120,9 +120,9 @@ void on_preset_disco(ReverbBox* self, GtkButton* btn) {
 }
 
 void on_preset_large_occupied_hall(ReverbBox* self, GtkButton* btn) {
-  gtk_spin_button_set_value(self->decay_time, 1.45397);
-  gtk_spin_button_set_value(self->hf_damp, 9795.58);
-  gtk_spin_button_set_value(self->wet, util::linear_to_db(0.184284));
+  g_settings_set_double(self->settings, "decay-time", 1.45397);
+  g_settings_set_double(self->settings, "hf-damp", 9795.58);
+  g_settings_set_double(self->settings, "amount", util::linear_to_db(0.184284));
   g_settings_reset(self->settings, "room-size");
   g_settings_reset(self->settings, "diffusion");
   g_settings_reset(self->settings, "dry");
@@ -193,7 +193,7 @@ void setup(ReverbBox* self, std::shared_ptr<Reverb> reverb, const std::string& s
   g_settings_bind(self->settings, "treble-cut", gtk_spin_button_get_adjustment(self->treble_cut), "value",
                   G_SETTINGS_BIND_DEFAULT);
 
-  g_settings_bind(self->settings, "room-size", self->room_size, "active-id", G_SETTINGS_BIND_DEFAULT);
+  ui::gsettings_bind_enum_to_dropdown<"room-size">(self->settings, self->room_size);
 }
 
 void dispose(GObject* object) {

--- a/util/NEWS.yaml
+++ b/util/NEWS.yaml
@@ -7,7 +7,7 @@ Description:
 - The Equalizer "sort bands" feature is now ordering bands on GSettings, so the result can be saved into presets.
 
 - Bug fixes∶
--
+- Fixed the "Large Empty Hall" preset selection in the Reverberation effect.
 
 - Other notes∶
 - As we are removing code deprecated by `GTK 4.10` the minimum GTK version has been increased.


### PR DESCRIPTION
- As mentioned in https://github.com/wwmm/easyeffects/issues/2215#issuecomment-1488402243 - in delay mode I added a mechanism to apply changes when a maximum count is reached (gsettings use 256, I set 128). Fixes #2215. 
- Added little right/left paddings in the Cristalyzer UI (before the labels were attached to the border, not very good to see).
- Implemented GtkDropDown in Reverb effect.
- Fixed `Large Empy Hall` preset selection in Reverb (before the Ambience were applied in its place).