### PR TITLE
Support DropDown Gsettings binding for tags and prepare to implement DD in Eq Band

### DIFF
--- a/data/ui/equalizer.ui
+++ b/data/ui/equalizer.ui
@@ -67,14 +67,18 @@
                                     </object>
                                 </child>
                                 <child>
-                                    <object class="GtkComboBoxText" id="mode">
+                                    <object class="GtkDropDown" id="mode">
                                         <property name="halign">center</property>
-                                        <items>
-                                            <item translatable="yes" id="IIR">IIR</item>
-                                            <item translatable="yes" id="FIR">FIR</item>
-                                            <item translatable="yes" id="FFT">FFT</item>
-                                            <item translatable="yes" id="SPM">SPM</item>
-                                        </items>
+                                        <property name="model">
+                                            <object class="GtkStringList">
+                                                <items>
+                                                    <item translatable="yes">IIR</item>
+                                                    <item translatable="yes">FIR</item>
+                                                    <item translatable="yes">FFT</item>
+                                                    <item translatable="yes">SPM</item>
+                                                </items>
+                                            </object>
+                                        </property>
                                         <layout>
                                             <property name="column">1</property>
                                             <property name="row">1</property>

--- a/data/ui/equalizer_band.ui
+++ b/data/ui/equalizer_band.ui
@@ -107,18 +107,22 @@
                             </object>
                         </child>
                         <child>
-                            <object class="GtkComboBoxText" id="band_type">
-                                <items>
-                                    <item translatable="yes" id="Off">Off</item>
-                                    <item translatable="yes" id="Bell">Bell</item>
-                                    <item translatable="yes" id="Hi-pass">High Pass</item>
-                                    <item translatable="yes" id="Hi-shelf">High Shelf</item>
-                                    <item translatable="yes" id="Lo-pass">Low Pass</item>
-                                    <item translatable="yes" id="Lo-shelf">Low Shelf</item>
-                                    <item translatable="yes" id="Notch">Notch</item>
-                                    <item translatable="yes" id="Resonance">Resonance</item>
-                                    <item translatable="yes" id="Allpass">All Pass</item>
-                                </items>
+                            <object class="GtkDropDown" id="band_type">
+                                <property name="model">
+                                    <object class="GtkStringList">
+                                        <items>
+                                            <item>Off</item>
+                                            <item>Bell</item>
+                                            <item>High Pass</item>
+                                            <item>High Shelf</item>
+                                            <item>Low Pass</item>
+                                            <item>Low Shelf</item>
+                                            <item>Notch</item>
+                                            <item>Resonance</item>
+                                            <item>All Pass</item>
+                                        </items>
+                                    </object>
+                                </property>
                                 <layout>
                                     <property name="column">0</property>
                                     <property name="row">1</property>
@@ -139,16 +143,20 @@
                             </object>
                         </child>
                         <child>
-                            <object class="GtkComboBoxText" id="band_mode">
-                                <items>
-                                    <item id="RLC (BT)">RLC (BT)</item>
-                                    <item id="RLC (MT)">RLC (MT)</item>
-                                    <item id="BWC (BT)">BWC (BT)</item>
-                                    <item id="BWC (MT)">BWC (MT)</item>
-                                    <item id="LRX (BT)">LRX (BT)</item>
-                                    <item id="LRX (MT)">LRX (MT)</item>
-                                    <item id="APO (DR)">APO (DR)</item>
-                                </items>
+                            <object class="GtkDropDown" id="band_mode">
+                                <property name="model">
+                                    <object class="GtkStringList">
+                                        <items>
+                                            <item>RLC (BT)</item>
+                                            <item>RLC (MT)</item>
+                                            <item>BWC (BT)</item>
+                                            <item>BWC (MT)</item>
+                                            <item>LRX (BT)</item>
+                                            <item>LRX (MT)</item>
+                                            <item>APO (DR)</item>
+                                        </items>
+                                    </object>
+                                </property>
                                 <layout>
                                     <property name="column">1</property>
                                     <property name="row">1</property>
@@ -169,13 +177,17 @@
                             </object>
                         </child>
                         <child>
-                            <object class="GtkComboBoxText" id="band_slope">
-                                <items>
-                                    <item id="x1">x1</item>
-                                    <item id="x2">x2</item>
-                                    <item id="x3">x3</item>
-                                    <item id="x4">x4</item>
-                                </items>
+                            <object class="GtkDropDown" id="band_slope">
+                                <property name="model">
+                                    <object class="GtkStringList">
+                                        <items>
+                                            <item>x1</item>
+                                            <item>x2</item>
+                                            <item>x3</item>
+                                            <item>x4</item>
+                                        </items>
+                                    </object>
+                                </property>
                                 <layout>
                                     <property name="column">2</property>
                                     <property name="row">1</property>

--- a/include/ui_helpers.hpp
+++ b/include/ui_helpers.hpp
@@ -73,6 +73,11 @@ void append_to_string_list(GtkStringList* string_list, const std::string& name);
 
 void remove_from_string_list(GtkStringList* string_list, const std::string& name);
 
+void gsettings_bind_enum_to_dropdown(GSettings* settings,
+                                     const gchar* key,
+                                     GtkDropDown* dropdown,
+                                     GSettingsBindFlags flags = G_SETTINGS_BIND_DEFAULT);
+
 template <StringLiteralWrapper sl_wrapper, bool lower_bound = true>
 void prepare_spinbutton(GtkSpinButton* button) {
   if (button == nullptr) {
@@ -164,25 +169,6 @@ void gsettings_bind_widget(GSettings* settings,
 template <StringLiteralWrapper... key_wrapper, typename... Targs>
 void gsettings_bind_widgets(GSettings* settings, Targs... widget) {
   (gsettings_bind_widget(settings, key_wrapper.msg.data(), widget), ...);
-}
-
-template <StringLiteralWrapper key_wrapper>
-void gsettings_bind_enum_to_dropdown(GSettings* settings,
-                                     GtkDropDown* dropdown,
-                                     GSettingsBindFlags flags = G_SETTINGS_BIND_DEFAULT) {
-  g_settings_bind_with_mapping(
-      settings, key_wrapper.msg.data(), dropdown, "selected", flags,
-      +[](GValue* value, GVariant* variant, gpointer user_data) {
-        auto* settings = static_cast<GSettings*>(user_data);
-        g_value_set_uint(value, static_cast<guint>(g_settings_get_enum(settings, key_wrapper.msg.data())));
-        return 1;
-      },
-      +[](const GValue* value, const GVariantType* expected_type, gpointer user_data) {
-        auto* settings = static_cast<GSettings*>(user_data);
-        g_settings_set_enum(settings, key_wrapper.msg.data(), static_cast<gint>(g_value_get_uint(value)));
-        return g_variant_new_string(g_settings_get_string(settings, key_wrapper.msg.data()));
-      },
-      settings, nullptr);
 }
 
 }  // namespace ui

--- a/src/equalizer_band_box.cpp
+++ b/src/equalizer_band_box.cpp
@@ -31,7 +31,7 @@ struct Data {
 struct _EqualizerBandBox {
   GtkBox parent_instance;
 
-  GtkComboBoxText *band_type, *band_mode, *band_slope;
+  GtkDropDown *band_type, *band_mode, *band_slope;
 
   GtkButton *reset_frequency, *reset_quality;
 
@@ -81,7 +81,7 @@ auto set_band_width_label(EqualizerBandBox* self, double quality, double frequen
   return g_strdup(_("infinity"));
 }
 
-auto set_band_scale_sensitive(EqualizerBandBox* self, const char* active_id) -> gboolean {
+auto set_band_scale_sensitive(EqualizerBandBox* self, const char* selected_position) -> gboolean {
   if (g_strcmp0(active_id, "Off") == 0 || g_strcmp0(active_id, "Hi-pass") == 0 ||
       g_strcmp0(active_id, "Lo-pass") == 0) {
     return 0;
@@ -112,14 +112,11 @@ void bind(EqualizerBandBox* self, int index) {
   g_settings_bind(self->settings, tags::equalizer::band_mute[index].data(), self->band_mute, "active",
                   G_SETTINGS_BIND_DEFAULT);
 
-  g_settings_bind(self->settings, tags::equalizer::band_type[index].data(), self->band_type, "active-id",
-                  G_SETTINGS_BIND_DEFAULT);
+  ui::gsettings_bind_enum_to_dropdown(self->settings, tags::equalizer::band_type[index].data(), self->band_type);
 
-  g_settings_bind(self->settings, tags::equalizer::band_mode[index].data(), self->band_mode, "active-id",
-                  G_SETTINGS_BIND_DEFAULT);
+  ui::gsettings_bind_enum_to_dropdown(self->settings, tags::equalizer::band_mode[index].data(), self->band_mode);
 
-  g_settings_bind(self->settings, tags::equalizer::band_slope[index].data(), self->band_slope, "active-id",
-                  G_SETTINGS_BIND_DEFAULT);
+  ui::gsettings_bind_enum_to_dropdown(self->settings, tags::equalizer::band_slope[index].data(), self->band_slope);
 }
 
 void dispose(GObject* object) {

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -773,7 +773,7 @@ void setup(EqualizerBox* self,
 
   g_settings_bind(self->settings, "split-channels", self->split_channels, "active", G_SETTINGS_BIND_DEFAULT);
 
-  ui::gsettings_bind_enum_to_dropdown<"mode">(self->settings, self->mode);
+  ui::gsettings_bind_enum_to_dropdown(self->settings, "mode", self->mode);
 
   g_settings_bind(self->settings, "balance", gtk_spin_button_get_adjustment(self->balance), "value",
                   G_SETTINGS_BIND_DEFAULT);

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -75,7 +75,7 @@ struct _EqualizerBox {
 
   GtkSpinButton *nbands, *balance, *pitch_left, *pitch_right;
 
-  GtkComboBoxText* mode;
+  GtkDropDown* mode;
 
   GtkToggleButton* split_channels;
 
@@ -773,7 +773,7 @@ void setup(EqualizerBox* self,
 
   g_settings_bind(self->settings, "split-channels", self->split_channels, "active", G_SETTINGS_BIND_DEFAULT);
 
-  g_settings_bind(self->settings, "mode", self->mode, "active-id", G_SETTINGS_BIND_DEFAULT);
+  ui::gsettings_bind_enum_to_dropdown<"mode">(self->settings, self->mode);
 
   g_settings_bind(self->settings, "balance", gtk_spin_button_get_adjustment(self->balance), "value",
                   G_SETTINGS_BIND_DEFAULT);

--- a/src/filter_ui.cpp
+++ b/src/filter_ui.cpp
@@ -107,7 +107,7 @@ void setup(FilterBox* self, std::shared_ptr<Filter> filter, const std::string& s
   g_settings_bind(self->settings, "inertia", gtk_spin_button_get_adjustment(self->inertia), "value",
                   G_SETTINGS_BIND_DEFAULT);
 
-  ui::gsettings_bind_enum_to_dropdown<"mode">(self->settings, self->mode);
+  ui::gsettings_bind_enum_to_dropdown(self->settings, "mode", self->mode);
 }
 
 void dispose(GObject* object) {

--- a/src/reverb_ui.cpp
+++ b/src/reverb_ui.cpp
@@ -193,7 +193,7 @@ void setup(ReverbBox* self, std::shared_ptr<Reverb> reverb, const std::string& s
   g_settings_bind(self->settings, "treble-cut", gtk_spin_button_get_adjustment(self->treble_cut), "value",
                   G_SETTINGS_BIND_DEFAULT);
 
-  ui::gsettings_bind_enum_to_dropdown<"room-size">(self->settings, self->room_size);
+  ui::gsettings_bind_enum_to_dropdown(self->settings, "room-size", self->room_size);
 }
 
 void dispose(GObject* object) {

--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -227,4 +227,32 @@ void remove_from_string_list(GtkStringList* string_list, const std::string& name
   }
 }
 
+void gsettings_bind_enum_to_dropdown(GSettings* settings,
+                                     const gchar* key,
+                                     GtkDropDown* dropdown,
+                                     GSettingsBindFlags flags) {
+  struct Data {
+    GSettings* settings;
+    const gchar* key;
+  };
+
+  g_settings_bind_with_mapping(
+      settings, key, dropdown, "selected", flags,
+      +[](GValue* value, GVariant* variant, gpointer user_data) {
+        auto* d = static_cast<Data*>(user_data);
+        g_value_set_uint(value, static_cast<guint>(g_settings_get_enum(d->settings, d->key)));
+        return 1;
+      },
+      +[](const GValue* value, const GVariantType* expected_type, gpointer user_data) {
+        auto* d = static_cast<Data*>(user_data);
+        g_settings_set_enum(d->settings, d->key, static_cast<gint>(g_value_get_uint(value)));
+        return g_variant_new_string(g_settings_get_string(d->settings, d->key));
+      },
+      new Data({.settings = settings, .key = key}),
+      +[](gpointer user_data) {
+        auto* d = static_cast<Data*>(user_data);
+        delete d;
+      });
+}
+
 }  // namespace ui


### PR DESCRIPTION
* Changed the binding mapping for dropdowns to support tags
* Tried to implement the GtkDropDown for Equalizer Band box. It compiles, but does not work because of the sensitive bind to `active-id` (see https://github.com/wwmm/easyeffects/issues/2210#issuecomment-1490962788).

Update: `selected_position` in `set_band_scale_sensitive` was an attempt of mine to handle the selected id returned by the dropdown, but I made it wrong. Forgot to restore the correct parameter.