### PR TITLE
build: make clang versions lower than 16 not able to build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,14 @@ project(
 	meson_version: '>= 0.59.0'
 )
 
+# see https://github.com/wwmm/easyeffects/pull/1739 for more info
+cxx = meson.get_compiler('cpp')
+cxx_version=cxx.version()
+if cxx.get_id() == 'clang'
+  clang_version = cxx_version.version_compare('>=16.0.0')
+  assert(clang_version == true, 'This project only supports gcc or > clang 16 compilers due to usage of c++20 features.')
+endif
+
 suppressed_warnings = [
   '-Wno-missing-field-initializers',
   '-Wno-unused-parameter'


### PR DESCRIPTION
commit https://github.com/wwmm/easyeffects/commit/f43d41a4c10496f94cd13a77d508cd4618d4b92d  makes clang able to build now, but other clang versions still can't, so this commit reproduces the original behaviour but only for clang versions lower than 16

this is also my first time working with meson so there is probably a much more efficient way to do this, but hey my change still works