### PR TITLE
app icons: add special case for Firefox Nightly

### DIFF
--- a/src/app_info.cpp
+++ b/src/app_info.cpp
@@ -86,7 +86,7 @@ auto get_app_icon_name(const NodeInfo& node_info) -> std::string {
   // map to handle cases where PipeWire does not set icon name string or app name equal to icon name.
 
   constexpr auto icon_map = std::to_array<std::pair<const char*, const char*>>(
-      {{"chromium-browser", "chromium"}, {"firefox", "firefox"}, {"obs", "com.obsproject.Studio"}});
+      {{"chromium-browser", "chromium"}, {"firefox", "firefox"}, {"Nightly","firefox-nightly"}, {"obs", "com.obsproject.Studio"}});
 
   std::string icon_name;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5215129/232334521-78ceb8b1-0c0d-4154-bd4a-c9250f153697.png)
