### PR TITLE
app icons: handle ALSA playback cases

### DIFF
--- a/src/app_info.cpp
+++ b/src/app_info.cpp
@@ -95,7 +95,12 @@ auto get_app_icon_name(const NodeInfo& node_info) -> std::string {
   } else if (!node_info.media_icon_name.empty()) {
     icon_name = node_info.media_icon_name;
   } else if (!node_info.name.empty()) {
-    icon_name = node_info.name;
+    const std::string prefix = "alsa_playback.";
+    if (node_info.name.substr(0, prefix.size()) == prefix) {
+      icon_name = node_info.name.substr(prefix.size());
+    } else {
+      icon_name = node_info.name;
+    }
 
     // get lowercase name so if it changes in the future, we have a chance to pick the same index
 


### PR DESCRIPTION
When ALSA is used (e.g. no PulseAudio or pipewire-pulse installed, or `media.cubeb.backend` in Firefox is set to `alsa`), the string `alsa_playback` is prepended to the node name, which prevents us from displaying the correct icon for the app:

![2023-04-20_17h-29m-23s](https://user-images.githubusercontent.com/5215129/233401860-6c28c453-1ad1-487a-9bb2-936acdf4a4cc.png)

This fixes it without changing the displayed node name:

![image](https://user-images.githubusercontent.com/5215129/233402269-296b3529-31c8-4a2a-897f-c0a73a51b612.png)

...unless that's what we want, since it's redundant?