### PR TITLE
Remove option to disable speex

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -188,7 +188,6 @@ jobs:
         pipewire-dev
         rnnoise-dev
         rubberband-dev
-        speex-dev
         speexdsp-dev
         zita-convolver-dev
         "

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -11,7 +11,7 @@ arch=(x86_64)
 url='https://github.com/wwmm/easyeffects'
 license=('GPL3')
 depends=('libadwaita' 'pipewire-pulse' 'lilv' 'libsigc++-3.0' 'libsamplerate' 'zita-convolver' 
-         'libebur128' 'rnnoise' 'rubberband' 'libbs2b' 'nlohmann-json' 'tbb' 'fmt' 'gsl' 'speexdsp' 'speex')
+         'libebur128' 'rnnoise' 'rubberband' 'libbs2b' 'nlohmann-json' 'tbb' 'fmt' 'gsl' 'speexdsp')
 makedepends=('meson' 'itstool' 'appstream-glib' 'git' 'mold')
 optdepends=('calf: limiter, exciter, bass enhancer and others'
             'lsp-plugins: equalizer, compressor, delay, loudness'

--- a/include/echo_canceller.hpp
+++ b/include/echo_canceller.hpp
@@ -24,9 +24,7 @@
 #include <numeric>
 #include "plugin_base.hpp"
 
-#ifdef SPEEX_AVAILABLE
 #include <speex/speex_preprocess.h>
-#endif
 
 class EchoCanceller : public PluginBase {
  public:
@@ -72,13 +70,11 @@ class EchoCanceller : public PluginBase {
   SpeexEchoState* echo_state_L = nullptr;
   SpeexEchoState* echo_state_R = nullptr;
 
-#ifdef SPEEX_AVAILABLE
 
   SpeexPreprocessState *state_left = nullptr, *state_right = nullptr;
 
   void free_speex();
 
-#endif
 
   void init_speex();
 };

--- a/include/preferences_general.hpp
+++ b/include/preferences_general.hpp
@@ -27,7 +27,7 @@
 #include "ui_helpers.hpp"
 #include "util.hpp"
 
-#ifdef USE_LIBPORTAL
+#ifdef ENABLE_LIBPORTAL
 #include "libportal.hpp"
 #endif
 

--- a/include/rnnoise.hpp
+++ b/include/rnnoise.hpp
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#ifdef RNNOISE_AVAILABLE
+#ifdef ENABLE_RNNOISE
 #include <rnnoise.h>
 #endif
 
@@ -45,7 +45,7 @@ class RNNoise : public PluginBase {
 
   auto get_latency_seconds() -> float override;
 
-#ifndef RNNOISE_AVAILABLE
+#ifndef ENABLE_RNNOISE
   bool package_installed = false;
 #endif
 
@@ -73,7 +73,7 @@ class RNNoise : public PluginBase {
   std::unique_ptr<Resampler> resampler_inL, resampler_outL;
   std::unique_ptr<Resampler> resampler_inR, resampler_outR;
 
-#ifdef RNNOISE_AVAILABLE
+#ifdef ENABLE_RNNOISE
 
   RNNModel* model = nullptr;
 

--- a/include/speex.hpp
+++ b/include/speex.hpp
@@ -19,9 +19,7 @@
 
 #pragma once
 
-#ifdef SPEEX_AVAILABLE
 #include <speex/speex_preprocess.h>
-#endif
 
 #include <deque>
 #include "plugin_base.hpp"
@@ -43,10 +41,6 @@ class Speex : public PluginBase {
 
   auto get_latency_seconds() -> float override;
 
-#ifndef SPEEX_AVAILABLE
-  bool package_installed = false;
-#endif
-
  private:
   bool speex_ready = false;
 
@@ -59,11 +53,8 @@ class Speex : public PluginBase {
 
   std::vector<spx_int16_t> data_L, data_R;
 
-#ifdef SPEEX_AVAILABLE
-
   SpeexPreprocessState *state_left = nullptr, *state_right = nullptr;
 
   void free_speex();
 
-#endif
 };

--- a/meson.build
+++ b/meson.build
@@ -32,8 +32,8 @@ add_project_arguments (
   language: [ 'c', 'cpp' ],
   )
 
-add_global_arguments('-DG_LOG_DOMAIN="easyeffects"', language : [ 'c', 'cpp' ])
-add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()),
+add_project_arguments('-DG_LOG_DOMAIN="easyeffects"', language : [ 'c', 'cpp' ])
+add_project_arguments('-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()),
 	language:'c')
 
 gnome_mod = import('gnome')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,3 +18,10 @@ option(
   type: 'boolean',
   value: false
 )
+
+option(
+  'enable-rnnoise',
+  description: 'Whether to use RRNNoise for noise cancellation.',
+  type: 'boolean',
+  value: true
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -122,7 +122,7 @@ easyeffects_sources = [
 libportal = dependency('libportal-gtk4', include_type: 'system', required: get_option('enable-libportal'))
 
 if get_option('enable-libportal')
-  add_global_arguments('-DUSE_LIBPORTAL=1', language : 'cpp')
+  add_project_arguments('-DUSE_LIBPORTAL=1', language : 'cpp')
   easyeffects_sources += 'libportal.cpp'
   status += 'Using libportal to handle autostart files.'
 endif
@@ -134,7 +134,7 @@ zita_convolver = cxx.find_library('zita-convolver', required: true)
 rnnoise = dependency('rnnoise', include_type: 'system', required: get_option('enable-rnnoise'))
 
 if get_option('enable-rnnoise')
-	add_global_arguments('-DRNNOISE_AVAILABLE=1', language : 'cpp')
+	add_project_arguments('-DRNNOISE_AVAILABLE=1', language : 'cpp')
 else
 	status += 'The RNNoise library is not being used. The calls to its functions will be disabled.'
 endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -122,7 +122,7 @@ easyeffects_sources = [
 libportal = dependency('libportal-gtk4', include_type: 'system', required: get_option('enable-libportal'))
 
 if get_option('enable-libportal')
-  add_project_arguments('-DUSE_LIBPORTAL=1', language : 'cpp')
+  add_project_arguments('-DENABLE_LIBPORTAL=1', language : 'cpp')
   easyeffects_sources += 'libportal.cpp'
   status += 'Using libportal to handle autostart files.'
 endif
@@ -134,7 +134,7 @@ zita_convolver = cxx.find_library('zita-convolver', required: true)
 rnnoise = dependency('rnnoise', include_type: 'system', required: get_option('enable-rnnoise'))
 
 if get_option('enable-rnnoise')
-	add_project_arguments('-DRNNOISE_AVAILABLE=1', language : 'cpp')
+	add_project_arguments('-DENABLE_RNNOISE=1', language : 'cpp')
 else
 	status += 'The RNNoise library is not being used. The calls to its functions will be disabled.'
 endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -133,18 +133,10 @@ zita_convolver = cxx.find_library('zita-convolver', required: true)
 
 rnnoise = dependency('rnnoise', required: false)
 
-speex = dependency('speex', required: false)
-
 if rnnoise.found()
 	add_global_arguments('-DRNNOISE_AVAILABLE=1', language : 'cpp')
 else
 	status += 'The RNNoise library was not found. The calls to its functions will be disabled.'
-endif
-
-if speex.found()
-	add_global_arguments('-DSPEEX_AVAILABLE=1', language : 'cpp')
-else
-	status += 'The Speex library was not found. The calls to its functions will be disabled.'
 endif
 
 easyeffects_deps = [

--- a/src/meson.build
+++ b/src/meson.build
@@ -131,12 +131,12 @@ cxx = meson.get_compiler('cpp')
 
 zita_convolver = cxx.find_library('zita-convolver', required: true)
 
-rnnoise = dependency('rnnoise', required: false)
+rnnoise = dependency('rnnoise', include_type: 'system', required: get_option('enable-rnnoise'))
 
-if rnnoise.found()
+if get_option('enable-rnnoise')
 	add_global_arguments('-DRNNOISE_AVAILABLE=1', language : 'cpp')
 else
-	status += 'The RNNoise library was not found. The calls to its functions will be disabled.'
+	status += 'The RNNoise library is not being used. The calls to its functions will be disabled.'
 endif
 
 easyeffects_deps = [

--- a/src/meson.build
+++ b/src/meson.build
@@ -118,18 +118,11 @@ easyeffects_sources = [
 	gresources
 ]
 
-# always require libportal if the meson option is enabled, so it can't be accidentally left out
-libportal = dependency('libportal-gtk4', include_type: 'system', required: get_option('enable-libportal'))
-
-if get_option('enable-libportal')
-  add_project_arguments('-DENABLE_LIBPORTAL=1', language : 'cpp')
-  easyeffects_sources += 'libportal.cpp'
-  status += 'Using libportal to handle autostart files.'
-endif
-
 cxx = meson.get_compiler('cpp')
 
 zita_convolver = cxx.find_library('zita-convolver', required: true)
+
+# always require these libraries if the respective meson option is enabled, so they can't be accidentally left out
 
 rnnoise = dependency('rnnoise', include_type: 'system', required: get_option('enable-rnnoise'))
 
@@ -137,6 +130,14 @@ if get_option('enable-rnnoise')
 	add_project_arguments('-DENABLE_RNNOISE=1', language : 'cpp')
 else
 	status += 'The RNNoise library is not being used. The calls to its functions will be disabled.'
+endif
+
+libportal = dependency('libportal-gtk4', include_type: 'system', required: get_option('enable-libportal'))
+
+if get_option('enable-libportal')
+  add_project_arguments('-DENABLE_LIBPORTAL=1', language : 'cpp')
+  easyeffects_sources += 'libportal.cpp'
+  status += 'Using libportal to handle autostart files.'
 endif
 
 easyeffects_deps = [

--- a/src/preferences_general.cpp
+++ b/src/preferences_general.cpp
@@ -37,7 +37,7 @@ struct _PreferencesGeneral {
 // NOLINTNEXTLINE
 G_DEFINE_TYPE(PreferencesGeneral, preferences_general, ADW_TYPE_PREFERENCES_PAGE)
 
-#ifndef USE_LIBPORTAL
+#ifndef ENABLE_LIBPORTAL
 
 auto on_enable_autostart(GtkSwitch* obj, gboolean state, gpointer user_data) -> gboolean {
   std::filesystem::path autostart_dir{g_get_user_config_dir() + "/autostart"s};
@@ -83,7 +83,7 @@ void dispose(GObject* object) {
 
   g_object_unref(self->settings);
 
-#ifdef USE_LIBPORTAL
+#ifdef ENABLE_LIBPORTAL
   g_settings_unbind(self->enable_autostart, "active");
   g_settings_unbind(self->shutdown_on_window_close, "active");
 #endif
@@ -130,7 +130,7 @@ void preferences_general_init(PreferencesGeneral* self) {
       self->shutdown_on_window_close, self->use_cubic_volumes, self->autohide_popovers, self->exclude_monitor_streams,
       self->inactivity_timeout, self->meters_update_interval);
 
-#ifdef USE_LIBPORTAL
+#ifdef ENABLE_LIBPORTAL
   libportal::init(self->enable_autostart, self->shutdown_on_window_close);
 #else
   gtk_switch_set_active(self->enable_autostart,

--- a/src/rnnoise.cpp
+++ b/src/rnnoise.cpp
@@ -39,7 +39,7 @@ RNNoise::RNNoise(const std::string& tag,
 
                                             self->data_mutex.unlock();
 
-#ifdef RNNOISE_AVAILABLE
+#ifdef ENABLE_RNNOISE
                                             self->free_rnnoise();
 
                                             auto* m = self->get_model_from_file();
@@ -56,7 +56,7 @@ RNNoise::RNNoise(const std::string& tag,
 
   setup_input_output_gain();
 
-#ifdef RNNOISE_AVAILABLE
+#ifdef ENABLE_RNNOISE
 
   auto* m = get_model_from_file();
 
@@ -80,7 +80,7 @@ RNNoise::~RNNoise() {
 
   resampler_ready = false;
 
-#ifdef RNNOISE_AVAILABLE
+#ifdef ENABLE_RNNOISE
   free_rnnoise();
 #endif
 
@@ -136,7 +136,7 @@ void RNNoise::process(std::span<float>& left_in,
       resampled_data_L.resize(0U);
       resampled_data_R.resize(0U);
 
-#ifdef RNNOISE_AVAILABLE
+#ifdef ENABLE_RNNOISE
       remove_noise(resampled_inL, resampled_inR, resampled_data_L, resampled_data_R);
 #endif
 
@@ -160,7 +160,7 @@ void RNNoise::process(std::span<float>& left_in,
       }
     }
   } else {
-#ifdef RNNOISE_AVAILABLE
+#ifdef ENABLE_RNNOISE
     remove_noise(left_in, right_in, deque_out_L, deque_out_R);
 #endif
   }
@@ -231,7 +231,7 @@ void RNNoise::process(std::span<float>& left_in,
   }
 }
 
-#ifdef RNNOISE_AVAILABLE
+#ifdef ENABLE_RNNOISE
 
 auto RNNoise::get_model_from_file() -> RNNModel* {
   RNNModel* m = nullptr;

--- a/src/speex.cpp
+++ b/src/speex.cpp
@@ -31,7 +31,6 @@ Speex::Speex(const std::string& tag,
       vad_probability_start(g_settings_get_int(settings, "vad-probability-start")),
       vad_probability_continue(g_settings_get_int(settings, "vad-probability-continue")),
       enable_dereverb(g_settings_get_boolean(settings, "enable-dereverb")) {
-#ifdef SPEEX_AVAILABLE
 
   gconnections.push_back(g_signal_connect(
       settings, "changed::enable-denoise", G_CALLBACK(+[](GSettings* settings, char* key, Speex* self) {
@@ -145,7 +144,6 @@ Speex::Speex(const std::string& tag,
       }),
       this));
 
-#endif
 
   setup_input_output_gain();
 }
@@ -157,9 +155,7 @@ Speex::~Speex() {
 
   std::scoped_lock<std::mutex> lock(data_mutex);
 
-#ifdef SPEEX_AVAILABLE
   free_speex();
-#endif
 
   util::debug(log_tag + name + " destroyed");
 }
@@ -174,7 +170,6 @@ void Speex::setup() {
   data_L.resize(n_samples);
   data_R.resize(n_samples);
 
-#ifdef SPEEX_AVAILABLE
   if (state_left != nullptr) {
     speex_preprocess_state_destroy(state_left);
   }
@@ -213,9 +208,6 @@ void Speex::setup() {
   }
 
   speex_ready = true;
-#else
-  util::warning("The Speex library was not available at compilation time. The noise reduction filter won't work");
-#endif
 }
 
 void Speex::process(std::span<float>& left_in,
@@ -235,7 +227,6 @@ void Speex::process(std::span<float>& left_in,
     apply_gain(left_in, right_in, input_gain);
   }
 
-#ifdef SPEEX_AVAILABLE
 
   for (size_t i = 0; i < n_samples; i++) {
     data_L[i] = static_cast<spx_int16_t>(left_in[i] * (SHRT_MAX + 1));
@@ -259,7 +250,6 @@ void Speex::process(std::span<float>& left_in,
     std::ranges::fill(right_out, 0.0F);
   }
 
-#endif
 
   if (output_gain != 1.0F) {
     apply_gain(left_out, right_out, output_gain);
@@ -274,7 +264,6 @@ void Speex::process(std::span<float>& left_in,
   }
 }
 
-#ifdef SPEEX_AVAILABLE
 
 void Speex::free_speex() {
   if (state_left != nullptr) {
@@ -289,7 +278,6 @@ void Speex::free_speex() {
   state_right = nullptr;
 }
 
-#endif
 
 auto Speex::get_latency_seconds() -> float {
   return latency_value;

--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -66,19 +66,19 @@ auto missing_plugin_box(const std::string& name, const std::string& package) -> 
     // For translators: {} is replaced by the effect name.
     const auto format_title = fmt::runtime(_("{} Not Available"));
 
-    // For translators: {} is replaced by the package name.
-    auto format_descr = fmt::runtime(_("{} Is Not Installed On The System"));
+    // For translators: the first {} is replaced by the effect name, the second {} is replaced by the package name.
+    auto format_descr = fmt::runtime(_("The software required for the {} effect, \"{}\", is not installed. Consider using the Easy Effects Flatpak package or installing the software yourself."));
 
     if (name == tags::plugin_name::rnnoise) {
+      // For translators: the first {} is replaced by the effect name, the second {} is replaced by the package name.
       format_descr =
-          fmt::runtime(_("{} RNNoise was not available when EasyEffects was compiled. Consider using a Flatpak package "
-                         "or building your own package."));
+          fmt::runtime(_("The {} effect was disabled when Easy Effects was compiled. This is perhaps since the software required for this effect, \"{}\", was not available. Consider using the Easy Effects Flatpak package or building your own Easy Effects package."));
     }
 
     const std::string translated_name = tags::plugin_name::get_translated().at(name);
 
     adw_status_page_set_title(ADW_STATUS_PAGE(status_page), fmt::format(format_title, translated_name).c_str());
-    adw_status_page_set_description(ADW_STATUS_PAGE(status_page), fmt::format(format_descr, package).c_str());
+    adw_status_page_set_description(ADW_STATUS_PAGE(status_page), fmt::format(format_descr, translated_name, package).c_str());
   } catch (...) {
   }
 

--- a/util/NEWS.yaml
+++ b/util/NEWS.yaml
@@ -11,6 +11,7 @@ Description:
 
 - Other notes∶
 - Speex is no longer incorrectly listed as a build dependency (speexdsp is still a build dependency)
+- RNNoise is no longer an autodependency. It is now required by default, if not available it must be explicitly disabled with -Denable-rnnoise=false
 
 ---
 Version: 7.0.3

--- a/util/NEWS.yaml
+++ b/util/NEWS.yaml
@@ -10,7 +10,7 @@ Description:
 - 
 
 - Other notes∶
-- 
+- Speex is no longer incorrectly listed as a build dependency (speexdsp is still a build dependency)
 
 ---
 Version: 7.0.3


### PR DESCRIPTION
It seems we can actually remove `speex` as a meson dependency and keep only `speexdsp` there. The `speex` package is not necessary for building, and from my fedora and flatpak testing it is not needed at runtime as well (unless I am missing something). 

Also RNNoise I realized was being setup as an auto dependency, which can be very confusing since the build will still work even if RNNoise is accidentally left out. Now it requires a meson option to disable. 