### PR TITLE
Publish help pages to GitHub pages

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -60,7 +60,7 @@ jobs:
         jq '.modules[0]."config-opts" += ["-Dwerror=true"]' util/flatpak/com.github.wwmm.easyeffects.Devel.json > "$updated_manifest"
         mv "$updated_manifest" util/flatpak/com.github.wwmm.easyeffects.Devel.json
 
-    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.1
       with:
         bundle: easyeffects-flatpak-${{ needs.prepare.outputs.github_commit_desc }}.flatpak
         manifest-path: util/flatpak/com.github.wwmm.easyeffects.Devel.json
@@ -138,15 +138,15 @@ jobs:
         source ./PKGBUILD && pacman -Syu --noconfirm --needed --asdeps "${makedepends[@]}" "${depends[@]}"
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v2.3.2
       with:
         languages: cpp # we don't use a matrix build (to analyze multiple lanaguages in parallel) as we are only analyzing c++
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v2.3.2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v2.3.2
 
   clang-tidy:
     name: Clang Tidy

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -161,6 +161,9 @@ jobs:
 
     - name: Install deps
       run: |
+        apk update
+        apk upgrade
+
         # install general build deps
         apk add meson clang clang-extra-tools build-base bash
 

--- a/.github/workflows/deploy-help.yaml
+++ b/.github/workflows/deploy-help.yaml
@@ -1,0 +1,49 @@
+name: Deploy help
+
+on:
+  # Runs on every push to a tag not containing a /
+  push:
+    tags:
+      - "*"
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy-help:
+    name: Deploy help
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.5.2
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3.0.6
+
+      - name: Build html help pages
+        run: |
+          sudo apt-get install -y yelp-tools
+          mkdir help/dist-html
+          yelp-build html -o help/dist-html help/C
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1.0.8
+        with:
+          path: help/dist-html
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2.0.1

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Easy Effects is designed assuming that your hardware stays as default.
 
 A comprehensive set of help pages are included in the application itself, accessed via the hamburger menu in the top right. If the help pages are inaccessible ensure the [yelp](https://gitlab.gnome.org/GNOME/yelp) package is installed.
 
-A comprehensive manual is included in the application itself, accessed via the hamburger menu in the top right. If the manual is inaccessible ensure the [yelp](https://gitlab.gnome.org/GNOME/yelp) package is installed.
+The latest version of the help pages can also be [seen here](https://wwmm.github.io/easyeffects).
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ If your distribution does not yet include packages required to build Easy Effect
 **Don't set** Easy Effects' virtual devices as your default audio input/output.
 Easy Effects is designed assuming that your hardware stays as default.
 
-## Documentation
+## Help
+
+A comprehensive set of help pages are included in the application itself, accessed via the hamburger menu in the top right. If the help pages are inaccessible ensure the [yelp](https://gitlab.gnome.org/GNOME/yelp) package is installed.
 
 A comprehensive manual is included in the application itself, accessed via the hamburger menu in the top right. If the manual is inaccessible ensure the [yelp](https://gitlab.gnome.org/GNOME/yelp) package is installed.
 

--- a/data/com.github.wwmm.easyeffects.metainfo.xml.in
+++ b/data/com.github.wwmm.easyeffects.metainfo.xml.in
@@ -28,12 +28,12 @@
   <launchable type="desktop-id">@APP_ID@.desktop</launchable>
   <url type="homepage">https://github.com/wwmm/easyeffects</url>
   <url type="bugtracker">https://github.com/wwmm/easyeffects/issues</url>
-  <url type="faq">https://github.com/wwmm/easyeffects#frequently-asked-questions</url>
+  <url type="faq">https://github.com/wwmm/easyeffects/wiki/FAQ</url>
   <url type="help">https://github.com/wwmm/easyeffects#documentation</url>
   <url type="donation">https://github.com/wwmm/easyeffects#donate</url>
-  <url type="translate">https://github.com/wwmm/easyeffects#translating-easy-effects</url>
+  <url type="translate">https://github.com/wwmm/easyeffects/wiki/Translating-EasyEffects</url>
   <url type="vcs-browser">https://github.com/wwmm/easyeffects</url>
-  <url type="contribute">https://github.com/wwmm/easyeffects#installing-from-source</url>
+  <url type="contribute">https://github.com/wwmm/easyeffects/wiki/Installation-from-Source</url>
   <translation type="gettext">Easy Effects</translation>
   <screenshots>
     <screenshot type="default">

--- a/data/com.github.wwmm.easyeffects.metainfo.xml.in
+++ b/data/com.github.wwmm.easyeffects.metainfo.xml.in
@@ -29,7 +29,7 @@
   <url type="homepage">https://github.com/wwmm/easyeffects</url>
   <url type="bugtracker">https://github.com/wwmm/easyeffects/issues</url>
   <url type="faq">https://github.com/wwmm/easyeffects/wiki/FAQ</url>
-  <url type="help">https://github.com/wwmm/easyeffects#documentation</url>
+  <url type="help">https://wwmm.github.io/easyeffects</url>
   <url type="donation">https://github.com/wwmm/easyeffects#donate</url>
   <url type="translate">https://github.com/wwmm/easyeffects/wiki/Translating-EasyEffects</url>
   <url type="vcs-browser">https://github.com/wwmm/easyeffects</url>

--- a/data/ui/application_window.ui
+++ b/data/ui/application_window.ui
@@ -3,7 +3,7 @@
     <menu id="primary_menu">
         <section>
             <item>
-                <attribute name="label" translatable="yes">_Manual</attribute>
+                <attribute name="label" translatable="yes">_Help</attribute>
                 <attribute name="action">app.help</attribute>
             </item>
         </section>

--- a/data/ui/shortcuts.ui
+++ b/data/ui/shortcuts.ui
@@ -13,7 +13,7 @@
                         <child>
                             <object class="GtkShortcutsShortcut">
                                 <property name="accelerator">F1</property>
-                                <property name="title" translatable="yes">Open the Easy Effects Manual</property>
+                                <property name="title" translatable="yes">Show help</property>
                             </object>
                         </child>
 

--- a/help/C/index.page
+++ b/help/C/index.page
@@ -9,6 +9,9 @@
     </info>
     <title>Easy Effects</title>
     <p>Easy Effects applies audio effects to applications managed by PipeWire. The user can apply effects to applications output or to the microphone before sending its audio to a recording application.</p>
+    <p>These are the Easy Effects help pages. Here you can find information concerning usage of the app, e.g. descriptions of each audio effect. Additional information beyond the scope of the app itself, e.g. how to build the app, is kept <link href="https://github.com/wwmm/easyeffects/wiki" its:translate="yes">in a seperate wiki</link>.</p>
+    <p>This documentation is available from within the app by clicking the Help button within the hamburger menu. This documentation is also <link href="https://wwmm.github.io/easyeffects" its:translate="yes">available online</link>.</p>
+    <p>Note the documentation within the app is offline and not automatically updated; it can only be updated by updating the app. The online documentation is automatically updated when a Easy Effects release is made, so it might be newer than the documentation within the app.</p>
     <section id="guides" style="2column">
         <title>Guides</title>
     </section>


### PR DESCRIPTION
Fixes https://github.com/wwmm/easyeffects/issues/2310

The pages are only published when a tag is pushed, but you can manually publish (after merging) by running the "run workflow" button here: https://github.com/wwmm/easyeffects/actions/workflows/deploy-help.yaml. Then the appstream check will be happy.

Note you will want to explicitly set GitHub Pages deployments source to GitHub Actions in repo settings, under Settings -> Pages -> Build and deployment -> Source. Before I changed this I saw in my repo it kept pointlessly trying to deploy the branch.

You will also want to change GitHub environment to allow any branch on this repo to push the help pages. In https://github.com/wwmm/easyeffects/settings/environments change the environment "github-pages" deployment branches to all branches. Otherwise when the action runs on a push to a tag it will not be allowed to publish its changes. You may need to run the workflow once manually before this setting shows up.

I also notably renamed Manual to Help which I think is more clear (and is what Gnome files/Nautilus does). 

Big picture ahead, I think some wiki pages (or at least parts of them) would be better suited in the (now more accessible) help pages. E.g. the command line page, and parts of FAQ. To me some of the information is directly relevant for usage of the app, the wiki in my mind is better suited for things more external to the app. 