### PR TITLE
Level Meter UI: use title-lines on AdwActionRow

### DIFF
--- a/data/ui/level_meter.ui
+++ b/data/ui/level_meter.ui
@@ -41,6 +41,7 @@
                                                 <child>
                                                     <object class="AdwActionRow">
                                                         <property name="title" translatable="yes">Left</property>
+                                                        <property name="title-lines">2</property>
                                                         <child>
                                                             <object class="GtkLabel" id="true_peak_left_label"></object>
                                                         </child>
@@ -50,6 +51,7 @@
                                                 <child>
                                                     <object class="AdwActionRow">
                                                         <property name="title" translatable="yes">Right</property>
+                                                        <property name="title-lines">2</property>
                                                         <child>
                                                             <object class="GtkLabel" id="true_peak_right_label"></object>
                                                         </child>


### PR DESCRIPTION
To avoid this when the window is shrinking:

![Schermata del 2023-05-18 18-01-32](https://github.com/wwmm/easyeffects/assets/25790525/3f42378d-b446-433b-83d4-84cebd383112)

This has to be taken in consideration also when porting the Autogain to libAdwaita widgets.