### PR TITLE
Level Meter UI: remove Reset button

### DIFF
--- a/data/schemas/com.github.wwmm.easyeffects.levelmeter.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.levelmeter.gschema.xml
@@ -4,8 +4,5 @@
         <key name="bypass" type="b">
             <default>false</default>
         </key>
-        <key name="reset-history" type="b">
-            <default>false</default>
-        </key>
     </schema>
 </schemalist>

--- a/data/ui/level_meter.ui
+++ b/data/ui/level_meter.ui
@@ -327,20 +327,6 @@
                                 <property name="hexpand">1</property>
                                 <property name="homogeneous">1</property>
 
-                                <!-- Empty placeholder used only for layout reason -->
-                                <child>
-                                    <object class="GtkLabel"> </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkButton" id="reset_button">
-                                        <property name="halign">center</property>
-                                        <property name="valign">center</property>
-                                        <property name="label" translatable="yes">Reset</property>
-                                        <signal name="clicked" handler="on_reset" object="LevelMeterBox" />
-                                    </object>
-                                </child>
-
                                 <child>
                                     <object class="GtkLabel" id="plugin_credit">
                                         <property name="halign">end</property>

--- a/include/level_meter.hpp
+++ b/include/level_meter.hpp
@@ -43,6 +43,8 @@ class LevelMeter : public PluginBase {
 
   auto get_latency_seconds() -> float override;
 
+  void reset_history();
+
   sigc::signal<void(const double,  // momentary
                     const double,  // shortterm
                     const double,  // integrated

--- a/src/level_meter_ui.cpp
+++ b/src/level_meter_ui.cpp
@@ -55,10 +55,6 @@ struct _LevelMeterBox {
 // NOLINTNEXTLINE
 G_DEFINE_TYPE(LevelMeterBox, level_meter_box, GTK_TYPE_BOX)
 
-void on_reset(LevelMeterBox* self, GtkButton* btn) {
-  util::reset_all_keys_except(self->settings);
-}
-
 void on_reset_history(LevelMeterBox* self, GtkButton* btn) {
   // Since there's no reason why someone would want to activate the reset-history
   // through a third party tool, we do not bind this action to a gsettings key
@@ -199,8 +195,6 @@ void level_meter_box_class_init(LevelMeterBoxClass* klass) {
   gtk_widget_class_bind_template_child(widget_class, LevelMeterBox, lra_label);
   gtk_widget_class_bind_template_child(widget_class, LevelMeterBox, true_peak_left_label);
   gtk_widget_class_bind_template_child(widget_class, LevelMeterBox, true_peak_right_label);
-
-  gtk_widget_class_bind_template_callback(widget_class, on_reset);
 
   gtk_widget_class_bind_template_callback(widget_class, on_reset_history);
 }

--- a/src/level_meter_ui.cpp
+++ b/src/level_meter_ui.cpp
@@ -60,10 +60,11 @@ void on_reset(LevelMeterBox* self, GtkButton* btn) {
 }
 
 void on_reset_history(LevelMeterBox* self, GtkButton* btn) {
-  // it is ugly but will ensure that third party tools are able to reset this plugin history
+  // Since there's no reason why someone would want to activate the reset-history
+  // through a third party tool, we do not bind this action to a gsettings key
+  // like it's done in the AutoGain.
 
-  g_settings_set_boolean(self->settings, "reset-history",
-                         static_cast<gboolean>(g_settings_get_boolean(self->settings, "reset-history") == 0));
+  self->data->level_meter->reset_history();
 }
 
 void setup(LevelMeterBox* self, std::shared_ptr<LevelMeter> level_meter, const std::string& schema_path) {

--- a/util/NEWS.yaml
+++ b/util/NEWS.yaml
@@ -2,28 +2,28 @@
 Version: UNRELEASED_VERSION
 Date: UNRELEASED_DATE
 
-Description: 
+Description:
 - Features∶
-- A new `Level Meter` plugin basedon `libebur128` has been added
-- The pitch plugin now uses the library SoundTouch instead of Rubberband. Hopefully some of the mysterious crashes
+- A new `Level Meter` plugin based on `libebur128` has been added.
+- The Pitch plugin now uses the library SoundTouch instead of Rubberband. Hopefully some of the mysterious crashes
 that were happening with Rubbernand are not going to happen anymore.
 
 - Bug fixes∶
-- 
+-
 
 - Other notes∶
-- 
+- Rabberband is not a dependency anymore since it has been replaced by SoundTouch.
 
 ---
 Version: 7.0.4
 Date: 2023-05-01
 
-Description: 
+Description:
 - Features∶
 - The presets menu now asks for confirmation before saving/deleting a preset file.
 
 - Bug fixes∶
-- The plugin reset should not make its controls innefective anymore. 
+- The plugin reset should not make its controls innefective anymore.
 
 - Other notes∶
 - Speex is no longer incorrectly listed as a build dependency (speexdsp is still a build dependency)
@@ -33,7 +33,7 @@ Description:
 Version: 7.0.3
 Date: 2023-04-06
 
-Description: 
+Description:
 - Features∶
 - Updated translations.
 


### PR DESCRIPTION
Fixes #2360 

- Removed the Reset button from UI
- Removed `reset-history` key from Gsettings
- News updated.