### PR TITLE
Check minimum PW version at startup

### DIFF
--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -232,7 +232,7 @@ class PipeManager {
 
   std::array<std::string, 2U> blocklist_media_role = {"event", "Notification"};
 
-  std::string header_version, library_version, core_name;
+  std::string header_version, library_version, core_name, version;
   std::string default_clock_rate = "0";
   std::string default_min_quantum = "0";
   std::string default_max_quantum = "0";

--- a/include/tags_app.hpp
+++ b/include/tags_app.hpp
@@ -23,6 +23,8 @@
 
 namespace tags::app {
 
+inline constexpr auto minimum_pw_version = "0.3.44";
+
 inline constexpr auto id = "com.github.wwmm.easyeffects";
 
 inline constexpr auto path = "/com/github/wwmm/easyeffects";

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -113,7 +113,7 @@ void reset_all_keys_except(GSettings* settings,
 
 auto str_contains(const std::string& haystack, const std::string& needle) -> bool;
 
-auto compare_versions(const std::string& v0, const std::string& v1) -> std::string;
+auto compare_versions(const std::string& v0, const std::string& v1) -> int;
 
 template <typename T>
 void print_type(T v) {

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -214,6 +214,25 @@ void on_startup(GApplication* gapp) {
   if ((g_application_get_flags(gapp) & G_APPLICATION_IS_SERVICE) != 0) {
     g_application_hold(gapp);
   }
+
+  // Debug check PipeWire minimum version
+  const auto comparison_result = util::compare_versions(self->pm->version, tags::app::minimum_pw_version);
+
+  switch (comparison_result) {
+    case 1:
+    case 0:
+      // Supported version. Nothing to show...
+      break;
+
+    case -1:
+      util::warning("PipeWire version " + self->pm->version + " is lower than " + tags::app::minimum_pw_version +
+                    " minimum supported.");
+      break;
+
+    default:
+      util::debug("Cannot check the current PipeWire version against the minimum supported.");
+      break;
+  }
 }
 
 void application_class_init(ApplicationClass* klass) {
@@ -396,7 +415,7 @@ void application_class_init(ApplicationClass* klass) {
     self->soe = nullptr;
     self->pm = nullptr;
 
-    util::debug("shutting down...");
+    util::debug("Shutting down...");
   };
 }
 

--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -1387,6 +1387,8 @@ void on_core_info(void* data, const struct pw_core_info* info) {
 
   pm->core_name = info->name;
 
+  pm->version = info->version;
+
   spa_dict_get_string(info->props, "default.clock.rate", pm->default_clock_rate);
 
   spa_dict_get_string(info->props, "default.clock.min-quantum", pm->default_min_quantum);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -385,7 +385,7 @@ auto compare_versions(const std::string& v0, const std::string& v1) -> std::stri
      two Pipewire versions.
      The format should adhere to what is defined at `https://semver.org/`.
      The additional extension label, if present, is ignored and fortunately
-     we don't need to look at it since Pipewire do not use it.
+     we don't need to look at it since Pipewire does not use it.
 
      Given two version strings v0 and v1, this util returns another string:
      - "0" if the versions are equal;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -380,19 +380,19 @@ auto str_contains(const std::string& haystack, const std::string& needle) -> boo
   return (haystack.find(needle) != std::string::npos);
 }
 
-auto compare_versions(const std::string& v0, const std::string& v1) -> std::string {
+auto compare_versions(const std::string& v0, const std::string& v1) -> int {
   /* This is an util to compare two strings as semver, mainly used to compare
      two Pipewire versions.
      The format should adhere to what is defined at `https://semver.org/`.
      The additional extension label, if present, is ignored and fortunately
      we don't need to look at it since Pipewire does not use it.
 
-     Given two version strings v0 and v1, this util returns another string:
-     - "0" if the versions are equal;
-     - "1" if v0 is higher than v1;
-     - "-1" if v0 is lower than v1;
-     - An empty string if the comparison fails (i.e. giving one or both strings
-       not respecting the semver format).
+     Given two version strings v0 and v1, this util returns an integer:
+     - 0 if the versions are equal;
+     - 1 if v0 is higher than v1;
+     - -1 if v0 is lower than v1;
+     - Whichever other number if the comparison fails (i.e. giving one or
+       both strings not respecting the semver format).
   */
 
   struct SemVer {
@@ -414,7 +414,7 @@ auto compare_versions(const std::string& v0, const std::string& v1) -> std::stri
 
     if (!std::regex_search(v[v_idx], match, re_semver)) {
       // The given string is not a semver: the comparison failed.
-      return "";
+      return 9;
     }
 
     // Submatches lookup
@@ -442,24 +442,24 @@ auto compare_versions(const std::string& v0, const std::string& v1) -> std::stri
 
   // Now that we are sure to have two valid semver, let's compare each part.
   if (sv[0].major < sv[1].major) {
-    return "-1";
+    return -1;
   } else if (sv[0].major > sv[1].major) {
-    return "1";
+    return 1;
   }
 
   if (sv[0].minor < sv[1].minor) {
-    return "-1";
+    return -1;
   } else if (sv[0].minor > sv[1].minor) {
-    return "1";
+    return 1;
   }
 
   if (sv[0].patch < sv[1].patch) {
-    return "-1";
+    return -1;
   } else if (sv[0].patch > sv[1].patch) {
-    return "1";
+    return 1;
   }
 
-  return "0";
+  return 0;
 }
 
 }  // namespace util


### PR DESCRIPTION
Related to #2327

Saves the version in PipeManager. Then hardcode the minimum supported PW version in app tags and make the comparison at startup.

This is only for debug. Testing it, I did not see the warning (correctly, since the version is higher).

To show a visual warning to the user, I still do not have a clue on how to do it.