### PR TITLE
Preparing for Community Presets

### DIFF
--- a/include/presets_manager.hpp
+++ b/include/presets_manager.hpp
@@ -135,8 +135,6 @@ class PresetsManager {
 
   std::filesystem::path user_presets_dir, user_input_dir, user_output_dir, autoload_input_dir, autoload_output_dir;
 
-  std::vector<std::filesystem::path> system_input_dir, system_output_dir;
-
   GSettings *settings = nullptr, *soe_settings = nullptr, *sie_settings = nullptr;
 
   GFileMonitor *user_output_monitor = nullptr, *user_input_monitor = nullptr;

--- a/include/tags_multiband_gate.hpp
+++ b/include/tags_multiband_gate.hpp
@@ -304,7 +304,6 @@ constexpr auto rt =
 constexpr auto gr =
     std::to_array({{"gr_0"}, {"gr_1"}, {"gr_2"}, {"gr_3"}, {"gr_4"}, {"gr_5"}, {"gr_6"}, std::to_array("gr_7")});
 
-// TODO
 constexpr auto mk =
     std::to_array({{"mk_0"}, {"mk_1"}, {"mk_2"}, {"mk_3"}, {"mk_4"}, {"mk_5"}, {"mk_6"}, std::to_array("mk_7")});
 

--- a/src/presets_menu.cpp
+++ b/src/presets_menu.cpp
@@ -120,15 +120,20 @@ void import_preset(PresetsMenu* self) {
 
   g_object_unref(filters);
 
-  gtk_file_dialog_open(
+  gtk_file_dialog_open_multiple(
       dialog, active_window, nullptr,
       +[](GObject* source_object, GAsyncResult* result, gpointer user_data) {
         auto* self = static_cast<PresetsMenu*>(user_data);
         auto* dialog = GTK_FILE_DIALOG(source_object);
 
-        auto* file = gtk_file_dialog_open_finish(dialog, result, nullptr);
+        auto* files_list = gtk_file_dialog_open_multiple_finish(dialog, result, nullptr);
 
-        if (file != nullptr) {
+        if (files_list == nullptr) {
+          return;
+        }
+
+        for (guint n = 0U; n < g_list_model_get_n_items(files_list); n++) {
+          auto* file = static_cast<GFile*>(g_list_model_get_item(files_list, n));
           auto* path = g_file_get_path(file);
 
           if constexpr (preset_type == PresetType::output) {
@@ -138,9 +143,9 @@ void import_preset(PresetsMenu* self) {
           }
 
           g_free(path);
-
-          g_object_unref(file);
         }
+
+        g_object_unref(files_list);
       },
       self);
 }

--- a/src/rnnoise_ui.cpp
+++ b/src/rnnoise_ui.cpp
@@ -148,22 +148,27 @@ void on_import_model_clicked(RNNoiseBox* self, GtkButton* btn) {
 
   g_object_unref(filters);
 
-  gtk_file_dialog_open(
+  gtk_file_dialog_open_multiple(
       dialog, active_window, nullptr,
       +[](GObject* source_object, GAsyncResult* result, gpointer user_data) {
         auto* dialog = GTK_FILE_DIALOG(source_object);
 
-        auto* file = gtk_file_dialog_open_finish(dialog, result, nullptr);
+        auto* files_list = gtk_file_dialog_open_multiple_finish(dialog, result, nullptr);
 
-        if (file != nullptr) {
+        if (files_list == nullptr) {
+          return;
+        }
+
+        for (guint n = 0U; n < g_list_model_get_n_items(files_list); n++) {
+          auto* file = static_cast<GFile*>(g_list_model_get_item(files_list, n));
           auto* path = g_file_get_path(file);
 
           import_model_file(path);
 
           g_free(path);
-
-          g_object_unref(file);
         }
+
+        g_object_unref(files_list);
       },
       self);
 }

--- a/util/NEWS.yaml
+++ b/util/NEWS.yaml
@@ -4,14 +4,14 @@ Date: UNRELEASED_DATE
 
 Description:
 - Features∶
-- The expander from Linux Studio Plugins can be used in EasyEffets.
-- The equalizer bands now have an additional gain control that allows for more efficient input of values that are hard to set in the scale. More details in issue 1383.
+- The Expander from Linux Studio Plugins can be used in EasyEffects.
+- The Equalizer bands now have an additional gain control that allows for more efficient input of values that are hard to set in the scale. More details in issue 1383.
 
 - Bug fixes∶
 -
 
 - Other notes∶
--
+- System folders under `/etc` have been deprecated in favor of a new location where Community Presets can be installed.
 
 ---
 Version: 7.0.6

--- a/util/NEWS.yaml
+++ b/util/NEWS.yaml
@@ -2,29 +2,29 @@
 Version: UNRELEASED_VERSION
 Date: UNRELEASED_DATE
 
-Description: 
+Description:
 - Features∶
 - The expander from Linux Studio Plugins can be used in EasyEffets.
-- The equalizer bands now have an additional gain control that allows for more efficient input of values that are hard to set in the scale. More details at #1383
+- The equalizer bands now have an additional gain control that allows for more efficient input of values that are hard to set in the scale. More details in issue 1383.
 
 - Bug fixes∶
-- 
+-
 
 - Other notes∶
-- 
+-
 
 ---
 Version: 7.0.6
 Date: 2023-07-28
 
-Description: 
+Description:
 - Features∶
 - An "Experimental Features" section was added to our preferences window.
 - The native window of the LSP plugins can be used. This is an experimental feature intended only for advanced users. So expect some bugs.
-- Fractional semitone values can now be used in the Pitch Shift effect. 
+- Fractional semitone values can now be used in the Pitch Shift effect.
 
 - Bug fixes∶
-- The input/output device dropdown in our PipeWire tab is updated when the system default device changes and `Use Default` is enabled. This fixes #1989
+- The input/output device dropdown in our PipeWire tab is updated when the system default device changes and `Use Default` is enabled. This fixes issue 1989.
 
 - Other notes∶
 


### PR DESCRIPTION
Implemented some of the changes suggested in #2445 

Old system folders have been removed and multiple selection has been implemented for file import in Presets menu, Convolver and RNNoise plugins.

It misses the setting of initial folder which can be done with the following: https://docs.gtk.org/gtk4/method.FileDialog.set_initial_folder.html

The problem is that I don't know where to pick the folder (which I suppose it has been declared in meson file?).

@wwmm Take a look also if there's some memory leak in the new system for multiple files import.

Fixed also the changelog that excludes the `#` since it's a character for writing comments. It seems there's no way to escape it in the current format, unless the double qouted strings are used, which is not our case because it seems we're using multilines strings.