### PR TITLE
include <numeric> for std::iota in convolver_menu_combine

### DIFF
--- a/include/convolver_menu_combine.hpp
+++ b/include/convolver_menu_combine.hpp
@@ -21,6 +21,7 @@
 
 #include <adwaita.h>
 #include <execution>
+#include <numeric>
 #include "convolver_ui_common.hpp"
 #include "resampler.hpp"
 #include "tags_resources.hpp"


### PR DESCRIPTION
specifically with clang+libc++:  

```
../src/convolver_menu_combine.cpp:69:8: error: no member named 'iota' in namespace 'std'
  std::iota(indices.begin(), indices.end(), 0U);
  ~~~~~^
1 error generated.
```