### PR TITLE
only use parallel stl with libcxx when available

### DIFF
--- a/src/convolver_menu_combine.cpp
+++ b/src/convolver_menu_combine.cpp
@@ -68,7 +68,7 @@ void direct_conv(const std::vector<float>& a, const std::vector<float>& b, std::
 
   std::iota(indices.begin(), indices.end(), 0U);
 
-  std::for_each(std::execution::par_unseq, indices.begin(), indices.end(), [&](const int n) {
+  auto each = [&](const int n) {
     c[n] = 0.0F;
 
     // Static cast to avoid gcc signedness warning.
@@ -81,7 +81,12 @@ void direct_conv(const std::vector<float>& a, const std::vector<float>& b, std::
         c[n] += b[m] * a[z];
       }
     }
-  });
+  };
+#if defined(ENABLE_LIBCPP_WORKAROUNDS) && (_LIBCPP_VERSION < 170000 || defined(_LIBCPP_HAS_NO_INCOMPLETE_PSTL))
+  std::for_each(indices.begin(), indices.end(), each);
+#else
+  std::for_each(std::execution::par_unseq, indices.begin(), indices.end(), each);
+#endif
 }
 
 void combine_kernels(ConvolverMenuCombine* self,


### PR DESCRIPTION
When using the libcxx workarounds option, switch off parallel for_each when using either LLVM older than 17 or when the incomplete pstl flag is set (which is when not using `-fxperimental` at this point). This is the last piece needed to make it build with libcxx.

Ref https://github.com/wwmm/easyeffects/issues/2535