### PR TITLE
chore: Disable clang tidy rule which is broken with libc++

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -52,6 +52,7 @@ Checks: 'bugprone-*,cert-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hi
   -readability-implicit-bool-conversion,
   -performance-inefficient-vector-operation,
   -readability-else-after-return,
+  -bugprone-exception-escape,
   '
 # todo, clang-analyzer-core.NullDereference is also suppressed in the code itself with NOLINT, consider fixing that too
 


### PR DESCRIPTION
I missed this in the last pr, but with libc++ for some reason clang tidy thinks structs are functions.

https://github.com/wwmm/easyeffects/actions/runs/5968770893/job/16193290930#step:8:799