### PR TITLE
Refine new controls of RNNoise

### DIFF
--- a/data/schemas/com.github.wwmm.easyeffects.rnnoise.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.rnnoise.gschema.xml
@@ -19,7 +19,7 @@
             <range min="0" max="100" />
             <default>95</default>
         </key>
-        <key name="wet-ratio" type="d">
+        <key name="wet" type="d">
             <range min="-100" max="20" />
             <default>0.0</default>
         </key>

--- a/data/ui/rnnoise.ui
+++ b/data/ui/rnnoise.ui
@@ -139,7 +139,7 @@
                                     <object class="GtkLabel">
                                         <property name="halign">center</property>
                                         <property name="valign">center</property>
-                                        <property name="label" translatable="yes">Wet Ratio</property>
+                                        <property name="label" translatable="yes">Wet Level</property>
                                         <layout>
                                             <property name="column">1</property>
                                             <property name="row">0</property>

--- a/data/ui/rnnoise.ui
+++ b/data/ui/rnnoise.ui
@@ -147,7 +147,7 @@
                                     </object>
                                 </child>
                                 <child>
-                                    <object class="GtkSpinButton" id="wet_ratio">
+                                    <object class="GtkSpinButton" id="wet">
                                         <property name="halign">center</property>
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>

--- a/include/echo_canceller.hpp
+++ b/include/echo_canceller.hpp
@@ -59,7 +59,7 @@ class EchoCanceller : public PluginBase {
   int residual_echo_suppression = -10;
   int near_end_suppression = -10;
 
-  const float inv_short_max = 1.0F / (SHRT_MAX + 1);
+  const float inv_short_max = 1.0F / (SHRT_MAX + 1.0F);
 
   std::vector<spx_int16_t> data_L;
   std::vector<spx_int16_t> data_R;
@@ -70,11 +70,9 @@ class EchoCanceller : public PluginBase {
   SpeexEchoState* echo_state_L = nullptr;
   SpeexEchoState* echo_state_R = nullptr;
 
-
   SpeexPreprocessState *state_left = nullptr, *state_right = nullptr;
 
   void free_speex();
-
 
   void init_speex();
 };

--- a/include/rnnoise.hpp
+++ b/include/rnnoise.hpp
@@ -65,9 +65,9 @@ class RNNoise : public PluginBase {
 
   float vad_thres = 0.95F;
   float wet_ratio = 1.0F;
-  uint release = 2;
+  uint release = 2U;
 
-  const float inv_short_max = 1.0F / (SHRT_MAX + 1);
+  const float inv_short_max = 1.0F / (SHRT_MAX + 1.0F);
 
   std::deque<float> deque_out_L, deque_out_R;
 
@@ -110,13 +110,13 @@ class RNNoise : public PluginBase {
           if (vad_grace_left >= 0) {
             --vad_grace_left;
 
-            for (size_t i = 0; i < data_L.size(); i++) {
-              data_L[i] = data_L[i] * wet_ratio + data_tmp[i] * (1 - wet_ratio);
+            for (size_t i = 0U; i < data_L.size(); i++) {
+              data_L[i] = data_L[i] * wet_ratio + data_tmp[i] * (1.0F - wet_ratio);
 
               data_L[i] *= inv_short_max;
             }
           } else {
-            std::ranges::for_each(data_L, [&](auto& v) { v = 0; });
+            std::ranges::for_each(data_L, [&](auto& v) { v = 0.0F; });
           }
         }
 
@@ -146,13 +146,13 @@ class RNNoise : public PluginBase {
           if (vad_grace_right >= 0) {
             --vad_grace_right;
 
-            for (size_t i = 0; i < data_R.size(); i++) {
-              data_R[i] = data_R[i] * wet_ratio + data_tmp[i] * (1 - wet_ratio);
+            for (size_t i = 0U; i < data_R.size(); i++) {
+              data_R[i] = data_R[i] * wet_ratio + data_tmp[i] * (1.0F - wet_ratio);
 
               data_R[i] *= inv_short_max;
             }
           } else {
-            std::ranges::for_each(data_R, [&](auto& v) { v = 0; });
+            std::ranges::for_each(data_R, [&](auto& v) { v = 0.0F; });
           }
         }
 

--- a/src/rnnoise_preset.cpp
+++ b/src/rnnoise_preset.cpp
@@ -37,7 +37,7 @@ void RNNoisePreset::save(nlohmann::json& json) {
 
   json[section][instance_name]["model-path"] = util::gsettings_get_string(settings, "model-path");
   json[section][instance_name]["vad-thres"] = g_settings_get_double(settings, "vad-thres");
-  json[section][instance_name]["wet-ratio"] = g_settings_get_double(settings, "wet-ratio");
+  json[section][instance_name]["wet"] = g_settings_get_double(settings, "wet");
   json[section][instance_name]["release"] = g_settings_get_double(settings, "release");
 }
 
@@ -50,6 +50,6 @@ void RNNoisePreset::load(const nlohmann::json& json) {
 
   update_key<gchar*>(json.at(section).at(instance_name), settings, "model-path", "model-path");
   update_key<double>(json.at(section).at(instance_name), settings, "vad-thres", "vad-thres");
-  update_key<double>(json.at(section).at(instance_name), settings, "wet-ratio", "wet-ratio");
+  update_key<double>(json.at(section).at(instance_name), settings, "wet", "wet");
   update_key<double>(json.at(section).at(instance_name), settings, "release", "release");
 }

--- a/src/rnnoise_ui.cpp
+++ b/src/rnnoise_ui.cpp
@@ -56,7 +56,7 @@ struct _RNNoiseBox {
 
   GtkScale *input_gain, *output_gain;
 
-  GtkSpinButton *vad_thres, *wet_ratio, *release;
+  GtkSpinButton *vad_thres, *wet, *release;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
 
@@ -251,8 +251,8 @@ void setup(RNNoiseBox* self,
   }));
 
   gtk_label_set_text(self->plugin_credit, ui::get_plugin_credit_translated(self->data->rnnoise->package).c_str());
-  gsettings_bind_widgets<"input-gain", "output-gain", "vad-thres", "wet-ratio", "release">(
-      self->settings, self->input_gain, self->output_gain, self->vad_thres, self->wet_ratio, self->release);
+  gsettings_bind_widgets<"input-gain", "output-gain", "vad-thres", "wet", "release">(
+      self->settings, self->input_gain, self->output_gain, self->vad_thres, self->wet, self->release);
 
   g_settings_bind_with_mapping(
       self->settings, "model-path", self->selection_model, "selected", G_SETTINGS_BIND_DEFAULT,
@@ -372,7 +372,7 @@ void rnnoise_box_class_init(RNNoiseBoxClass* klass) {
   gtk_widget_class_bind_template_child(widget_class, RNNoiseBox, plugin_credit);
 
   gtk_widget_class_bind_template_child(widget_class, RNNoiseBox, vad_thres);
-  gtk_widget_class_bind_template_child(widget_class, RNNoiseBox, wet_ratio);
+  gtk_widget_class_bind_template_child(widget_class, RNNoiseBox, wet);
   gtk_widget_class_bind_template_child(widget_class, RNNoiseBox, release);
 
   gtk_widget_class_bind_template_child(widget_class, RNNoiseBox, string_list);
@@ -400,7 +400,8 @@ void rnnoise_box_init(RNNoiseBox* self) {
 
   prepare_spinbutton<"%">(self->vad_thres);
 
-  prepare_spinbutton<"dB">(self->wet_ratio);
+  // The following spinbuttons can assume -inf
+  prepare_spinbuttons<"dB", false>(self->wet);
 
   // model dir
 

--- a/src/stereo_tools.cpp
+++ b/src/stereo_tools.cpp
@@ -64,19 +64,19 @@ StereoTools::StereoTools(const std::string& tag,
 
   lv2_wrapper->bind_key_enum<"mode", "mode">(settings);
 
-  auto key_v = g_settings_get_double(settings, "dry");
+  const auto key_dry = g_settings_get_double(settings, "dry");
 
-  dry = (key_v <= util::minimum_db_d_level) ? 0.0F : static_cast<float>(util::db_to_linear(key_v));
+  dry = (key_dry <= util::minimum_db_d_level) ? 0.0F : static_cast<float>(util::db_to_linear(key_dry));
 
-  key_v = g_settings_get_double(settings, "wet");
+  const auto key_wet = g_settings_get_double(settings, "wet");
 
-  wet = (key_v <= util::minimum_db_d_level) ? 0.0F : static_cast<float>(util::db_to_linear(key_v));
+  wet = (key_wet <= util::minimum_db_d_level) ? 0.0F : static_cast<float>(util::db_to_linear(key_wet));
 
   gconnections.push_back(g_signal_connect(
       settings, "changed::dry", G_CALLBACK(+[](GSettings* settings, char* key, gpointer user_data) {
         auto* self = static_cast<StereoTools*>(user_data);
 
-        auto key_v = g_settings_get_double(settings, key);
+        const auto key_v = g_settings_get_double(settings, key);
 
         self->dry = (key_v <= util::minimum_db_d_level) ? 0.0F : static_cast<float>(util::db_to_linear(key_v));
       }),
@@ -86,7 +86,7 @@ StereoTools::StereoTools(const std::string& tag,
       settings, "changed::wet", G_CALLBACK(+[](GSettings* settings, char* key, gpointer user_data) {
         auto* self = static_cast<StereoTools*>(user_data);
 
-        auto key_v = g_settings_get_double(settings, key);
+        const auto key_v = g_settings_get_double(settings, key);
 
         self->wet = (key_v <= util::minimum_db_d_level) ? 0.0F : static_cast<float>(util::db_to_linear(key_v));
       }),

--- a/util/NEWS.yaml
+++ b/util/NEWS.yaml
@@ -5,6 +5,8 @@ Date: UNRELEASED_DATE
 Description:
 - Features∶
 - The Filter effect has been improved with new parameters since it has been ported from Calf Studio to Linux Studio Plugins.
+- Noise reduction by RNNoise has been improved with the addition of Release and VAD Threshold controls.
+- Noise reduction by RNNoise can now mix the original and denoised signals to avoid the output to sound too "dry".  
 
 - Bug fixes∶
 -


### PR DESCRIPTION
Related to #2556 

- Align RNNoise Wet label to other plugins (this avoids useless extra translations)
- Show `-inf` for RNNoise Wet control
- Tried to reduce implicit conversions on new variables
- Changelog updated

In UI side, there's a visual issue on screens with low height. I will show it in the related tocket. 