### PR TITLE
[QoL] Change NoiseReduction threshold from 95% to 0%

### DIFF
--- a/data/ui/rnnoise.ui
+++ b/data/ui/rnnoise.ui
@@ -73,7 +73,7 @@
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">0</property>
                                                                 <property name="upper">100</property>
-                                                                <property name="value">95</property>
+                                                                <property name="value">0</property>
                                                                 <property name="step-increment">1</property>
                                                                 <property name="page-increment">10</property>
                                                             </object>

--- a/include/rnnoise.hpp
+++ b/include/rnnoise.hpp
@@ -66,7 +66,7 @@ class RNNoise : public PluginBase {
   uint rnnoise_rate = 48000U;
   uint latency_n_frames = 0U;
 
-  float vad_thres = 0.95F;
+  float vad_thres = 0.0F;
   float wet_ratio = 1.0F;
   uint release = 2U;
 


### PR DESCRIPTION
Based on #2572

The 95% threshold is too strong. It chops voice inside a room with minimal noise levels while using a Scarlett Solo and a Condenser Microphone. The degree of chopping did not allow for single word sentences, such in saying: 'Hey', 'Wow', etc.

0% resets to the previous behavior before the reimplementation. This only affects the default value and users can set to 95% manually.
