### PR TITLE
DeepFilterNet fixes

### DIFF
--- a/include/deepfilternet.hpp
+++ b/include/deepfilternet.hpp
@@ -52,4 +52,5 @@ class DeepFilterNet : public PluginBase {
   std::unique_ptr<Resampler> resampler_inL, resampler_outL;
   std::unique_ptr<Resampler> resampler_inR, resampler_outR;
   std::vector<float> resampled_outL, resampled_outR;
+  std::vector<float> carryover_l, carryover_r;
 };

--- a/include/deepfilternet.hpp
+++ b/include/deepfilternet.hpp
@@ -48,6 +48,7 @@ class DeepFilterNet : public PluginBase {
   std::unique_ptr<ladspa::LadspaWrapper> ladspa_wrapper;
 
   bool resample = false;
+  bool resampler_ready = true;
   std::unique_ptr<Resampler> resampler_inL, resampler_outL;
   std::unique_ptr<Resampler> resampler_inR, resampler_outR;
   std::vector<float> resampled_outL, resampled_outR;

--- a/include/ladspa_wrapper.hpp
+++ b/include/ladspa_wrapper.hpp
@@ -214,12 +214,12 @@ class LadspaWrapper {
   LADSPA_Handle instance = nullptr;
 
   bool found = false;
-  bool control_ports_initialized = false;
   bool active = false;
 
   uint rate = 0U;
 
   LADSPA_Data* control_ports = nullptr;
+  bool* control_ports_initialized = nullptr;
 
   std::unordered_map<std::string, unsigned long> map_cp_name_to_idx = std::unordered_map<std::string, unsigned long>();
 };

--- a/include/resampler.hpp
+++ b/include/resampler.hpp
@@ -34,7 +34,7 @@ class Resampler {
   ~Resampler();
 
   template <typename T>
-  auto process(const T& input, const bool& end_of_input) -> std::vector<float> {
+  auto process(const T& input, const bool& end_of_input) -> const std::vector<float>& {
     output.resize(std::ceil(1.5 * resample_ratio * input.size()));
 
     // The number of frames of data pointed to by data_in

--- a/include/resampler.hpp
+++ b/include/resampler.hpp
@@ -35,7 +35,7 @@ class Resampler {
 
   template <typename T>
   auto process(const T& input, const bool& end_of_input) -> std::vector<float> {
-    output.resize(std::ceil(1.5F * resample_ratio * input.size()));
+    output.resize(std::ceil(1.5 * resample_ratio * input.size()));
 
     // The number of frames of data pointed to by data_in
     src_data.input_frames = input.size();
@@ -63,7 +63,7 @@ class Resampler {
   }
 
  private:
-  float resample_ratio = 1.0F;
+  double resample_ratio = 1.0;
 
   SRC_STATE* src_state = nullptr;
 

--- a/src/deepfilternet.cpp
+++ b/src/deepfilternet.cpp
@@ -78,6 +78,7 @@ void DeepFilterNet::setup() {
 
   util::idle_add([&, this] {
     ladspa_wrapper->n_samples = n_samples;
+    std::scoped_lock<std::mutex> lock(data_mutex);
 
     if (ladspa_wrapper->get_rate() != 48000) {
       ladspa_wrapper->create_instance(48000);

--- a/src/deepfilternet.cpp
+++ b/src/deepfilternet.cpp
@@ -129,6 +129,9 @@ void DeepFilterNet::process(std::span<float>& left_in,
   if (resample) {
     const auto& resampled_inL = resampler_inL->process(left_in, false);
     const auto& resampled_inR = resampler_inR->process(right_in, false);
+    resampled_outL.resize(resampled_inL.size());
+    resampled_outR.resize(resampled_inR.size());
+    ladspa_wrapper->n_samples = resampled_inL.size();
     ladspa_wrapper->connect_data_ports(resampled_inL, resampled_inR, resampled_outL, resampled_outR);
   } else {
     ladspa_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);

--- a/src/deepfilternet.cpp
+++ b/src/deepfilternet.cpp
@@ -32,7 +32,7 @@ DeepFilterNet::DeepFilterNet(const std::string& tag,
                  schema,
                  schema_path,
                  pipe_manager), ladspa_wrapper(), resampler_inL(), resampler_outL(), resampler_inR(), resampler_outR(),
-      resampled_outL(), resampled_outR() {
+      resampled_outL(), resampled_outR(), carryover_l(), carryover_r() {
   ladspa_wrapper = std::make_unique<ladspa::LadspaWrapper>("libdeep_filter_ladspa.so", "deep_filter_stereo");
 
   package_installed = ladspa_wrapper->found_plugin();
@@ -104,6 +104,13 @@ void DeepFilterNet::setup() {
       resampler_outL->process(resampled_inL, false);
       resampler_outR->process(resampled_inR, false);
 
+      carryover_l.clear();
+      carryover_r.clear();
+      carryover_l.reserve(4); // chosen by fair dice roll.
+      carryover_r.reserve(4); // guaranteed to be random.
+      carryover_l.push_back(0.0F);
+      carryover_r.push_back(0.0F);
+
       resampler_ready = true;
     }
   });
@@ -142,8 +149,24 @@ void DeepFilterNet::process(std::span<float>& left_in,
   if (resample) {
     const auto& outL = resampler_outL->process(resampled_outL, false);
     const auto& outR = resampler_outR->process(resampled_outR, false);
-    std::copy(outL.begin(), outL.begin() + std::min(outL.size(), left_out.size()), left_out.begin());
-    std::copy(outR.begin(), outR.begin() + std::min(outR.size(), right_out.size()), right_out.begin());
+    auto carryover_end_l = std::min(carryover_l.size(), left_out.size());
+    auto carryover_end_r = std::min(carryover_r.size(), right_out.size());
+    auto left_offset = carryover_end_l + outL.size() > left_out.size() ? carryover_end_l : left_out.size() - outL.size();
+    auto right_offset = carryover_end_r + outR.size() > right_out.size() ? carryover_end_r : right_out.size() - outR.size();
+    auto left_count = std::min(outL.size(), left_out.size() - left_offset);
+    auto right_count = std::min(outR.size(), right_out.size() - right_offset);
+    std::copy(carryover_l.begin(), carryover_l.begin() + carryover_end_l, left_out.begin());
+    std::copy(carryover_r.begin(), carryover_r.begin() + carryover_end_r, right_out.begin());
+    carryover_l.erase(carryover_l.begin(), carryover_l.begin() + carryover_end_l);
+    carryover_r.erase(carryover_r.begin(), carryover_r.begin() + carryover_end_r);
+    std::fill(left_out.begin() + carryover_end_l, left_out.begin() + left_offset, 0);
+    std::fill(right_out.begin() + carryover_end_r, right_out.begin() + right_offset, 0);
+    std::copy(outL.begin(), outL.begin() + left_count, left_out.begin() + left_offset);
+    std::copy(outR.begin(), outR.begin() + right_count, right_out.begin() + right_offset);
+    carryover_l.insert(carryover_l.end(), outL.begin() + left_count, outL.end());
+    carryover_r.insert(carryover_r.end(), outR.begin() + right_count, outR.end());
+    std::fill(left_out.begin() + left_offset + left_count, left_out.end(), 0);
+    std::fill(right_out.begin() + right_offset + right_count, right_out.end(), 0);
   }
 
   if (output_gain != 1.0F) {
@@ -160,5 +183,5 @@ void DeepFilterNet::process(std::span<float>& left_in,
 }
 
 auto DeepFilterNet::get_latency_seconds() -> float {
-  return 0.02F;
+  return 0.02F + 1.0F / rate;
 }

--- a/src/deepfilternet.cpp
+++ b/src/deepfilternet.cpp
@@ -152,5 +152,5 @@ void DeepFilterNet::process(std::span<float>& left_in,
 }
 
 auto DeepFilterNet::get_latency_seconds() -> float {
-  return 0.2F;
+  return 0.02F;
 }

--- a/src/deepfilternet.cpp
+++ b/src/deepfilternet.cpp
@@ -127,8 +127,8 @@ void DeepFilterNet::process(std::span<float>& left_in,
   }
 
   if (resample) {
-    const auto resampled_inL = resampler_inL->process(left_in, false);
-    const auto resampled_inR = resampler_inR->process(right_in, false);
+    const auto& resampled_inL = resampler_inL->process(left_in, false);
+    const auto& resampled_inR = resampler_inR->process(right_in, false);
     ladspa_wrapper->connect_data_ports(resampled_inL, resampled_inR, resampled_outL, resampled_outR);
   } else {
     ladspa_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
@@ -137,8 +137,8 @@ void DeepFilterNet::process(std::span<float>& left_in,
   ladspa_wrapper->run();
 
   if (resample) {
-    const auto outL = resampler_outL->process(resampled_outL, false);
-    const auto outR = resampler_outR->process(resampled_outR, false);
+    const auto& outL = resampler_outL->process(resampled_outL, false);
+    const auto& outR = resampler_outR->process(resampled_outR, false);
     std::copy(outL.begin(), outL.begin() + std::min(outL.size(), left_out.size()), left_out.begin());
     std::copy(outR.begin(), outR.begin() + std::min(outR.size(), right_out.size()), right_out.begin());
   }

--- a/src/deepfilternet.cpp
+++ b/src/deepfilternet.cpp
@@ -31,7 +31,8 @@ DeepFilterNet::DeepFilterNet(const std::string& tag,
                  tags::plugin_package::deepfilternet,
                  schema,
                  schema_path,
-                 pipe_manager) {
+                 pipe_manager), ladspa_wrapper(), resampler_inL(), resampler_outL(), resampler_inR(), resampler_outR(),
+      resampled_outL(), resampled_outR() {
   ladspa_wrapper = std::make_unique<ladspa::LadspaWrapper>("libdeep_filter_ladspa.so", "deep_filter_stereo");
 
   package_installed = ladspa_wrapper->found_plugin();

--- a/src/resampler.cpp
+++ b/src/resampler.cpp
@@ -20,7 +20,7 @@
 #include "resampler.hpp"
 
 Resampler::Resampler(const int& input_rate, const int& output_rate) : output(1, 0) {
-  resample_ratio = static_cast<float>(output_rate) / static_cast<float>(input_rate);
+  resample_ratio = static_cast<double>(output_rate) / static_cast<double>(input_rate);
 
   src_state = src_new(SRC_SINC_FASTEST, 1, nullptr);
 }


### PR DESCRIPTION
- Fixes loading of control port values of LADSPA plugins when they are instantiated after some control ports have already been set.
- Fixes distorted, clicking, or otherwise mangled audio from DeepFilterNet effect.
- Some other stability fixes and minor improvements.