### PR TITLE
Build and CI fixes

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -219,8 +219,8 @@ jobs:
         git checkout bd1620a8609ddaf2f64500820abc8b4d150edeaf # v1.1.0
         ./install-user-client
 
-    - name: Cache Clang Tidy
-      uses: actions/cache@v3.3.2
+    - name: Restore Clang Tidy cache
+      uses: actions/cache/restore@v3.3.2
       with:
         # since the ctcache is just a list of checksums that were checked, we want to write to it every ci run to keep it up to date
         # otherwise github actions just restores some old cache if the key didn't change
@@ -241,6 +241,15 @@ jobs:
       run: |
         cd build
         PATH=~/.local/bin:"$PATH" CTCACHE_DIR=/tmp/ci-ctcache ../util/clang-tidy.sh
+
+    - name: Save Clang Tidy cache
+      uses: actions/cache/save@v3.3.2
+      # always run, except if the workflow was cancelled
+      # this means clang tidy will get cached even if some checks are failing
+      if: success() || failure()
+      with:
+        path: /tmp/ci-ctcache
+        key: clang-tidy-ctcache-${{ github.run_id }}
 
   appstream-news-validate:
     name: AppStream and News validate

--- a/meson.build
+++ b/meson.build
@@ -65,7 +65,8 @@ endif
 if get_option('enable-mold')
   # mold 1.11.0 or later needed due to https://github.com/rui314/mold/issues/1017
   status += 'Using mold linker, so make sure mold 1.11.0 or later is installed on your system.'
-  link_args = ['-fuse-ld=mold']
+  # --no-as-needed temporarily necessary due to the seeming return of https://github.com/rui314/mold/issues/1017
+  link_args = ['-fuse-ld=mold', '-Wl,--no-as-needed']
 else
   link_args = []
 endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -128,6 +128,15 @@ easyeffects_sources = [
 	gresources
 ]
 
+cc = meson.get_compiler('c')
+
+# apparantly this is not available as a standard dependency
+have_ladspa = cc.has_header('ladspa.h')
+
+if not have_ladspa
+	error('Dependency "ladspa" not found, tried looking for ladspa.h')
+endif
+
 cxx = meson.get_compiler('cpp')
 
 zita_convolver = cxx.find_library('zita-convolver', required: true)


### PR DESCRIPTION
Fix flatpak CI build with mold workaround.

Also adjust clang tidy workflow so it caches even if the workflow fails.

Also throw in a fix to require ladspa with meson.