### PR TITLE
Add Equal Mode to Filter, fix RRNoise UI and Ladspa Wrapper refactoring

### DIFF
--- a/data/schemas/com.github.wwmm.easyeffects.filter.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.filter.gschema.xml
@@ -13,6 +13,12 @@
         <value nick="Ladder-rejection" value="9" />
         <value nick="Allpass" value="10" />
     </enum>
+    <enum id="com.github.wwmm.easyeffects.filter.equalmode.enum">
+        <value nick="IIR" value="0" />
+        <value nick="FIR" value="1" />
+        <value nick="FFT" value="2" />
+        <value nick="SPM" value="3" />
+    </enum>
     <enum id="com.github.wwmm.easyeffects.filter.mode.enum">
         <value nick="RLC (BT)" value="0" />
         <value nick="RLC (MT)" value="1" />
@@ -69,6 +75,9 @@
         </key>
         <key name="mode" enum="com.github.wwmm.easyeffects.filter.mode.enum">
             <default>"RLC (BT)"</default>
+        </key>
+        <key name="equal-mode" enum="com.github.wwmm.easyeffects.filter.equalmode.enum">
+            <default>"IIR"</default>
         </key>
         <key name="slope" enum="com.github.wwmm.easyeffects.filter.slope.enum">
             <default>"x1"</default>

--- a/data/ui/equalizer.ui
+++ b/data/ui/equalizer.ui
@@ -72,10 +72,10 @@
                                         <property name="model">
                                             <object class="GtkStringList">
                                                 <items>
-                                                    <item translatable="yes">IIR</item>
-                                                    <item translatable="yes">FIR</item>
-                                                    <item translatable="yes">FFT</item>
-                                                    <item translatable="yes">SPM</item>
+                                                    <item>IIR</item>
+                                                    <item>FIR</item>
+                                                    <item>FFT</item>
+                                                    <item>SPM</item>
                                                 </items>
                                             </object>
                                         </property>

--- a/data/ui/filter.ui
+++ b/data/ui/filter.ui
@@ -92,6 +92,30 @@
 
                                         <child>
                                             <object class="AdwActionRow">
+                                                <property name="title" translatable="yes">Equalizer Mode</property>
+                                                <child>
+                                                    <object class="GtkDropDown" id="equalizer_mode">
+                                                        <property name="valign">center</property>
+                                                        <property name="model">
+                                                            <object class="GtkStringList">
+                                                                <items>
+                                                                    <item>IIR</item>
+                                                                    <item>FIR</item>
+                                                                    <item>FFT</item>
+                                                                    <item>SPM</item>
+                                                                </items>
+                                                            </object>
+                                                        </property>
+                                                        <accessibility>
+                                                            <property name="label">Equalizer Mode</property>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
+
+                                        <child>
+                                            <object class="AdwActionRow">
                                                 <property name="title" translatable="yes">Slope</property>
                                                 <child>
                                                     <object class="GtkDropDown" id="slope">

--- a/data/ui/rnnoise.ui
+++ b/data/ui/rnnoise.ui
@@ -37,6 +37,8 @@
 
                         <child>
                             <object class="GtkBox">
+                                <property name="margin-start">6</property>
+                                <property name="margin-end">6</property>
                                 <property name="spacing">24</property>
                                 <property name="homogeneous">1</property>
 
@@ -147,7 +149,11 @@
                                         <property name="spacing">12</property>
                                         <child>
                                             <object class="GtkLabel">
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Models</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
                                             </object>
                                         </child>
 

--- a/include/ladspa_wrapper.hpp
+++ b/include/ladspa_wrapper.hpp
@@ -162,11 +162,9 @@ class LadspaWrapper {
 
   template <StringLiteralWrapper key_wrapper, StringLiteralWrapper gkey_wrapper, bool lower_bound = true>
   void bind_key_double_db_exponential(GSettings* settings) {
-    auto key_v = g_settings_get_double(settings, gkey_wrapper.msg.data());
+    auto val = static_cast<float>(g_settings_get_double(settings, gkey_wrapper.msg.data()));
 
-    auto val = static_cast<float>(key_v);
-
-    auto clamped = (!lower_bound && key_v <= util::minimum_db_d_level) ? -std::numeric_limits<float>::infinity() : val;
+    auto clamped = (!lower_bound && val <= util::minimum_db_level) ? -std::numeric_limits<float>::infinity() : val;
 
     float new_v = set_control_port_value_clamp(key_wrapper.msg.data(), clamped);
 
@@ -178,11 +176,9 @@ class LadspaWrapper {
                      G_CALLBACK(+[](GSettings* settings, char* key, gpointer user_data) {
                        auto* self = static_cast<LadspaWrapper*>(user_data);
 
-                       auto key_v = g_settings_get_double(settings, gkey_wrapper.msg.data());
+                       auto val = static_cast<float>(g_settings_get_double(settings, gkey_wrapper.msg.data()));
 
-                       auto val = static_cast<float>(key_v);
-
-                       auto clamped = (!lower_bound && key_v <= util::minimum_db_d_level)
+                       auto clamped = (!lower_bound && val <= util::minimum_db_level)
                                           ? -std::numeric_limits<float>::infinity()
                                           : val;
 
@@ -196,11 +192,9 @@ class LadspaWrapper {
 
   template <StringLiteralWrapper key_wrapper, StringLiteralWrapper gkey_wrapper, bool lower_bound = true>
   void bind_key_double_db(GSettings* settings) {
-    auto key_v = g_settings_get_double(settings, gkey_wrapper.msg.data());
+    auto linear_v = static_cast<float>(util::db_to_linear(g_settings_get_double(settings, gkey_wrapper.msg.data())));
 
-    auto linear_v = static_cast<float>(util::db_to_linear(key_v));
-
-    auto clamped_v = (!lower_bound && linear_v <= util::minimum_db_d_level) ? 0.0F : linear_v;
+    auto clamped_v = (!lower_bound && linear_v <= util::minimum_db_level) ? 0.0F : linear_v;
 
     float new_v = set_control_port_value_clamp(key_wrapper.msg.data(), clamped_v);
 
@@ -212,11 +206,10 @@ class LadspaWrapper {
                      G_CALLBACK(+[](GSettings* settings, char* key, gpointer user_data) {
                        auto* self = static_cast<LadspaWrapper*>(user_data);
 
-                       auto key_v = g_settings_get_double(settings, gkey_wrapper.msg.data());
+                       auto linear_v = static_cast<float>(
+                           util::db_to_linear(g_settings_get_double(settings, gkey_wrapper.msg.data())));
 
-                       auto linear_v = static_cast<float>(util::db_to_linear(key_v));
-
-                       auto clamped_v = (!lower_bound && key_v <= util::minimum_db_d_level) ? 0.0F : linear_v;
+                       auto clamped_v = (!lower_bound && linear_v <= util::minimum_db_level) ? 0.0F : linear_v;
 
                        float new_v = self->set_control_port_value_clamp(key_wrapper.msg.data(), clamped_v);
 

--- a/include/ladspa_wrapper.hpp
+++ b/include/ladspa_wrapper.hpp
@@ -93,7 +93,7 @@ class LadspaWrapper {
       value = static_cast<float>(g_settings_get_enum(settings, gkey));
     }
 
-    float actual_value = set_control_port_value_clamp(port_name, value);
+    const auto actual_value = set_control_port_value_clamp(port_name, value);
 
     if (actual_value != value && !(std::isnan(actual_value) && std::isnan(value))) {
       if constexpr (std::is_same_v<T, double>) {
@@ -162,11 +162,12 @@ class LadspaWrapper {
 
   template <StringLiteralWrapper key_wrapper, StringLiteralWrapper gkey_wrapper, bool lower_bound = true>
   void bind_key_double_db_exponential(GSettings* settings) {
-    auto val = static_cast<float>(g_settings_get_double(settings, gkey_wrapper.msg.data()));
+    const auto val = static_cast<float>(g_settings_get_double(settings, gkey_wrapper.msg.data()));
 
-    auto clamped = (!lower_bound && val <= util::minimum_db_level) ? -std::numeric_limits<float>::infinity() : val;
+    const auto clamped =
+        (!lower_bound && val <= util::minimum_db_level) ? -std::numeric_limits<float>::infinity() : val;
 
-    float new_v = set_control_port_value_clamp(key_wrapper.msg.data(), clamped);
+    const auto new_v = set_control_port_value_clamp(key_wrapper.msg.data(), clamped);
 
     if (new_v != clamped && !(std::isnan(new_v) && std::isnan(clamped))) {
       g_settings_set_double(settings, gkey_wrapper.msg.data(), new_v);
@@ -176,13 +177,13 @@ class LadspaWrapper {
                      G_CALLBACK(+[](GSettings* settings, char* key, gpointer user_data) {
                        auto* self = static_cast<LadspaWrapper*>(user_data);
 
-                       auto val = static_cast<float>(g_settings_get_double(settings, gkey_wrapper.msg.data()));
+                       const auto val = static_cast<float>(g_settings_get_double(settings, gkey_wrapper.msg.data()));
 
-                       auto clamped = (!lower_bound && val <= util::minimum_db_level)
-                                          ? -std::numeric_limits<float>::infinity()
-                                          : val;
+                       const auto clamped = (!lower_bound && val <= util::minimum_db_level)
+                                                ? -std::numeric_limits<float>::infinity()
+                                                : val;
 
-                       float new_v = self->set_control_port_value_clamp(key_wrapper.msg.data(), clamped);
+                       const auto new_v = self->set_control_port_value_clamp(key_wrapper.msg.data(), clamped);
 
                        if (new_v != clamped && !(std::isnan(new_v) && std::isnan(clamped)))
                          g_settings_set_double(settings, gkey_wrapper.msg.data(), new_v);
@@ -192,11 +193,12 @@ class LadspaWrapper {
 
   template <StringLiteralWrapper key_wrapper, StringLiteralWrapper gkey_wrapper, bool lower_bound = true>
   void bind_key_double_db(GSettings* settings) {
-    auto linear_v = static_cast<float>(util::db_to_linear(g_settings_get_double(settings, gkey_wrapper.msg.data())));
+    const auto linear_v =
+        static_cast<float>(util::db_to_linear(g_settings_get_double(settings, gkey_wrapper.msg.data())));
 
-    auto clamped_v = (!lower_bound && linear_v <= util::minimum_db_level) ? 0.0F : linear_v;
+    const auto clamped_v = (!lower_bound && linear_v <= util::minimum_db_level) ? 0.0F : linear_v;
 
-    float new_v = set_control_port_value_clamp(key_wrapper.msg.data(), clamped_v);
+    const auto new_v = set_control_port_value_clamp(key_wrapper.msg.data(), clamped_v);
 
     if (new_v != clamped_v && !(std::isnan(new_v) && std::isnan(clamped_v))) {
       g_settings_set_double(settings, gkey_wrapper.msg.data(), util::linear_to_db(new_v));
@@ -206,12 +208,12 @@ class LadspaWrapper {
                      G_CALLBACK(+[](GSettings* settings, char* key, gpointer user_data) {
                        auto* self = static_cast<LadspaWrapper*>(user_data);
 
-                       auto linear_v = static_cast<float>(
+                       const auto linear_v = static_cast<float>(
                            util::db_to_linear(g_settings_get_double(settings, gkey_wrapper.msg.data())));
 
-                       auto clamped_v = (!lower_bound && linear_v <= util::minimum_db_level) ? 0.0F : linear_v;
+                       const auto clamped_v = (!lower_bound && linear_v <= util::minimum_db_level) ? 0.0F : linear_v;
 
-                       float new_v = self->set_control_port_value_clamp(key_wrapper.msg.data(), clamped_v);
+                       const auto new_v = self->set_control_port_value_clamp(key_wrapper.msg.data(), clamped_v);
 
                        if (new_v != clamped_v && !(std::isnan(new_v) && std::isnan(clamped_v)))
                          g_settings_set_double(settings, gkey_wrapper.msg.data(), util::linear_to_db(new_v));

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -46,6 +46,8 @@ Filter::Filter(const std::string& tag,
 
   lv2_wrapper->bind_key_enum<"fm", "mode">(settings);
 
+  lv2_wrapper->bind_key_enum<"mode", "equal-mode">(settings);
+
   lv2_wrapper->bind_key_enum<"s", "slope">(settings);
 
   setup_input_output_gain();

--- a/src/filter_preset.cpp
+++ b/src/filter_preset.cpp
@@ -49,6 +49,8 @@ void FilterPreset::save(nlohmann::json& json) {
 
   json[section][instance_name]["mode"] = util::gsettings_get_string(settings, "mode");
 
+  json[section][instance_name]["equal-mode"] = util::gsettings_get_string(settings, "equal-mode");
+
   json[section][instance_name]["slope"] = util::gsettings_get_string(settings, "slope");
 }
 
@@ -72,6 +74,8 @@ void FilterPreset::load(const nlohmann::json& json) {
   update_key<gchar*>(json.at(section).at(instance_name), settings, "type", "type");
 
   update_key<gchar*>(json.at(section).at(instance_name), settings, "mode", "mode");
+
+  update_key<gchar*>(json.at(section).at(instance_name), settings, "equal-mode", "equal-mode");
 
   update_key<gchar*>(json.at(section).at(instance_name), settings, "slope", "slope");
 }

--- a/src/filter_ui.cpp
+++ b/src/filter_ui.cpp
@@ -44,7 +44,7 @@ struct _FilterBox {
   GtkLabel *input_level_left_label, *input_level_right_label, *output_level_left_label, *output_level_right_label,
       *plugin_credit;
 
-  GtkDropDown *mode, *type, *slope;
+  GtkDropDown *mode, *equalizer_mode, *type, *slope;
 
   GtkSpinButton *frequency, *width, *gain, *quality, *balance;
 
@@ -129,6 +129,8 @@ void setup(FilterBox* self, std::shared_ptr<Filter> filter, const std::string& s
 
   ui::gsettings_bind_enum_to_combo_widget(self->settings, "mode", self->mode);
 
+  ui::gsettings_bind_enum_to_combo_widget(self->settings, "equal-mode", self->equalizer_mode);
+
   ui::gsettings_bind_enum_to_combo_widget(self->settings, "slope", self->slope);
 
   g_settings_bind(ui::get_global_app_settings(), "show-native-plugin-ui", self->show_native_ui, "visible",
@@ -195,6 +197,7 @@ void filter_box_class_init(FilterBoxClass* klass) {
 
   gtk_widget_class_bind_template_child(widget_class, FilterBox, type);
   gtk_widget_class_bind_template_child(widget_class, FilterBox, mode);
+  gtk_widget_class_bind_template_child(widget_class, FilterBox, equalizer_mode);
   gtk_widget_class_bind_template_child(widget_class, FilterBox, slope);
   gtk_widget_class_bind_template_child(widget_class, FilterBox, frequency);
   gtk_widget_class_bind_template_child(widget_class, FilterBox, width);

--- a/src/ladspa_wrapper.cpp
+++ b/src/ladspa_wrapper.cpp
@@ -698,7 +698,7 @@ static inline unsigned long cp_to_port_idx(const LADSPA_Descriptor* descriptor, 
 }
 
 auto LadspaWrapper::get_control_port_name(uint index) const -> std::string {
-  unsigned long i = cp_to_port_idx(descriptor, index);
+  const unsigned long i = cp_to_port_idx(descriptor, index);
 
   if (i == (unsigned long)-1L) {
     return {};
@@ -708,7 +708,7 @@ auto LadspaWrapper::get_control_port_name(uint index) const -> std::string {
 }
 
 auto LadspaWrapper::is_control_port_output(uint index) const -> bool {
-  unsigned long i = cp_to_port_idx(descriptor, index);
+  const unsigned long i = cp_to_port_idx(descriptor, index);
 
   if (i == (unsigned long)-1L) {
     return false;
@@ -718,7 +718,7 @@ auto LadspaWrapper::is_control_port_output(uint index) const -> bool {
 }
 
 auto LadspaWrapper::get_control_port_range(uint index) const -> std::tuple<float, float> {
-  unsigned long i = cp_to_port_idx(descriptor, index);
+  const unsigned long i = cp_to_port_idx(descriptor, index);
 
   if (i == (unsigned long)-1L) {
     return std::make_tuple(0.0F, 0.0F);
@@ -733,7 +733,7 @@ auto LadspaWrapper::get_control_port_range(uint index) const -> std::tuple<float
 }
 
 auto LadspaWrapper::get_control_port_default(uint index) const -> float {
-  unsigned long i = cp_to_port_idx(descriptor, index);
+  const unsigned long i = cp_to_port_idx(descriptor, index);
 
   if (i == (unsigned long)-1L) {
     return 0.0F;
@@ -762,7 +762,7 @@ auto LadspaWrapper::get_control_port_value(const std::string& symbol) const -> f
 }
 
 auto LadspaWrapper::set_control_port_value_clamp(uint index, float value) -> float {
-  unsigned long i = cp_to_port_idx(descriptor, index);
+  const unsigned long i = cp_to_port_idx(descriptor, index);
 
   assert(i != (unsigned long)-1L);
 

--- a/src/ladspa_wrapper.cpp
+++ b/src/ladspa_wrapper.cpp
@@ -55,21 +55,21 @@ struct dlhandle {
 };
 
 static inline bool validate_ports(const LADSPA_Descriptor* descriptor) {
-  unsigned long count_input = 0;
-  unsigned long count_output = 0;
+  unsigned long count_input = 0UL;
+  unsigned long count_output = 0UL;
 
-  for (unsigned long i = 0; i < descriptor->PortCount; i++) {
+  for (unsigned long i = 0UL; i < descriptor->PortCount; i++) {
     if (LADSPA_IS_PORT_CONTROL(descriptor->PortDescriptors[i])) {
       if (LADSPA_IS_PORT_AUDIO(descriptor->PortDescriptors[i])) {
         return false;
       }
     } else if (LADSPA_IS_PORT_AUDIO(descriptor->PortDescriptors[i])) {
       if (LADSPA_IS_PORT_INPUT(descriptor->PortDescriptors[i])) {
-        if (++count_input > 4) {
+        if (++count_input > 4UL) {
           return false;
         }
       } else if (LADSPA_IS_PORT_OUTPUT(descriptor->PortDescriptors[i])) {
-        if (++count_output > 2) {
+        if (++count_output > 2UL) {
           return false;
         }
       } else {
@@ -119,7 +119,7 @@ LadspaWrapper::LadspaWrapper(const std::string& plugin_filename, const std::stri
       continue;
     }
 
-    unsigned long i = 0;
+    unsigned long i = 0UL;
 
     const LADSPA_Descriptor* descriptor = nullptr;
 
@@ -137,9 +137,9 @@ LadspaWrapper::LadspaWrapper(const std::string& plugin_filename, const std::stri
     if (descriptor != nullptr) {
       if (descriptor->instantiate != nullptr && descriptor->connect_port != nullptr && descriptor->run != nullptr &&
           validate_ports(descriptor)) {
-        unsigned long count = 0;
+        unsigned long count = 0UL;
 
-        for (unsigned long i = 0; i < descriptor->PortCount; i++) {
+        for (unsigned long i = 0UL; i < descriptor->PortCount; i++) {
           if (LADSPA_IS_PORT_CONTROL(descriptor->PortDescriptors[i])) {
             count++;
           }
@@ -156,7 +156,7 @@ LadspaWrapper::LadspaWrapper(const std::string& plugin_filename, const std::stri
         this->control_ports = control_ports;
         this->control_ports_initialized = control_ports_initialized;
 
-        for (unsigned long i = 0, j = 0; i < descriptor->PortCount; i++) {
+        for (unsigned long i = 0UL, j = 0UL; i < descriptor->PortCount; i++) {
           if (LADSPA_IS_PORT_CONTROL(descriptor->PortDescriptors[i])) {
             map_cp_name_to_idx.insert(std::make_pair(descriptor->PortNames[i], j++));
           }
@@ -332,12 +332,12 @@ static inline void scale_control_ports(const LADSPA_Descriptor* descriptor,
                                        bool* control_ports_initialized,
                                        uint old_rate,
                                        uint rate) {
-  for (unsigned long i = 0, j = 0; i < descriptor->PortCount; i++) {
+  for (unsigned long i = 0UL, j = 0UL; i < descriptor->PortCount; i++) {
     if (LADSPA_IS_PORT_CONTROL(descriptor->PortDescriptors[i])) {
       if (!control_ports_initialized[j]) {
         control_ports[j] = get_port_default(descriptor, i, rate);
         control_ports_initialized[j] = true;
-      } else if (old_rate != 0) {
+      } else if (old_rate != 0U) {
         const LADSPA_PortRangeHint* hint = &descriptor->PortRangeHints[i];
 
         if (LADSPA_IS_HINT_SAMPLE_RATE(hint->HintDescriptor)) {
@@ -362,7 +362,7 @@ auto LadspaWrapper::create_instance(uint rate) -> bool {
 
   scale_control_ports(descriptor, control_ports, control_ports_initialized, this->rate, rate);
 
-  for (unsigned long i = 0, j = 0; i < descriptor->PortCount; i++) {
+  for (unsigned long i = 0UL, j = 0UL; i < descriptor->PortCount; i++) {
     if (LADSPA_IS_PORT_CONTROL(descriptor->PortDescriptors[i])) {
       descriptor->connect_port(new_instance, i, &control_ports[j++]);
     }
@@ -425,19 +425,19 @@ void LadspaWrapper::connect_data_ports(const std::span<const float>& left_in,
     return;
   }
 
-  unsigned long left_in_idx = -1;
-  unsigned long right_in_idx = -1;
-  unsigned long first_in_idx = -1;
-  unsigned long second_in_idx = -1;
-  unsigned long left_out_idx = -1;
-  unsigned long right_out_idx = -1;
-  unsigned long first_out_idx = -1;
-  unsigned long second_out_idx = -1;
+  unsigned long left_in_idx = -1L;
+  unsigned long right_in_idx = -1L;
+  unsigned long first_in_idx = -1L;
+  unsigned long second_in_idx = -1L;
+  unsigned long left_out_idx = -1L;
+  unsigned long right_out_idx = -1L;
+  unsigned long first_out_idx = -1L;
+  unsigned long second_out_idx = -1L;
 
   int count_input = 0;
   int count_output = 0;
 
-  for (unsigned long i = 0; i < descriptor->PortCount; i++) {
+  for (unsigned long i = 0UL; i < descriptor->PortCount; i++) {
     if (LADSPA_IS_PORT_AUDIO(descriptor->PortDescriptors[i])) {
       if (LADSPA_IS_PORT_INPUT(descriptor->PortDescriptors[i])) {
         if (striendswith(descriptor->PortNames[i], " L") || striendswith(descriptor->PortNames[i], " (L)")) {
@@ -471,27 +471,27 @@ void LadspaWrapper::connect_data_ports(const std::span<const float>& left_in,
     }
   }
 
-  if (left_in_idx == (unsigned long)-1 || right_in_idx == (unsigned long)-1) {
+  if (left_in_idx == (unsigned long)-1L || right_in_idx == (unsigned long)-1L) {
     left_in_idx = first_in_idx;
     right_in_idx = second_in_idx;
   }
-  if (left_in_idx != (unsigned long)-1) {
+  if (left_in_idx != (unsigned long)-1L) {
     descriptor->connect_port(instance, left_in_idx, const_cast<LADSPA_Data*>(left_in.data()));
   }
 
-  if (right_in_idx != (unsigned long)-1) {
+  if (right_in_idx != (unsigned long)-1L) {
     descriptor->connect_port(instance, right_in_idx, const_cast<LADSPA_Data*>(right_in.data()));
   }
 
-  if (left_out_idx == (unsigned long)-1 || right_out_idx == (unsigned long)-1) {
+  if (left_out_idx == (unsigned long)-1L || right_out_idx == (unsigned long)-1L) {
     left_out_idx = first_out_idx;
     right_out_idx = second_out_idx;
   }
-  if (left_out_idx != (unsigned long)-1) {
+  if (left_out_idx != (unsigned long)-1L) {
     descriptor->connect_port(instance, left_out_idx, left_out.data());
   }
 
-  if (right_out_idx != (unsigned long)-1) {
+  if (right_out_idx != (unsigned long)-1L) {
     descriptor->connect_port(instance, right_out_idx, right_out.data());
   }
 }
@@ -521,23 +521,23 @@ void LadspaWrapper::connect_data_ports(const std::span<const float>& left_in,
     return;
   }
 
-  unsigned long left_in_idx = -1;
-  unsigned long right_in_idx = -1;
-  unsigned long first_in_idx = -1;
-  unsigned long second_in_idx = -1;
-  unsigned long probe_left_idx = -1;
-  unsigned long probe_right_idx = -1;
-  unsigned long third_in_idx = -1;
-  unsigned long fourth_in_idx = -1;
-  unsigned long left_out_idx = -1;
-  unsigned long right_out_idx = -1;
-  unsigned long first_out_idx = -1;
-  unsigned long second_out_idx = -1;
+  unsigned long left_in_idx = -1L;
+  unsigned long right_in_idx = -1L;
+  unsigned long first_in_idx = -1L;
+  unsigned long second_in_idx = -1L;
+  unsigned long probe_left_idx = -1L;
+  unsigned long probe_right_idx = -1L;
+  unsigned long third_in_idx = -1L;
+  unsigned long fourth_in_idx = -1L;
+  unsigned long left_out_idx = -1L;
+  unsigned long right_out_idx = -1L;
+  unsigned long first_out_idx = -1L;
+  unsigned long second_out_idx = -1L;
 
   int count_input = 0;
   int count_output = 0;
 
-  for (unsigned long i = 0; i < descriptor->PortCount; i++) {
+  for (unsigned long i = 0UL; i < descriptor->PortCount; i++) {
     if (LADSPA_IS_PORT_AUDIO(descriptor->PortDescriptors[i])) {
       if (LADSPA_IS_PORT_INPUT(descriptor->PortDescriptors[i])) {
         bool sc = stristr(descriptor->PortNames[i], "Probe") != nullptr ||
@@ -585,19 +585,19 @@ void LadspaWrapper::connect_data_ports(const std::span<const float>& left_in,
     }
   }
 
-  if (left_in_idx == (unsigned long)-1 || right_in_idx == (unsigned long)-1) {
+  if (left_in_idx == (unsigned long)-1L || right_in_idx == (unsigned long)-1L) {
     left_in_idx = first_in_idx;
     right_in_idx = second_in_idx;
   }
-  if (left_in_idx != (unsigned long)-1) {
+  if (left_in_idx != (unsigned long)-1L) {
     descriptor->connect_port(instance, left_in_idx, const_cast<LADSPA_Data*>(left_in.data()));
   }
 
-  if (right_in_idx != (unsigned long)-1) {
+  if (right_in_idx != (unsigned long)-1L) {
     descriptor->connect_port(instance, right_in_idx, const_cast<LADSPA_Data*>(left_in.data()));
   }
 
-  if (probe_left_idx == (unsigned long)-1 || probe_right_idx == (unsigned long)-1) {
+  if (probe_left_idx == (unsigned long)-1L || probe_right_idx == (unsigned long)-1L) {
     if (left_in_idx == first_in_idx) {
       if (right_in_idx == second_in_idx) {
         probe_left_idx = third_in_idx;
@@ -629,23 +629,23 @@ void LadspaWrapper::connect_data_ports(const std::span<const float>& left_in,
       probe_right_idx = second_in_idx;
     }
   }
-  if (probe_left_idx != (unsigned long)-1) {
+  if (probe_left_idx != (unsigned long)-1L) {
     descriptor->connect_port(instance, probe_left_idx, const_cast<LADSPA_Data*>(probe_left.data()));
   }
 
-  if (probe_right_idx != (unsigned long)-1) {
+  if (probe_right_idx != (unsigned long)-1L) {
     descriptor->connect_port(instance, probe_right_idx, const_cast<LADSPA_Data*>(probe_right.data()));
   }
 
-  if (left_out_idx == (unsigned long)-1 || right_out_idx == (unsigned long)-1) {
+  if (left_out_idx == (unsigned long)-1L || right_out_idx == (unsigned long)-1L) {
     left_out_idx = first_out_idx;
     right_out_idx = second_out_idx;
   }
-  if (left_out_idx != (unsigned long)-1) {
+  if (left_out_idx != (unsigned long)-1L) {
     descriptor->connect_port(instance, left_out_idx, left_out.data());
   }
 
-  if (right_out_idx != (unsigned long)-1) {
+  if (right_out_idx != (unsigned long)-1L) {
     descriptor->connect_port(instance, right_out_idx, left_out.data());
   }
 }
@@ -674,9 +674,9 @@ void LadspaWrapper::run() const {
 }
 
 auto LadspaWrapper::get_control_port_count() const -> uint {
-  uint count = 0;
+  uint count = 0U;
 
-  for (unsigned long i = 0; i < descriptor->PortCount; i++) {
+  for (unsigned long i = 0UL; i < descriptor->PortCount; i++) {
     if (LADSPA_IS_PORT_CONTROL(descriptor->PortDescriptors[i])) {
       count++;
     }
@@ -686,9 +686,9 @@ auto LadspaWrapper::get_control_port_count() const -> uint {
 }
 
 static inline unsigned long cp_to_port_idx(const LADSPA_Descriptor* descriptor, uint index) {
-  for (unsigned long i = 0; i < descriptor->PortCount; i++) {
+  for (unsigned long i = 0UL; i < descriptor->PortCount; i++) {
     if (LADSPA_IS_PORT_CONTROL(descriptor->PortDescriptors[i])) {
-      if (index-- == 0) {
+      if (index-- == 0U) {
         return i;
       }
     }


### PR DESCRIPTION
- Made a little refactoring to Ladspa Wrapper using literals, trying to avoid implicit conversions and making use of const where possible.
- - The use of `(unsigned long)-1` is funny. I suppose there's no alternative. ^^
- - No errors while testing this new ladpsa plugin, but I got warnings telling me that my system is too slow and after a while a core dump occurs. The issue is my old laptop.
- Added Equalizer Mode to LSP Filter (fixes #2570).
- Improved RNNoise UI.