### PR TITLE
Split stereo for Gate and Expander + Clamp values for LV2 wrapper

### DIFF
--- a/data/schemas/com.github.wwmm.easyeffects.expander.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.expander.gschema.xml
@@ -22,6 +22,14 @@
         <value nick="Min" value="4" />
         <value nick="Max" value="5" />
     </enum>
+    <enum id="com.github.wwmm.easyeffects.expander.sidechain.stereosplit.source.enum">
+        <value nick="Left/Right" value="0" />
+        <value nick="Right/Left" value="1" />
+        <value nick="Mid/Side" value="2" />
+        <value nick="Side/Mid" value="3" />
+        <value nick="Min" value="4" />
+        <value nick="Max" value="5" />
+    </enum>
     <enum id="com.github.wwmm.easyeffects.expander.filter.mode.enum">
         <value nick="off" value="0" />
         <value nick="12 dB/oct" value="1" />
@@ -88,9 +96,16 @@
         <key name="sidechain-mode" enum="com.github.wwmm.easyeffects.expander.sidechain.mode.enum">
             <default>"RMS"</default>
         </key>
+        <key name="stereo-split" type="b">
+            <default>false</default>
+        </key>
         <key name="sidechain-source"
             enum="com.github.wwmm.easyeffects.expander.sidechain.source.enum">
             <default>"Middle"</default>
+        </key>
+        <key name="stereo-split-source"
+            enum="com.github.wwmm.easyeffects.expander.sidechain.stereosplit.source.enum">
+            <default>"Left/Right"</default>
         </key>
         <key name="sidechain-preamp" type="d">
             <range min="-120" max="40" />

--- a/data/schemas/com.github.wwmm.easyeffects.gate.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.gate.gschema.xml
@@ -18,6 +18,14 @@
         <value nick="Min" value="4" />
         <value nick="Max" value="5" />
     </enum>
+    <enum id="com.github.wwmm.easyeffects.gate.sidechain.stereosplit.source.enum">
+        <value nick="Left/Right" value="0" />
+        <value nick="Right/Left" value="1" />
+        <value nick="Mid/Side" value="2" />
+        <value nick="Side/Mid" value="3" />
+        <value nick="Min" value="4" />
+        <value nick="Max" value="5" />
+    </enum>
     <enum id="com.github.wwmm.easyeffects.gate.filter.mode.enum">
         <value nick="off" value="0" />
         <value nick="12 dB/oct" value="1" />
@@ -88,8 +96,15 @@
         <key name="sidechain-mode" enum="com.github.wwmm.easyeffects.gate.sidechain.mode.enum">
             <default>"RMS"</default>
         </key>
+        <key name="stereo-split" type="b">
+            <default>false</default>
+        </key>
         <key name="sidechain-source" enum="com.github.wwmm.easyeffects.gate.sidechain.source.enum">
             <default>"Middle"</default>
+        </key>
+        <key name="stereo-split-source"
+            enum="com.github.wwmm.easyeffects.gate.sidechain.stereosplit.source.enum">
+            <default>"Left/Right"</default>
         </key>
         <key name="sidechain-preamp" type="d">
             <range min="-120" max="40" />

--- a/data/ui/compressor.ui
+++ b/data/ui/compressor.ui
@@ -532,6 +532,9 @@
                                                                             <property name="column">0</property>
                                                                             <property name="row">2</property>
                                                                         </layout>
+                                                                        <accessibility>
+                                                                            <property name="label" translatable="yes">Stereo Split Mode</property>
+                                                                        </accessibility>
                                                                     </object>
                                                                 </child>
 

--- a/data/ui/expander.ui
+++ b/data/ui/expander.ui
@@ -424,13 +424,102 @@
                                                 <child>
                                                     <object class="GtkBox">
                                                         <property name="halign">center</property>
-                                                        <property name="homogeneous">1</property>
                                                         <property name="spacing">24</property>
                                                         <child>
                                                             <object class="GtkGrid">
+                                                                <property name="halign">center</property>
                                                                 <property name="row-spacing">6</property>
-                                                                <property name="column-spacing">18</property>
-                                                                <property name="column-homogeneous">1</property>
+                                                                <property name="column-spacing">12</property>
+
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="label" translatable="yes">Sidechain</property>
+                                                                        <layout>
+                                                                            <property name="column">0</property>
+                                                                            <property name="row">1</property>
+                                                                        </layout>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkCheckButton" id="stereo_split">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="label" translatable="yes">Stereo Split Mode</property>
+                                                                        <layout>
+                                                                            <property name="column">0</property>
+                                                                            <property name="row">2</property>
+                                                                        </layout>
+                                                                        <accessibility>
+                                                                            <property name="label" translatable="yes">Stereo Split Mode</property>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">Source</property>
+                                                                        <layout>
+                                                                            <property name="column">1</property>
+                                                                            <property name="row">0</property>
+                                                                        </layout>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkDropDown" id="sidechain_source">
+                                                                        <property name="model">
+                                                                            <object class="GtkStringList">
+                                                                                <items>
+                                                                                    <item translatable="yes">Middle</item>
+                                                                                    <item translatable="yes">Side</item>
+                                                                                    <item translatable="yes">Left</item>
+                                                                                    <item translatable="yes">Right</item>
+                                                                                    <item translatable="yes">Min</item>
+                                                                                    <item translatable="yes">Max</item>
+                                                                                </items>
+                                                                            </object>
+                                                                        </property>
+                                                                        <layout>
+                                                                            <property name="column">1</property>
+                                                                            <property name="row">1</property>
+                                                                        </layout>
+                                                                        <accessibility>
+                                                                            <property name="label" translatable="yes">Sidechain Source</property>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkDropDown" id="stereo_split_source">
+                                                                        <property name="model">
+                                                                            <object class="GtkStringList">
+                                                                                <items>
+                                                                                    <item translatable="yes">Left/Right</item>
+                                                                                    <item translatable="yes">Right/Left</item>
+                                                                                    <item translatable="yes">Mid/Side</item>
+                                                                                    <item translatable="yes">Side/Mid</item>
+                                                                                    <item translatable="yes">Min</item>
+                                                                                    <item translatable="yes">Max</item>
+                                                                                </items>
+                                                                            </object>
+                                                                        </property>
+                                                                        <layout>
+                                                                            <property name="column">1</property>
+                                                                            <property name="row">2</property>
+                                                                        </layout>
+                                                                        <accessibility>
+                                                                            <property name="label" translatable="yes">Stereo Split Source</property>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkGrid">
+                                                                <property name="halign">center</property>
+                                                                <property name="row-spacing">6</property>
+                                                                <property name="column-spacing">24</property>
                                                                 <child>
                                                                     <object class="GtkLabel">
                                                                         <property name="label" translatable="yes">Mode</property>
@@ -447,8 +536,8 @@
                                                                                 <items>
                                                                                     <item translatable="yes">Peak</item>
                                                                                     <item translatable="yes">RMS</item>
-                                                                                    <item translatable="yes">Low-Pass</item>
-                                                                                    <item translatable="yes">Uniform</item>
+                                                                                    <item translatable="yes">Low-Pass Filter</item>
+                                                                                    <item translatable="yes">Simple Moving Average</item>
                                                                                 </items>
                                                                             </object>
                                                                         </property>
@@ -470,38 +559,8 @@
                                                                             <property name="column">1</property>
                                                                             <property name="row">1</property>
                                                                         </layout>
-                                                                    </object>
-                                                                </child>
-
-                                                                <child>
-                                                                    <object class="GtkLabel">
-                                                                        <property name="label" translatable="yes">Source</property>
-                                                                        <layout>
-                                                                            <property name="column">2</property>
-                                                                            <property name="row">0</property>
-                                                                        </layout>
-                                                                    </object>
-                                                                </child>
-                                                                <child>
-                                                                    <object class="GtkDropDown" id="sidechain_source">
-                                                                        <property name="model">
-                                                                            <object class="GtkStringList">
-                                                                                <items>
-                                                                                    <item translatable="yes">Middle</item>
-                                                                                    <item translatable="yes">Side</item>
-                                                                                    <item translatable="yes">Left</item>
-                                                                                    <item translatable="yes">Right</item>
-                                                                                    <item translatable="yes">Min</item>
-                                                                                    <item translatable="yes">Max</item>
-                                                                                </items>
-                                                                            </object>
-                                                                        </property>
-                                                                        <layout>
-                                                                            <property name="column">2</property>
-                                                                            <property name="row">1</property>
-                                                                        </layout>
                                                                         <accessibility>
-                                                                            <property name="label" translatable="yes">Sidechain Source</property>
+                                                                            <property name="label" translatable="yes">Listen Sidechain</property>
                                                                         </accessibility>
                                                                     </object>
                                                                 </child>

--- a/data/ui/gate.ui
+++ b/data/ui/gate.ui
@@ -665,6 +665,9 @@
                                                                             <property name="column">0</property>
                                                                             <property name="row">2</property>
                                                                         </layout>
+                                                                        <accessibility>
+                                                                            <property name="label" translatable="yes">Stereo Split Mode</property>
+                                                                        </accessibility>
                                                                     </object>
                                                                 </child>
 

--- a/data/ui/gate.ui
+++ b/data/ui/gate.ui
@@ -820,13 +820,17 @@
                                                         </child>
 
                                                         <child>
-                                                            <object class="GtkComboBoxText" id="sidechain_input">
+                                                            <object class="GtkDropDown" id="sidechain_input">
                                                                 <property name="valign">center</property>
                                                                 <property name="margin-end">6</property>
-                                                                <items>
-                                                                    <item id="Internal" translatable="yes">Internal</item>
-                                                                    <item id="External" translatable="yes">External</item>
-                                                                </items>
+                                                                <property name="model">
+                                                                    <object class="GtkStringList">
+                                                                        <items>
+                                                                            <item translatable="yes">Internal</item>
+                                                                            <item translatable="yes">External</item>
+                                                                        </items>
+                                                                    </object>
+                                                                </property>
                                                                 <layout>
                                                                     <property name="column">1</property>
                                                                     <property name="row">1</property>
@@ -842,8 +846,9 @@
                                                                 <property name="margin-end">6</property>
 
                                                                 <binding name="sensitive">
-                                                                    <closure type="gboolean" function="set_dropdown_sensitive">
-                                                                        <lookup name="active-id">sidechain_input</lookup>
+                                                                    <closure type="gboolean"
+                                                                        function="set_dropdown_sensitive">
+                                                                        <lookup name="selected">sidechain_input</lookup>
                                                                     </closure>
                                                                 </binding>
 
@@ -1028,15 +1033,19 @@
                                                 </child>
 
                                                 <child>
-                                                    <object class="GtkComboBoxText" id="hpf_mode">
+                                                    <object class="GtkDropDown" id="hpf_mode">
                                                         <property name="margin-bottom">6</property>
                                                         <property name="margin-end">6</property>
-                                                        <items>
-                                                            <item translatable="yes" id="off">Off</item>
-                                                            <item translatable="yes" id="12 dB/oct">12 dB/oct</item>
-                                                            <item translatable="yes" id="24 dB/oct">24 dB/oct</item>
-                                                            <item translatable="yes" id="36 dB/oct">36 dB/oct</item>
-                                                        </items>
+                                                        <property name="model">
+                                                            <object class="GtkStringList">
+                                                                <items>
+                                                                    <item translatable="yes">Off</item>
+                                                                    <item translatable="yes">12 dB/oct</item>
+                                                                    <item translatable="yes">24 dB/oct</item>
+                                                                    <item translatable="yes">36 dB/oct</item>
+                                                                </items>
+                                                            </object>
+                                                        </property>
                                                         <layout>
                                                             <property name="column">1</property>
                                                             <property name="row">1</property>
@@ -1084,15 +1093,19 @@
                                                 </child>
 
                                                 <child>
-                                                    <object class="GtkComboBoxText" id="lpf_mode">
+                                                    <object class="GtkDropDown" id="lpf_mode">
                                                         <property name="margin-bottom">6</property>
                                                         <property name="margin-start">6</property>
-                                                        <items>
-                                                            <item translatable="yes" id="off">Off</item>
-                                                            <item translatable="yes" id="12 dB/oct">12 dB/oct</item>
-                                                            <item translatable="yes" id="24 dB/oct">24 dB/oct</item>
-                                                            <item translatable="yes" id="36 dB/oct">36 dB/oct</item>
-                                                        </items>
+                                                        <property name="model">
+                                                            <object class="GtkStringList">
+                                                                <items>
+                                                                    <item translatable="yes">Off</item>
+                                                                    <item translatable="yes">12 dB/oct</item>
+                                                                    <item translatable="yes">24 dB/oct</item>
+                                                                    <item translatable="yes">36 dB/oct</item>
+                                                                </items>
+                                                            </object>
+                                                        </property>
                                                         <layout>
                                                             <property name="column">2</property>
                                                             <property name="row">1</property>

--- a/data/ui/gate.ui
+++ b/data/ui/gate.ui
@@ -638,13 +638,99 @@
                                                 <child>
                                                     <object class="GtkBox">
                                                         <property name="halign">center</property>
-                                                        <property name="homogeneous">1</property>
                                                         <property name="spacing">24</property>
                                                         <child>
                                                             <object class="GtkGrid">
+                                                                <property name="halign">center</property>
                                                                 <property name="row-spacing">6</property>
-                                                                <property name="column-spacing">18</property>
-                                                                <property name="column-homogeneous">1</property>
+                                                                <property name="column-spacing">12</property>
+
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="label" translatable="yes">Sidechain</property>
+                                                                        <layout>
+                                                                            <property name="column">0</property>
+                                                                            <property name="row">1</property>
+                                                                        </layout>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkCheckButton" id="stereo_split">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="valign">center</property>
+                                                                        <property name="label" translatable="yes">Stereo Split Mode</property>
+                                                                        <layout>
+                                                                            <property name="column">0</property>
+                                                                            <property name="row">2</property>
+                                                                        </layout>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">Source</property>
+                                                                        <layout>
+                                                                            <property name="column">1</property>
+                                                                            <property name="row">0</property>
+                                                                        </layout>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkDropDown" id="sidechain_source">
+                                                                        <property name="model">
+                                                                            <object class="GtkStringList">
+                                                                                <items>
+                                                                                    <item translatable="yes">Middle</item>
+                                                                                    <item translatable="yes">Side</item>
+                                                                                    <item translatable="yes">Left</item>
+                                                                                    <item translatable="yes">Right</item>
+                                                                                    <item translatable="yes">Min</item>
+                                                                                    <item translatable="yes">Max</item>
+                                                                                </items>
+                                                                            </object>
+                                                                        </property>
+                                                                        <layout>
+                                                                            <property name="column">1</property>
+                                                                            <property name="row">1</property>
+                                                                        </layout>
+                                                                        <accessibility>
+                                                                            <property name="label" translatable="yes">Sidechain Source</property>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkDropDown" id="stereo_split_source">
+                                                                        <property name="model">
+                                                                            <object class="GtkStringList">
+                                                                                <items>
+                                                                                    <item translatable="yes">Left/Right</item>
+                                                                                    <item translatable="yes">Right/Left</item>
+                                                                                    <item translatable="yes">Mid/Side</item>
+                                                                                    <item translatable="yes">Side/Mid</item>
+                                                                                    <item translatable="yes">Min</item>
+                                                                                    <item translatable="yes">Max</item>
+                                                                                </items>
+                                                                            </object>
+                                                                        </property>
+                                                                        <layout>
+                                                                            <property name="column">1</property>
+                                                                            <property name="row">2</property>
+                                                                        </layout>
+                                                                        <accessibility>
+                                                                            <property name="label" translatable="yes">Stereo Split Source</property>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+
+                                                        <child>
+                                                            <object class="GtkGrid">
+                                                                <property name="halign">center</property>
+                                                                <property name="row-spacing">6</property>
+                                                                <property name="column-spacing">24</property>
                                                                 <child>
                                                                     <object class="GtkLabel">
                                                                         <property name="label" translatable="yes">Mode</property>
@@ -655,13 +741,17 @@
                                                                     </object>
                                                                 </child>
                                                                 <child>
-                                                                    <object class="GtkComboBoxText" id="sidechain_mode">
-                                                                        <items>
-                                                                            <item translatable="yes" id="Peak">Peak</item>
-                                                                            <item translatable="yes" id="RMS">RMS</item>
-                                                                            <item translatable="yes" id="LPF">Low-Pass Filter</item>
-                                                                            <item translatable="yes" id="SMA">Simple Moving Average</item>
-                                                                        </items>
+                                                                    <object class="GtkDropDown" id="sidechain_mode">
+                                                                        <property name="model">
+                                                                            <object class="GtkStringList">
+                                                                                <items>
+                                                                                    <item translatable="yes">Peak</item>
+                                                                                    <item translatable="yes">RMS</item>
+                                                                                    <item translatable="yes">Low-Pass Filter</item>
+                                                                                    <item translatable="yes">Simple Moving Average</item>
+                                                                                </items>
+                                                                            </object>
+                                                                        </property>
                                                                         <layout>
                                                                             <property name="column">0</property>
                                                                             <property name="row">1</property>
@@ -680,34 +770,8 @@
                                                                             <property name="column">1</property>
                                                                             <property name="row">1</property>
                                                                         </layout>
-                                                                    </object>
-                                                                </child>
-
-                                                                <child>
-                                                                    <object class="GtkLabel">
-                                                                        <property name="label" translatable="yes">Source</property>
-                                                                        <layout>
-                                                                            <property name="column">2</property>
-                                                                            <property name="row">0</property>
-                                                                        </layout>
-                                                                    </object>
-                                                                </child>
-                                                                <child>
-                                                                    <object class="GtkComboBoxText" id="sidechain_source">
-                                                                        <items>
-                                                                            <item translatable="yes" id="Middle">Middle</item>
-                                                                            <item translatable="yes" id="Side">Side</item>
-                                                                            <item translatable="yes" id="Left">Left</item>
-                                                                            <item translatable="yes" id="Right">Right</item>
-                                                                            <item translatable="yes" id="Min">Min</item>
-                                                                            <item translatable="yes" id="Max">Max</item>
-                                                                        </items>
-                                                                        <layout>
-                                                                            <property name="column">2</property>
-                                                                            <property name="row">1</property>
-                                                                        </layout>
                                                                         <accessibility>
-                                                                            <property name="label" translatable="yes">Sidechain Source</property>
+                                                                            <property name="label" translatable="yes">Listen Sidechain</property>
                                                                         </accessibility>
                                                                     </object>
                                                                 </child>

--- a/include/lv2_wrapper.hpp
+++ b/include/lv2_wrapper.hpp
@@ -58,7 +58,11 @@ struct Port {
 
   std::string symbol;
 
-  float value;  // Control value (if applicable)
+  float value = 0.0F;  // Control value (if applicable)
+
+  float min = -std::numeric_limits<float>::infinity();
+
+  float max = std::numeric_limits<float>::infinity();
 
   bool is_input;  // True if an input port
 

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -249,4 +249,34 @@ auto linspace(const T& start, const T& stop, const uint& npoints) -> std::vector
   return output;
 }
 
+// The following is not used and it was made only for reference. May be removed in the future.
+template <Number T>
+auto gsettings_key_check_number_range(GSettings* settings, const char* key, const T& v) -> bool {
+  GSettingsSchema* schema = nullptr;
+  GVariant* g_value = nullptr;
+
+  // Get GSettingsSchema
+  g_object_get(settings, "settings-schema", &schema, nullptr);
+
+  auto* schema_key = g_settings_schema_get_key(schema, key);
+
+  // Get GVariant
+  if constexpr (std::is_same_v<T, double>) {
+    g_value = g_variant_new_double(v);
+  } else if constexpr (std::is_same_v<T, int>) {
+    g_value = g_variant_new_int32(v);
+  }
+
+  if (g_value == nullptr) {
+    return false;
+  }
+
+  const auto is_in_range = g_settings_schema_key_range_check(schema_key, g_value);
+
+  g_variant_unref(g_value);
+  g_settings_schema_unref(schema);
+
+  return is_in_range != 0;
+}
+
 }  // namespace util

--- a/src/expander.cpp
+++ b/src/expander.cpp
@@ -56,9 +56,13 @@ Expander::Expander(const std::string& tag,
 
   lv2_wrapper->bind_key_enum<"scs", "sidechain-source">(settings);
 
+  lv2_wrapper->bind_key_enum<"sscs", "stereo-split-source">(settings);
+
   lv2_wrapper->bind_key_enum<"shpm", "hpf-mode">(settings);
 
   lv2_wrapper->bind_key_enum<"slpm", "lpf-mode">(settings);
+
+  lv2_wrapper->bind_key_bool<"ssplit", "stereo-split">(settings);
 
   lv2_wrapper->bind_key_bool<"scl", "sidechain-listen">(settings);
 

--- a/src/expander_preset.cpp
+++ b/src/expander_preset.cpp
@@ -55,11 +55,16 @@ void ExpanderPreset::save(nlohmann::json& json) {
 
   json[section][instance_name]["makeup"] = g_settings_get_double(settings, "makeup");
 
+  json[section][instance_name]["stereo-split"] = g_settings_get_boolean(settings, "stereo-split") != 0;
+
   json[section][instance_name]["sidechain"]["type"] = util::gsettings_get_string(settings, "sidechain-type");
 
   json[section][instance_name]["sidechain"]["mode"] = util::gsettings_get_string(settings, "sidechain-mode");
 
   json[section][instance_name]["sidechain"]["source"] = util::gsettings_get_string(settings, "sidechain-source");
+
+  json[section][instance_name]["sidechain"]["stereo-split-source"] =
+      util::gsettings_get_string(settings, "stereo-split-source");
 
   json[section][instance_name]["sidechain"]["preamp"] = g_settings_get_double(settings, "sidechain-preamp");
 
@@ -103,9 +108,14 @@ void ExpanderPreset::load(const nlohmann::json& json) {
 
   update_key<double>(json.at(section).at(instance_name), settings, "makeup", "makeup");
 
+  update_key<bool>(json.at(section).at(instance_name), settings, "stereo-split", "stereo-split");
+
   update_key<gchar*>(json.at(section).at(instance_name).at("sidechain"), settings, "sidechain-type", "type");
 
   update_key<gchar*>(json.at(section).at(instance_name).at("sidechain"), settings, "sidechain-mode", "mode");
+
+  update_key<gchar*>(json.at(section).at(instance_name).at("sidechain"), settings, "stereo-split-source",
+                     "stereo-split-source");
 
   update_key<gchar*>(json.at(section).at(instance_name).at("sidechain"), settings, "sidechain-source", "source");
 

--- a/src/expander_ui.cpp
+++ b/src/expander_ui.cpp
@@ -51,8 +51,10 @@ struct _ExpanderBox {
 
   GtkToggleButton *listen, *show_native_ui;
 
-  GtkDropDown *expander_mode, *sidechain_type, *sidechain_mode, *sidechain_source, *lpf_mode, *hpf_mode,
-      *dropdown_input_devices;
+  GtkCheckButton* stereo_split;
+
+  GtkDropDown *expander_mode, *sidechain_type, *sidechain_mode, *sidechain_source, *stereo_split_source, *lpf_mode,
+      *hpf_mode, *dropdown_input_devices;
 
   GListStore* input_devices_model;
 
@@ -293,6 +295,8 @@ void setup(ExpanderBox* self, std::shared_ptr<Expander> expander, const std::str
 
   g_settings_bind(self->settings, "sidechain-listen", self->listen, "active", G_SETTINGS_BIND_DEFAULT);
 
+  g_settings_bind(self->settings, "stereo-split", self->stereo_split, "active", G_SETTINGS_BIND_DEFAULT);
+
   ui::gsettings_bind_enum_to_combo_widget(self->settings, "mode", self->expander_mode);
 
   ui::gsettings_bind_enum_to_combo_widget(self->settings, "sidechain-type", self->sidechain_type);
@@ -301,12 +305,21 @@ void setup(ExpanderBox* self, std::shared_ptr<Expander> expander, const std::str
 
   ui::gsettings_bind_enum_to_combo_widget(self->settings, "sidechain-source", self->sidechain_source);
 
+  ui::gsettings_bind_enum_to_combo_widget(self->settings, "stereo-split-source", self->stereo_split_source);
+
   ui::gsettings_bind_enum_to_combo_widget(self->settings, "hpf-mode", self->hpf_mode);
 
   ui::gsettings_bind_enum_to_combo_widget(self->settings, "lpf-mode", self->lpf_mode);
 
   g_settings_bind(ui::get_global_app_settings(), "show-native-plugin-ui", self->show_native_ui, "visible",
                   G_SETTINGS_BIND_DEFAULT);
+
+  // bind source dropdowns sensitive property to split-stereo gsettings boolean
+
+  g_settings_bind(self->settings, "stereo-split", self->sidechain_source, "sensitive",
+                  static_cast<GSettingsBindFlags>(G_SETTINGS_BIND_DEFAULT | G_SETTINGS_BIND_INVERT_BOOLEAN));
+
+  g_settings_bind(self->settings, "stereo-split", self->stereo_split_source, "sensitive", G_SETTINGS_BIND_DEFAULT);
 }
 
 void dispose(GObject* object) {
@@ -389,6 +402,8 @@ void expander_box_class_init(ExpanderBoxClass* klass) {
   gtk_widget_class_bind_template_child(widget_class, ExpanderBox, sidechain_type);
   gtk_widget_class_bind_template_child(widget_class, ExpanderBox, sidechain_mode);
   gtk_widget_class_bind_template_child(widget_class, ExpanderBox, sidechain_source);
+  gtk_widget_class_bind_template_child(widget_class, ExpanderBox, stereo_split_source);
+  gtk_widget_class_bind_template_child(widget_class, ExpanderBox, stereo_split);
   gtk_widget_class_bind_template_child(widget_class, ExpanderBox, lpf_mode);
   gtk_widget_class_bind_template_child(widget_class, ExpanderBox, hpf_mode);
   gtk_widget_class_bind_template_child(widget_class, ExpanderBox, listen);

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -51,9 +51,13 @@ Gate::Gate(const std::string& tag, const std::string& schema, const std::string&
 
   lv2_wrapper->bind_key_enum<"scs", "sidechain-source">(settings);
 
+  lv2_wrapper->bind_key_enum<"sscs", "stereo-split-source">(settings);
+
   lv2_wrapper->bind_key_enum<"shpm", "hpf-mode">(settings);
 
   lv2_wrapper->bind_key_enum<"slpm", "lpf-mode">(settings);
+
+  lv2_wrapper->bind_key_bool<"ssplit", "stereo-split">(settings);
 
   lv2_wrapper->bind_key_bool<"scl", "sidechain-listen">(settings);
 

--- a/src/gate_preset.cpp
+++ b/src/gate_preset.cpp
@@ -57,11 +57,16 @@ void GatePreset::save(nlohmann::json& json) {
 
   json[section][instance_name]["makeup"] = g_settings_get_double(settings, "makeup");
 
+  json[section][instance_name]["stereo-split"] = g_settings_get_boolean(settings, "stereo-split") != 0;
+
   json[section][instance_name]["sidechain"]["input"] = util::gsettings_get_string(settings, "sidechain-input");
 
   json[section][instance_name]["sidechain"]["mode"] = util::gsettings_get_string(settings, "sidechain-mode");
 
   json[section][instance_name]["sidechain"]["source"] = util::gsettings_get_string(settings, "sidechain-source");
+
+  json[section][instance_name]["sidechain"]["stereo-split-source"] =
+      util::gsettings_get_string(settings, "stereo-split-source");
 
   json[section][instance_name]["sidechain"]["preamp"] = g_settings_get_double(settings, "sidechain-preamp");
 
@@ -107,9 +112,14 @@ void GatePreset::load(const nlohmann::json& json) {
 
   update_key<double>(json.at(section).at(instance_name), settings, "makeup", "makeup");
 
+  update_key<bool>(json.at(section).at(instance_name), settings, "stereo-split", "stereo-split");
+
   update_key<gchar*>(json.at(section).at(instance_name).at("sidechain"), settings, "sidechain-input", "input");
 
   update_key<gchar*>(json.at(section).at(instance_name).at("sidechain"), settings, "sidechain-mode", "mode");
+
+  update_key<gchar*>(json.at(section).at(instance_name).at("sidechain"), settings, "stereo-split-source",
+                     "stereo-split-source");
 
   update_key<gchar*>(json.at(section).at(instance_name).at("sidechain"), settings, "sidechain-source", "source");
 

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -55,9 +55,8 @@ struct _GateBox {
   GtkSpinButton *attack, *release, *curve_threshold, *curve_zone, *hysteresis_threshold, *hysteresis_zone, *dry, *wet,
       *reduction, *makeup, *preamp, *reactivity, *lookahead, *hpf_freq, *lpf_freq;
 
-  GtkComboBoxText *sidechain_input, *lpf_mode, *hpf_mode;
-
-  GtkDropDown *sidechain_source, *stereo_split_source, *sidechain_mode, *dropdown_input_devices;
+  GtkDropDown *sidechain_source, *stereo_split_source, *sidechain_mode, *dropdown_input_devices, *sidechain_input,
+      *lpf_mode, *hpf_mode;
 
   GListStore* input_devices_model;
 
@@ -81,12 +80,9 @@ void on_show_native_window(GateBox* self, GtkToggleButton* btn) {
   }
 }
 
-auto set_dropdown_sensitive(GateBox* self, const char* active_id) -> gboolean {
-  if (g_strcmp0(active_id, "External") == 0) {
-    return 1;
-  }
-
-  return 0;
+auto set_dropdown_sensitive(GateBox* self, const guint selected_id) -> gboolean {
+  // Sensitive on External Device selected
+  return (selected_id == 0U) ? 0 : 1;
 }
 
 void setup_dropdown_input_device(GateBox* self) {
@@ -369,17 +365,17 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
 
   g_settings_bind(self->settings, "stereo-split", self->stereo_split, "active", G_SETTINGS_BIND_DEFAULT);
 
-  g_settings_bind(self->settings, "sidechain-input", self->sidechain_input, "active-id", G_SETTINGS_BIND_DEFAULT);
-
-  g_settings_bind(self->settings, "hpf-mode", self->hpf_mode, "active-id", G_SETTINGS_BIND_DEFAULT);
-
-  g_settings_bind(self->settings, "lpf-mode", self->lpf_mode, "active-id", G_SETTINGS_BIND_DEFAULT);
+  ui::gsettings_bind_enum_to_combo_widget(self->settings, "sidechain-input", self->sidechain_input);
 
   ui::gsettings_bind_enum_to_combo_widget(self->settings, "sidechain-mode", self->sidechain_mode);
 
   ui::gsettings_bind_enum_to_combo_widget(self->settings, "sidechain-source", self->sidechain_source);
 
   ui::gsettings_bind_enum_to_combo_widget(self->settings, "stereo-split-source", self->stereo_split_source);
+
+  ui::gsettings_bind_enum_to_combo_widget(self->settings, "hpf-mode", self->hpf_mode);
+
+  ui::gsettings_bind_enum_to_combo_widget(self->settings, "lpf-mode", self->lpf_mode);
 
   g_settings_bind(ui::get_global_app_settings(), "show-native-plugin-ui", self->show_native_ui, "visible",
                   G_SETTINGS_BIND_DEFAULT);

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -48,16 +48,16 @@ struct _GateBox {
 
   GtkLabel *gain_label, *sidechain_label, *curve_label, *envelope_label;
 
-  GtkToggleButton* hysteresis;
+  GtkToggleButton *hysteresis, *listen, *show_native_ui;
+
+  GtkCheckButton* stereo_split;
 
   GtkSpinButton *attack, *release, *curve_threshold, *curve_zone, *hysteresis_threshold, *hysteresis_zone, *dry, *wet,
       *reduction, *makeup, *preamp, *reactivity, *lookahead, *hpf_freq, *lpf_freq;
 
-  GtkComboBoxText *sidechain_input, *sidechain_mode, *sidechain_source, *lpf_mode, *hpf_mode;
+  GtkComboBoxText *sidechain_input, *lpf_mode, *hpf_mode;
 
-  GtkToggleButton *listen, *show_native_ui;
-
-  GtkDropDown* dropdown_input_devices;
+  GtkDropDown *sidechain_source, *stereo_split_source, *sidechain_mode, *dropdown_input_devices;
 
   GListStore* input_devices_model;
 
@@ -367,18 +367,29 @@ void setup(GateBox* self, std::shared_ptr<Gate> gate, const std::string& schema_
 
   g_settings_bind(self->settings, "sidechain-listen", self->listen, "active", G_SETTINGS_BIND_DEFAULT);
 
+  g_settings_bind(self->settings, "stereo-split", self->stereo_split, "active", G_SETTINGS_BIND_DEFAULT);
+
   g_settings_bind(self->settings, "sidechain-input", self->sidechain_input, "active-id", G_SETTINGS_BIND_DEFAULT);
-
-  g_settings_bind(self->settings, "sidechain-mode", self->sidechain_mode, "active-id", G_SETTINGS_BIND_DEFAULT);
-
-  g_settings_bind(self->settings, "sidechain-source", self->sidechain_source, "active-id", G_SETTINGS_BIND_DEFAULT);
 
   g_settings_bind(self->settings, "hpf-mode", self->hpf_mode, "active-id", G_SETTINGS_BIND_DEFAULT);
 
   g_settings_bind(self->settings, "lpf-mode", self->lpf_mode, "active-id", G_SETTINGS_BIND_DEFAULT);
 
+  ui::gsettings_bind_enum_to_combo_widget(self->settings, "sidechain-mode", self->sidechain_mode);
+
+  ui::gsettings_bind_enum_to_combo_widget(self->settings, "sidechain-source", self->sidechain_source);
+
+  ui::gsettings_bind_enum_to_combo_widget(self->settings, "stereo-split-source", self->stereo_split_source);
+
   g_settings_bind(ui::get_global_app_settings(), "show-native-plugin-ui", self->show_native_ui, "visible",
                   G_SETTINGS_BIND_DEFAULT);
+
+  // bind source dropdowns sensitive property to split-stereo gsettings boolean
+
+  g_settings_bind(self->settings, "stereo-split", self->sidechain_source, "sensitive",
+                  static_cast<GSettingsBindFlags>(G_SETTINGS_BIND_DEFAULT | G_SETTINGS_BIND_INVERT_BOOLEAN));
+
+  g_settings_bind(self->settings, "stereo-split", self->stereo_split_source, "sensitive", G_SETTINGS_BIND_DEFAULT);
 }
 
 void dispose(GObject* object) {
@@ -466,6 +477,8 @@ void gate_box_class_init(GateBoxClass* klass) {
   gtk_widget_class_bind_template_child(widget_class, GateBox, sidechain_input);
   gtk_widget_class_bind_template_child(widget_class, GateBox, sidechain_mode);
   gtk_widget_class_bind_template_child(widget_class, GateBox, sidechain_source);
+  gtk_widget_class_bind_template_child(widget_class, GateBox, stereo_split_source);
+  gtk_widget_class_bind_template_child(widget_class, GateBox, stereo_split);
   gtk_widget_class_bind_template_child(widget_class, GateBox, lpf_mode);
   gtk_widget_class_bind_template_child(widget_class, GateBox, hpf_mode);
   gtk_widget_class_bind_template_child(widget_class, GateBox, listen);

--- a/src/lv2_wrapper.cpp
+++ b/src/lv2_wrapper.cpp
@@ -140,7 +140,7 @@ void Lv2Wrapper::create_ports() {
     if (!std::isnan(values[n])) {
       port->value = values[n];
     }
-    // Save min minimum and maximum values
+    // Save minimum and maximum values
     if (!std::isnan(minimum[n])) {
       port->min = minimum[n];
     }
@@ -372,11 +372,13 @@ void Lv2Wrapper::set_control_port_value(const std::string& symbol, const float& 
 
       // Check port bounds
       if (value < p.min) {
-        // util::warning(plugin_uri + " value out of minimum limit for port " + p.symbol + " (" + p.name + ")");
+        // util::warning(plugin_uri + ": value " + util::to_string(value) + " is out of minimum limit for port " +
+        //               p.symbol + " (" + p.name + ")");
 
         p.value = p.min;
       } else if (value > p.max) {
-        // util::warning(plugin_uri + " value out of maximum limit for port " + p.symbol + " (" + p.name + ")");
+        // util::warning(plugin_uri + ": value " + util::to_string(value) + " is out of maximum limit for port " +
+        //               p.symbol + " (" + p.name + ")");
 
         p.value = p.max;
       } else {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -197,6 +197,8 @@ auto gsettings_get_string(GSettings* settings, const char* key) -> std::string {
   return output;
 }
 
+// The following is not used and it was made only for reference. May be removed in the future.
+// GIO recommends to not use g_settings_schema_key_get_range in "normal programs".
 auto gsettings_get_range(GSettings* settings, const char* key) -> std::pair<std::string, std::string> {
   GSettingsSchema* schema = nullptr;
   const gchar* type = nullptr;


### PR DESCRIPTION
- Exposed split stereo parameters for Sidechain Gate #2533
- Exposed split stereo parameters for Sidechain Expander #2533
- Removed last deprecated GtkComboBox in Sidechain Gate
- Clamp values when applying to LV2 plugin ports #2684 

I wanted also to test a method to clamp values for GSettings, but there's nothing reliable. `gsettings_get_range` util returns a pair of strings which should be converted, so it's not so good when applying to many keys (considering also that Flatpak backend is already slow at the current state).

I also tested `g_settings_schema_key_range_check` which checks only the range, but it's not very helpful because GIO has already something like that internally (i.e. when applying wrong values from a preset). Anyway I left it for reference, could be deleted in the future. 