### PR TITLE
Gnome 45 runtime

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -46,7 +46,7 @@ jobs:
       FLATPAK_BUILD_PATH: flatpak_app/files/share
     needs: prepare
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-44
+      image: bilelmoussaoui/flatpak-github-actions:gnome-45
       options: --privileged
     steps:
     - name: Checkout

--- a/util/flatpak/com.github.wwmm.easyeffects.Devel.json
+++ b/util/flatpak/com.github.wwmm.easyeffects.Devel.json
@@ -1,7 +1,7 @@
 {
     "id": "com.github.wwmm.easyeffects.Devel",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
     "command": "easyeffects",
     "finish-args": [
@@ -28,7 +28,7 @@
     "add-extensions": {
         "org.freedesktop.LinuxAudio.Plugins": {
             "directory": "extensions/Plugins",
-            "version": "22.08",
+            "version": "23.08",
             "add-ld-path": "lib",
             "merge-dirs": "lv2",
             "subdirectories": true,
@@ -36,7 +36,7 @@
         },
         "org.freedesktop.LinuxAudio.Plugins.Calf": {
             "directory": "extensions/Plugins/Calf",
-            "version": "22.08",
+            "version": "23.08",
             "add-ld-path": "lib",
             "merge-dirs": "lv2",
             "autodelete": false,
@@ -44,7 +44,7 @@
         },
         "org.freedesktop.LinuxAudio.Plugins.LSP": {
             "directory": "extensions/Plugins/LSP",
-            "version": "22.08",
+            "version": "23.08",
             "add-ld-path": "lib",
             "merge-dirs": "lv2",
             "autodelete": false,
@@ -52,7 +52,7 @@
         },
         "org.freedesktop.LinuxAudio.Plugins.ZamPlugins": {
             "directory": "extensions/Plugins/ZamPlugins",
-            "version": "22.08",
+            "version": "23.08",
             "add-ld-path": "lib",
             "merge-dirs": "lv2",
             "autodelete": false,
@@ -60,7 +60,7 @@
         },
         "org.freedesktop.LinuxAudio.Plugins.MDA": {
             "directory": "extensions/Plugins/MDA",
-            "version": "22.08",
+            "version": "23.08",
             "add-ld-path": "lib",
             "merge-dirs": "lv2",
             "autodelete": false,

--- a/util/flatpak/easyeffects-modules.json
+++ b/util/flatpak/easyeffects-modules.json
@@ -233,22 +233,6 @@
             ]
         },
         {
-            "name": "zenity",
-            "buildsystem": "meson",
-            "build-commands": [
-                "mkdir -p /app/share/icons/hicolor"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/zenity",
-                    "tag": "3.44.0",
-                    "commit": "7bf8c8910d34bfb2b883b32118b93b68d44dd77b",
-                    "//": "flatpak-external-data-checker doesn't work well here, since it thinks that 3.90.0 is more recent (despite being an alpha), and 3.91.0 fails to build since it can't install translations properly"
-                }
-            ]
-        },
-        {
             "name": "fmt",
             "buildsystem": "cmake-ninja",
             "config-opts": [


### PR DESCRIPTION
This will update the gcc version, as well allow us to use as newer versions of runtime extensions like LSP which now use freedesktop 23.08.