### PR TITLE
Add "Quit" menu option and "--version" command line option

### DIFF
--- a/data/ui/application_window.ui
+++ b/data/ui/application_window.ui
@@ -27,6 +27,12 @@
                 <attribute name="action">app.about</attribute>
             </item>
         </section>
+        <section>
+            <item>
+                <attribute name="label" translatable="yes">_Quit</attribute>
+                <attribute name="action">app.quit</attribute>
+            </item>
+        </section>
     </menu>
 
     <template class="ApplicationWindow" parent="AdwApplicationWindow">

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -290,12 +290,18 @@ void application_class_init(ApplicationClass* klass) {
 
   application_class->command_line = [](GApplication* gapp, GApplicationCommandLine* cmdline) {
     auto* self = EE_APP(gapp);
-    auto* options = g_application_command_line_get_options_dict(cmdline);
+    GVariantDict* options = g_application_command_line_get_options_dict(cmdline);
 
     if (g_variant_dict_contains(options, "quit") != 0) {
       hide_all_windows(gapp);
 
       g_application_quit(G_APPLICATION(gapp));
+
+      return EXIT_SUCCESS;
+    }
+
+    if (g_variant_dict_contains(options, "version") != 0) {
+      std::cout << "easyeffects version: " + std::string(VERSION);
 
       return EXIT_SUCCESS;
     }
@@ -549,8 +555,8 @@ auto application_new() -> GApplication* {
   g_application_add_main_option(G_APPLICATION(app), "quit", 'q', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
                                 _("Quit Easy Effects. Useful when running in service mode."), nullptr);
 
-  g_application_add_main_option(G_APPLICATION(app), "load-preset", 'l', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING,
-                                _("Load a preset. Example: easyeffects -l music"), nullptr);
+  g_application_add_main_option(G_APPLICATION(app), "version", 'v', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING,
+                                _("Print the easyeffects version"), nullptr);
 
   g_application_add_main_option(G_APPLICATION(app), "reset", 'r', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
                                 _("Reset Easy Effects."), nullptr);
@@ -563,6 +569,9 @@ auto application_new() -> GApplication* {
 
   g_application_add_main_option(G_APPLICATION(app), "presets", 'p', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
                                 _("Show available presets."), nullptr);
+
+  g_application_add_main_option(G_APPLICATION(app), "load-preset", 'l', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING,
+                                _("Load a preset. Example: easyeffects -l music"), nullptr);
 
   return G_APPLICATION(app);
 }

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -555,7 +555,7 @@ auto application_new() -> GApplication* {
   g_application_add_main_option(G_APPLICATION(app), "quit", 'q', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
                                 _("Quit Easy Effects. Useful when running in service mode."), nullptr);
 
-  g_application_add_main_option(G_APPLICATION(app), "version", 'v', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING,
+  g_application_add_main_option(G_APPLICATION(app), "version", 'v', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
                                 _("Print the easyeffects version"), nullptr);
 
   g_application_add_main_option(G_APPLICATION(app), "reset", 'r', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,


### PR DESCRIPTION
As per recent requests in #2738 and #2697 , add a `--version` command line option, and add the "quit" application action to the primary_menu hamburger menu in the GUI.