### PR TITLE
Add ability to disable inactivity timeout

### DIFF
--- a/data/schemas/com.github.wwmm.easyeffects.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.gschema.xml
@@ -47,7 +47,7 @@
             <range min="1" max="3600" />
             <default>10</default>
         </key>
-        <key name="inactivity-timer-enabled" type="b">
+        <key name="inactivity-timer-enable" type="b">
             <default>true</default>
         </key>
         <key name="meters-update-interval" type="i">

--- a/data/schemas/com.github.wwmm.easyeffects.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.gschema.xml
@@ -44,7 +44,7 @@
             <default>true</default>
         </key>
         <key name="inactivity-timeout" type="i">
-            <range min="1" max="3600" />
+            <range min="0" max="3600" />
             <default>10</default>
         </key>
         <key name="meters-update-interval" type="i">

--- a/data/schemas/com.github.wwmm.easyeffects.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.gschema.xml
@@ -44,8 +44,11 @@
             <default>true</default>
         </key>
         <key name="inactivity-timeout" type="i">
-            <range min="0" max="3600" />
+            <range min="1" max="3600" />
             <default>10</default>
+        </key>
+        <key name="inactivity-timer-enabled" type="b">
+            <default>true</default>
         </key>
         <key name="meters-update-interval" type="i">
             <range min="10" max="1000" />

--- a/data/ui/preferences_general.ui
+++ b/data/ui/preferences_general.ui
@@ -89,7 +89,7 @@
                     <object class="AdwActionRow">
                         <property name="title" translatable="yes">Inactivity Timeout</property>
                         <child>
-                            <object class="GtkSwitch" id="inactivity_timer_enabled">
+                            <object class="GtkSwitch" id="inactivity_timer_enable">
                                 <property name="valign">center</property>
                             </object>
                         </child>

--- a/data/ui/preferences_general.ui
+++ b/data/ui/preferences_general.ui
@@ -87,12 +87,19 @@
 
                 <child>
                     <object class="AdwActionRow">
-                        <property name="title" translatable="yes">Inactivity Timeout</property>
+                        <property name="title" translatable="yes">Enable Inactivity Timer</property>
+                        <property name="activatable-widget">inactivity_timer_enable</property>
                         <child>
                             <object class="GtkSwitch" id="inactivity_timer_enable">
                                 <property name="valign">center</property>
                             </object>
                         </child>
+                    </object>
+                </child>
+
+                <child>
+                    <object class="AdwActionRow">
+                        <property name="title" translatable="yes">Inactivity Timeout</property>
                         <child>
                             <object class="GtkSpinButton" id="inactivity_timeout">
                                 <property name="valign">center</property>

--- a/data/ui/preferences_general.ui
+++ b/data/ui/preferences_general.ui
@@ -88,7 +88,11 @@
                 <child>
                     <object class="AdwActionRow">
                         <property name="title" translatable="yes">Inactivity Timeout</property>
-
+                        <child>
+                            <object class="GtkSwitch" id="inactivity_timer_enabled">
+                                <property name="valign">center</property>
+                            </object>
+                        </child>
                         <child>
                             <object class="GtkSpinButton" id="inactivity_timeout">
                                 <property name="valign">center</property>
@@ -97,7 +101,7 @@
                                 <property name="update-policy">if-valid</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
-                                        <property name="lower">0</property>
+                                        <property name="lower">1</property>
                                         <property name="upper">3600</property>
                                         <property name="step-increment">1</property>
                                         <property name="page-increment">10</property>

--- a/data/ui/preferences_general.ui
+++ b/data/ui/preferences_general.ui
@@ -97,7 +97,7 @@
                                 <property name="update-policy">if-valid</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
-                                        <property name="lower">1</property>
+                                        <property name="lower">0</property>
                                         <property name="upper">3600</property>
                                         <property name="step-increment">1</property>
                                         <property name="page-increment">10</property>

--- a/src/preferences_general.cpp
+++ b/src/preferences_general.cpp
@@ -27,7 +27,7 @@ struct _PreferencesGeneral {
   AdwPreferencesPage parent_instance;
 
   GtkSwitch *enable_autostart, *process_all_inputs, *process_all_outputs, *theme_switch, *shutdown_on_window_close,
-      *use_cubic_volumes, *autohide_popovers, *exclude_monitor_streams, *show_native_plugin_ui;
+      *use_cubic_volumes, *inactivity_timer_enable, *autohide_popovers, *exclude_monitor_streams, *show_native_plugin_ui;
 
   GtkSpinButton *inactivity_timeout, *meters_update_interval, *lv2ui_update_frequency;
 
@@ -127,11 +127,11 @@ void preferences_general_init(PreferencesGeneral* self) {
   // initializing some widgets
 
   gsettings_bind_widgets<"process-all-inputs", "process-all-outputs", "use-dark-theme", "shutdown-on-window-close",
-                         "use-cubic-volumes", "autohide-popovers", "exclude-monitor-streams", "inactivity-timeout",
+                         "use-cubic-volumes", "autohide-popovers", "exclude-monitor-streams", "inactivity-timer-enable", "inactivity-timeout",
                          "meters-update-interval", "lv2ui-update-frequency", "show-native-plugin-ui">(
       self->settings, self->process_all_inputs, self->process_all_outputs, self->theme_switch,
       self->shutdown_on_window_close, self->use_cubic_volumes, self->autohide_popovers, self->exclude_monitor_streams,
-      self->inactivity_timeout, self->meters_update_interval, self->lv2ui_update_frequency,
+      self->inactivity_timer_enable, self->inactivity_timeout, self->meters_update_interval, self->lv2ui_update_frequency,
       self->show_native_plugin_ui);
 
 #ifdef ENABLE_LIBPORTAL

--- a/src/preferences_general.cpp
+++ b/src/preferences_general.cpp
@@ -109,6 +109,7 @@ void preferences_general_class_init(PreferencesGeneralClass* klass) {
   gtk_widget_class_bind_template_child(widget_class, PreferencesGeneral, shutdown_on_window_close);
   gtk_widget_class_bind_template_child(widget_class, PreferencesGeneral, use_cubic_volumes);
   gtk_widget_class_bind_template_child(widget_class, PreferencesGeneral, exclude_monitor_streams);
+  gtk_widget_class_bind_template_child(widget_class, PreferencesGeneral, inactivity_timer_enable);
   gtk_widget_class_bind_template_child(widget_class, PreferencesGeneral, inactivity_timeout);
   gtk_widget_class_bind_template_child(widget_class, PreferencesGeneral, meters_update_interval);
   gtk_widget_class_bind_template_child(widget_class, PreferencesGeneral, lv2ui_update_frequency);

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -160,17 +160,21 @@ void StreamInputEffects::on_link_changed(const LinkInfo link_info) {
   } else {
     int inactivity_timeout = g_settings_get_int(global_settings, "inactivity-timeout");
 
-    g_timeout_add_seconds(inactivity_timeout, GSourceFunc(+[](StreamInputEffects* self) {
-                            if (!self->apps_want_to_play() && !self->list_proxies.empty()) {
-                              util::debug("No app linked to our device wants to play. Unlinking our filters.");
+    if (inactivity_timeout == 0) {
+      util::debug("No app linked to our device wants to play, but the inactivity timer is set to 0. Leaving filters linked.");
+    } else {
+      g_timeout_add_seconds(inactivity_timeout, GSourceFunc(+[](StreamInputEffects* self) {
+                              if (!self->apps_want_to_play() && !self->list_proxies.empty()) {
+                                util::debug("No app linked to our device wants to play. Unlinking our filters.");
 
-                              self->disconnect_filters();
-                            }
+                                self->disconnect_filters();
+                              }
 
-                            return G_SOURCE_REMOVE;
-                          }),
-                          this);
-  }
+                              return G_SOURCE_REMOVE;
+                            }),
+                            this);
+    };
+  };
 }
 
 void StreamInputEffects::connect_filters(const bool& bypass) {

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -156,15 +156,13 @@ void StreamInputEffects::on_link_changed(const LinkInfo link_info) {
       util::debug("At least one app linked to our device wants to play. Linking our filters.");
 
       connect_filters();
-    }
+    };
   } else {
-    int inactivity_timeout = g_settings_get_int(global_settings, "inactivity-timeout");
+    // no apps want to play, check if the inactivity timer is enabled
+    if (g_settings_get_boolean(global_settings, "inactivity-timer-enabled")) {
 
-    if (inactivity_timeout == 0) {
-      if (!list_proxies.empty()) {
-        util::debug("No app linked to our device wants to play, but the inactivity timer is set to 0. Leaving filters linked.");
-      };
-    } else {
+      // if the timer is enabled, wait for the timeout, then unlink plugin pipeline
+      int inactivity_timeout = g_settings_get_int(global_settings, "inactivity-timeout");
       g_timeout_add_seconds(inactivity_timeout, GSourceFunc(+[](StreamInputEffects* self) {
                               if (!self->apps_want_to_play() && !self->list_proxies.empty()) {
                                 util::debug("No app linked to our device wants to play. Unlinking our filters.");
@@ -175,7 +173,14 @@ void StreamInputEffects::on_link_changed(const LinkInfo link_info) {
                               return G_SOURCE_REMOVE;
                             }),
                             this);
+
+    } else {
+      // otherwise, do nothing
+      if (!list_proxies.empty()) {
+        util::debug("No app linked to our device wants to play, but the inactivity timer is disabled. Leaving filters linked.");
+      };
     };
+
   };
 }
 

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -159,7 +159,7 @@ void StreamInputEffects::on_link_changed(const LinkInfo link_info) {
     };
   } else {
     // no apps want to play, check if the inactivity timer is enabled
-    if (g_settings_get_boolean(global_settings, "inactivity-timer-enabled")) {
+    if (g_settings_get_boolean(global_settings, "inactivity-timer-enable")) {
 
       // if the timer is enabled, wait for the timeout, then unlink plugin pipeline
       int inactivity_timeout = g_settings_get_int(global_settings, "inactivity-timeout");

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -161,7 +161,7 @@ void StreamInputEffects::on_link_changed(const LinkInfo link_info) {
     int inactivity_timeout = g_settings_get_int(global_settings, "inactivity-timeout");
 
     if (inactivity_timeout == 0) {
-      if (list_proxies.empty()) {
+      if (!list_proxies.empty()) {
         util::debug("No app linked to our device wants to play, but the inactivity timer is set to 0. Leaving filters linked.");
       };
     } else {

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -161,7 +161,9 @@ void StreamInputEffects::on_link_changed(const LinkInfo link_info) {
     int inactivity_timeout = g_settings_get_int(global_settings, "inactivity-timeout");
 
     if (inactivity_timeout == 0) {
-      util::debug("No app linked to our device wants to play, but the inactivity timer is set to 0. Leaving filters linked.");
+      if (list_proxies.empty()) {
+        util::debug("No app linked to our device wants to play, but the inactivity timer is set to 0. Leaving filters linked.");
+      };
     } else {
       g_timeout_add_seconds(inactivity_timeout, GSourceFunc(+[](StreamInputEffects* self) {
                               if (!self->apps_want_to_play() && !self->list_proxies.empty()) {

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -155,7 +155,9 @@ void StreamOutputEffects::on_link_changed(const LinkInfo link_info) {
     int inactivity_timeout = g_settings_get_int(global_settings, "inactivity-timeout");
 
     if (inactivity_timeout == 0) {
-      util::debug("No app linked to our device wants to play, but the inactivity timer is set to 0. Leaving filters linked.");
+      if (list_proxies.empty()) {
+        util::debug("No app linked to our device wants to play, but the inactivity timer is set to 0. Leaving filters linked.");
+      };
     } else {
       g_timeout_add_seconds(inactivity_timeout, GSourceFunc(+[](StreamOutputEffects* self) {
                               if (!self->apps_want_to_play() && !self->list_proxies.empty()) {

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -155,7 +155,7 @@ void StreamOutputEffects::on_link_changed(const LinkInfo link_info) {
     int inactivity_timeout = g_settings_get_int(global_settings, "inactivity-timeout");
 
     if (inactivity_timeout == 0) {
-      if (list_proxies.empty()) {
+      if (!list_proxies.empty()) {
         util::debug("No app linked to our device wants to play, but the inactivity timer is set to 0. Leaving filters linked.");
       };
     } else {

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -153,7 +153,7 @@ void StreamOutputEffects::on_link_changed(const LinkInfo link_info) {
     };
   } else {
     // no apps want to play, check if the inactivity timer is enabled
-    if ( g_settings_get_boolean(global_settings, "inactivity-timer-enabled") ) {
+    if ( g_settings_get_boolean(global_settings, "inactivity-timer-enable") ) {
       
       // if the timer is enabled, wait for the timeout, then unlink plugin pipeline
       int inactivity_timeout = g_settings_get_int(global_settings, "inactivity-timeout");

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -150,15 +150,13 @@ void StreamOutputEffects::on_link_changed(const LinkInfo link_info) {
       util::debug("At least one app linked to our device wants to play. Linking our filters.");
 
       connect_filters();
-    }
+    };
   } else {
-    int inactivity_timeout = g_settings_get_int(global_settings, "inactivity-timeout");
-
-    if (inactivity_timeout == 0) {
-      if (!list_proxies.empty()) {
-        util::debug("No app linked to our device wants to play, but the inactivity timer is set to 0. Leaving filters linked.");
-      };
-    } else {
+    // no apps want to play, check if the inactivity timer is enabled
+    if ( g_settings_get_boolean(global_settings, "inactivity-timer-enabled") ) {
+      
+      // if the timer is enabled, wait for the timeout, then unlink plugin pipeline
+      int inactivity_timeout = g_settings_get_int(global_settings, "inactivity-timeout");
       g_timeout_add_seconds(inactivity_timeout, GSourceFunc(+[](StreamOutputEffects* self) {
                               if (!self->apps_want_to_play() && !self->list_proxies.empty()) {
                                 util::debug("No app linked to our device wants to play. Unlinking our filters.");
@@ -169,7 +167,14 @@ void StreamOutputEffects::on_link_changed(const LinkInfo link_info) {
                               return G_SOURCE_REMOVE;
                             }),
                             this);
+
+    } else {
+      // otherwise, do nothing
+      if (!list_proxies.empty()) {
+        util::debug("No app linked to our device wants to play, but the inactivity timer is disabled. Leaving filters linked.");
+      };
     };
+
   };
 }
 

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -154,17 +154,21 @@ void StreamOutputEffects::on_link_changed(const LinkInfo link_info) {
   } else {
     int inactivity_timeout = g_settings_get_int(global_settings, "inactivity-timeout");
 
-    g_timeout_add_seconds(inactivity_timeout, GSourceFunc(+[](StreamOutputEffects* self) {
-                            if (!self->apps_want_to_play() && !self->list_proxies.empty()) {
-                              util::debug("No app linked to our device wants to play. Unlinking our filters.");
+    if (inactivity_timeout == 0) {
+      util::debug("No app linked to our device wants to play, but the inactivity timer is set to 0. Leaving filters linked.");
+    } else {
+      g_timeout_add_seconds(inactivity_timeout, GSourceFunc(+[](StreamOutputEffects* self) {
+                              if (!self->apps_want_to_play() && !self->list_proxies.empty()) {
+                                util::debug("No app linked to our device wants to play. Unlinking our filters.");
 
-                              self->disconnect_filters();
-                            }
+                                self->disconnect_filters();
+                              }
 
-                            return G_SOURCE_REMOVE;
-                          }),
-                          this);
-  }
+                              return G_SOURCE_REMOVE;
+                            }),
+                            this);
+    };
+  };
 }
 
 void StreamOutputEffects::connect_filters(const bool& bypass) {


### PR DESCRIPTION
For users who do not care about saving CPU cycles, and would rather their effects chain be always ready for audio, allow the inactivity timeout to be disabled by setting the "Inactivity Timeout" setting to 0