### PR TITLE
Fix compatabilty with old pipewire servers

### DIFF
--- a/util/flatpak/com.github.wwmm.easyeffects.Devel.json
+++ b/util/flatpak/com.github.wwmm.easyeffects.Devel.json
@@ -1,7 +1,7 @@
 {
     "id": "com.github.wwmm.easyeffects.Devel",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "45",
+    "runtime-version": "44",
     "sdk": "org.gnome.Sdk",
     "command": "easyeffects",
     "finish-args": [

--- a/util/flatpak/com.github.wwmm.easyeffects.Devel.json
+++ b/util/flatpak/com.github.wwmm.easyeffects.Devel.json
@@ -1,7 +1,7 @@
 {
     "id": "com.github.wwmm.easyeffects.Devel",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
     "command": "easyeffects",
     "finish-args": [

--- a/util/flatpak/easyeffects-modules.json
+++ b/util/flatpak/easyeffects-modules.json
@@ -2,6 +2,27 @@
     "name": "easyeffects-modules",
     "modules": [
         {
+            "name": "pipewire",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dgstreamer=disabled",
+                "-Dman=disabled",
+                "-Dsystemd=disabled",
+                "-Dudev=disabled",
+                "-Dudevrulesdir=disabled",
+                "-Dsession-managers=[]",
+                "-Djack=enabled"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/pipewire/pipewire.git",
+                    "tag": "0.3.69",
+                    "commit": "cd8be0ba3b27542253f7744b699c2ede159e2d7c"
+                }
+            ]
+        },
+        {
             "name": "libsigc++",
             "buildsystem": "meson",
             "config-opts": [


### PR DESCRIPTION
Many recent reports of easyeffects breaking when used with an older pipewire server.

[This comment](https://github.com/wwmm/easyeffects/issues/2732#issuecomment-1817535159) seems to suggest that reverting the runtime may help.