### PR TITLE
Export apo preset

### DIFF
--- a/data/ui/equalizer.ui
+++ b/data/ui/equalizer.ui
@@ -357,6 +357,32 @@
                                                         </child>
                                                     </object>
                                                 </child>
+
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="label" translatable="yes">Export Preset</property>
+                                                        <property name="valign">center</property>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkBox">
+                                                        <property name="orientation">vertical</property>
+                                                        <property name="valign">center</property>
+
+                                                        <style>
+                                                            <class name="linked" />
+                                                        </style>
+
+                                                        <child>
+                                                            <object class="GtkButton" id="export_apo">
+                                                                <property name="label">APO</property>
+                                                                <property name="valign">center</property>
+                                                                <signal name="clicked" handler="on_export_apo_preset_clicked" object="EqualizerBox" />
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
                                             </object>
                                         </child>
                                     </object>

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -38,7 +38,7 @@ struct GraphicEQ_Band {
   float gain = 0.0F;
 };
 
-std::unordered_map<std::string, std::string> const FilterTypeMap = {
+std::unordered_map<std::string, std::string> const ApoToEasyEffectsFilter = {
     {"PK", "Bell"},          {"MODAL", "Bell"},  {"PEQ", "Bell"},     {"LP", "Lo-pass"},      {"LPQ", "Lo-pass"},
     {"HP", "Hi-pass"},       {"HPQ", "Hi-pass"}, {"LS", "Lo-shelf"},  {"LSC", "Lo-shelf"},    {"LS 6DB", "Lo-shelf"},
     {"LS 12DB", "Lo-shelf"}, {"HS", "Hi-shelf"}, {"HSC", "Hi-shelf"}, {"HS 6DB", "Hi-shelf"}, {"HS 12DB", "Hi-shelf"},
@@ -368,7 +368,7 @@ auto import_apo_preset(EqualizerBox* self, const std::string& file_path) -> bool
         std::string curr_band_type;
 
         try {
-          curr_band_type = FilterTypeMap.at(bands[n].type);
+          curr_band_type = ApoToEasyEffectsFilter.at(bands[n].type);
         } catch (std::out_of_range const&) {
           curr_band_type = "Off";
         }


### PR DESCRIPTION
Adding support for exporting equalizer presets to EqualizerAPO preset files, to complement the already in-place import functionality. For now does not support split channels (added popup when attempting).

I have an export_geq_preset ready as well that simply treats the GEQ filters as Bell filters, similar to how import_geq_preset is currently implemented, but not sure if I should add it, considering they aren't actually implemented as Bell/Peak filters in APO (as discussed in #1808 [here](https://github.com/wwmm/easyeffects/issues/1808#issuecomment-1732255085)).

I personally feel like putting the import/export buttons in their current location becomes a bit cluttered as more options are added, but I don't want to start messing with the ui layout, so just adding them logically beneath the current import buttons for now.
