### PR TITLE
Change the spin button to a slider in the app info ui

### DIFF
--- a/data/ui/app_info.ui
+++ b/data/ui/app_info.ui
@@ -252,12 +252,10 @@
                                 </child>
 
                                 <child>
-                                    <object class="GtkSpinButton" id="volume">
+                                    <object class="GtkScale" id="volume">
                                         <property name="sensitive" bind-source="mute" bind-property="active" bind-flags="sync-create|invert-boolean" />
                                         <property name="hexpand">1</property>
-                                        <property name="xalign">0.5</property>
-                                        <property name="digits">0</property>
-                                        <property name="update-policy">if-valid</property>
+                                        <property name="digits">1</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">0</property>

--- a/data/ui/app_info.ui
+++ b/data/ui/app_info.ui
@@ -17,7 +17,6 @@
                 <!-- Application info section -->
                 <child>
                     <object class="GtkBox">
-                        <property name="hexpand">1</property>
                         <property name="halign">start</property>
                         <property name="valign">center</property>
                         <property name="spacing">6</property>
@@ -192,7 +191,6 @@
 
                 <child>
                     <object class="GtkBox">
-                        <property name="halign">end</property>
                         <property name="valign">center</property>
                         <property name="spacing">12</property>
                         <property name="orientation">vertical</property>
@@ -201,13 +199,12 @@
                         <property name="margin-bottom">6</property>
                         <child>
                             <object class="GtkBox" id="enable_box">
-                                <property name="halign">end</property>
                                 <property name="valign">center</property>
                                 <property name="spacing">8</property>
                                 <!-- Enable section -->
                                 <child>
                                     <object class="GtkCheckButton" id="enable">
-                                        <property name="halign">end</property>
+                                        <property name="halign">start</property>
                                         <property name="valign">center</property>
                                         <property name="tooltip-text" translatable="yes">Enable/disable this application</property>
                                         <property name="label" translatable="yes">Enable</property>
@@ -220,7 +217,7 @@
                                 <!-- Exclude section -->
                                 <child>
                                     <object class="GtkCheckButton" id="blocklist">
-                                        <property name="halign">end</property>
+                                        <property name="halign">start</property>
                                         <property name="valign">center</property>
                                         <property name="tooltip-text" translatable="yes">Excluded App List: Add/remove this application</property>
                                         <property name="label" translatable="yes">Exclude</property>
@@ -235,12 +232,7 @@
                         <!-- Volume section -->
                         <child>
                             <object class="GtkBox" id="volume_box">
-                                <property name="width-request">300</property>
-                                <property name="halign">end</property>
                                 <property name="valign">center</property>
-                                <style>
-                                    <class name="linked" />
-                                </style>
 
                                 <child>
                                     <object class="GtkToggleButton" id="mute">

--- a/data/ui/app_info.ui
+++ b/data/ui/app_info.ui
@@ -235,6 +235,7 @@
                         <!-- Volume section -->
                         <child>
                             <object class="GtkBox" id="volume_box">
+                                <property name="width-request">300</property>
                                 <property name="halign">end</property>
                                 <property name="valign">center</property>
                                 <style>
@@ -254,8 +255,11 @@
                                 <child>
                                     <object class="GtkScale" id="volume">
                                         <property name="sensitive" bind-source="mute" bind-property="active" bind-flags="sync-create|invert-boolean" />
+
                                         <property name="hexpand">1</property>
-                                        <property name="digits">1</property>
+                                        <property name="draw-value">1</property>
+                                        <property name="value-pos">1</property>
+                                        <property name="digits">0</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">0</property>

--- a/src/app_info.cpp
+++ b/src/app_info.cpp
@@ -46,7 +46,7 @@ struct _AppInfo {
 
   GtkToggleButton* mute;
 
-  GtkSpinButton* volume;
+  GtkScale* volume;
 
   GtkCheckButton *blocklist, *enable;
 
@@ -176,8 +176,9 @@ void on_enable(GtkCheckButton* btn, AppInfo* self) {
   }
 }
 
-void on_volume_changed(GtkSpinButton* sbtn, AppInfo* self) {
-  auto vol = static_cast<float>(gtk_spin_button_get_value(sbtn)) / 100.0F;
+void on_volume_changed(GtkRange* gscale, AppInfo* self) {
+  auto vol = static_cast<float>(gtk_range_get_value(gscale)) / 100.0F;
+  
 
   if (g_settings_get_boolean(self->app_settings, "use-cubic-volumes") != 0) {
     vol = vol * vol * vol;
@@ -276,9 +277,9 @@ void update(AppInfo* self, const NodeInfo node_info) {
   g_signal_handler_block(self->volume, self->data->handler_id_volume);
 
   if (g_settings_get_boolean(self->app_settings, "use-cubic-volumes") != 0) {
-    gtk_spin_button_set_value(self->volume, 100.0 * std::cbrt(static_cast<double>(node_info.volume)));
+    gtk_range_set_value(reinterpret_cast<GtkRange*>(self->volume), 100.0 * std::cbrt(static_cast<double>(node_info.volume)));
   } else {
-    gtk_spin_button_set_value(self->volume, 100.0 * static_cast<double>(node_info.volume));
+    gtk_range_set_value(reinterpret_cast<GtkRange*>(self->volume), 100.0 * static_cast<double>(node_info.volume));
   }
 
   g_signal_handler_unblock(self->volume, self->data->handler_id_volume);
@@ -385,7 +386,7 @@ void app_info_init(AppInfo* self) {
 
   self->app_settings = g_settings_new(tags::app::id);
 
-  prepare_spinbuttons<"%">(self->volume);
+  prepare_scale<"%">(self->volume);
 
   self->data->handler_id_enable = g_signal_connect(self->enable, "toggled", G_CALLBACK(on_enable), self);
   self->data->handler_id_volume = g_signal_connect(self->volume, "value-changed", G_CALLBACK(on_volume_changed), self);

--- a/src/app_info.cpp
+++ b/src/app_info.cpp
@@ -277,9 +277,9 @@ void update(AppInfo* self, const NodeInfo node_info) {
   g_signal_handler_block(self->volume, self->data->handler_id_volume);
 
   if (g_settings_get_boolean(self->app_settings, "use-cubic-volumes") != 0) {
-    gtk_range_set_value(reinterpret_cast<GtkRange*>(self->volume), 100.0 * std::cbrt(static_cast<double>(node_info.volume)));
+    gtk_range_set_value(GTK_RANGE(self->volume), 100.0 * std::cbrt(static_cast<double>(node_info.volume)));
   } else {
-    gtk_range_set_value(reinterpret_cast<GtkRange*>(self->volume), 100.0 * static_cast<double>(node_info.volume));
+    gtk_range_set_value(GTK_RANGE(self->volume), 100.0 * static_cast<double>(node_info.volume));
   }
 
   g_signal_handler_unblock(self->volume, self->data->handler_id_volume);


### PR DESCRIPTION
As i understand it was a slider before but for some reason was changed to a spin button? Anyway in my opinion a slider is just faster and easier to use. 

Here's what this PR proposes:
![20240126_16h04m03s_grim](https://github.com/wwmm/easyeffects/assets/57047474/d677efee-9511-4bc9-a120-3ba5ee32c8e1)