### PR TITLE
Bump actions upload pages action version

### DIFF
--- a/.github/workflows/deploy-help.yaml
+++ b/.github/workflows/deploy-help.yaml
@@ -40,7 +40,7 @@ jobs:
           yelp-build html -o help/dist-html help/C
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2.0.0
+        uses: actions/upload-pages-artifact@v3.0.0
         with:
           path: help/dist-html
 


### PR DESCRIPTION
As this action needs to be a version compatible with the deploy pages action.