### PR TITLE
Equalizer APO: fix regex

### DIFF
--- a/include/app_info.hpp
+++ b/include/app_info.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/application.hpp
+++ b/include/application.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/application_ui.hpp
+++ b/include/application_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/apps_box.hpp
+++ b/include/apps_box.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/autogain.hpp
+++ b/include/autogain.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/autogain_preset.hpp
+++ b/include/autogain_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/autogain_ui.hpp
+++ b/include/autogain_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/bass_enhancer.hpp
+++ b/include/bass_enhancer.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/bass_enhancer_preset.hpp
+++ b/include/bass_enhancer_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects
  *

--- a/include/bass_enhancer_ui.hpp
+++ b/include/bass_enhancer_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/bass_loudness.hpp
+++ b/include/bass_loudness.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/bass_loudness_preset.hpp
+++ b/include/bass_loudness_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects
  *

--- a/include/bass_loudness_ui.hpp
+++ b/include/bass_loudness_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/blocklist_menu.hpp
+++ b/include/blocklist_menu.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/chart.hpp
+++ b/include/chart.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/client_info_holder.hpp
+++ b/include/client_info_holder.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/compressor.hpp
+++ b/include/compressor.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/compressor_preset.hpp
+++ b/include/compressor_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/compressor_ui.hpp
+++ b/include/compressor_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/convolver.hpp
+++ b/include/convolver.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects
  *

--- a/include/convolver_menu_combine.hpp
+++ b/include/convolver_menu_combine.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/convolver_menu_impulses.hpp
+++ b/include/convolver_menu_impulses.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/convolver_preset.hpp
+++ b/include/convolver_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/convolver_ui.hpp
+++ b/include/convolver_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/convolver_ui_common.hpp
+++ b/include/convolver_ui_common.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/crossfeed.hpp
+++ b/include/crossfeed.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/crossfeed_preset.hpp
+++ b/include/crossfeed_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/crossfeed_ui.hpp
+++ b/include/crossfeed_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/crystalizer.hpp
+++ b/include/crystalizer.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/crystalizer_preset.hpp
+++ b/include/crystalizer_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/crystalizer_ui.hpp
+++ b/include/crystalizer_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/deesser.hpp
+++ b/include/deesser.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/deesser_preset.hpp
+++ b/include/deesser_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/deesser_ui.hpp
+++ b/include/deesser_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/delay.hpp
+++ b/include/delay.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/delay_preset.hpp
+++ b/include/delay_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/delay_ui.hpp
+++ b/include/delay_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/echo_canceller.hpp
+++ b/include/echo_canceller.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/echo_canceller_preset.hpp
+++ b/include/echo_canceller_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/echo_canceller_ui.hpp
+++ b/include/echo_canceller_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/effects_base.hpp
+++ b/include/effects_base.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/effects_box.hpp
+++ b/include/effects_box.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/equalizer.hpp
+++ b/include/equalizer.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects
  *

--- a/include/equalizer_band_box.hpp
+++ b/include/equalizer_band_box.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/equalizer_preset.hpp
+++ b/include/equalizer_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/equalizer_ui.hpp
+++ b/include/equalizer_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/exciter.hpp
+++ b/include/exciter.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/exciter_preset.hpp
+++ b/include/exciter_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/exciter_ui.hpp
+++ b/include/exciter_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/expander.hpp
+++ b/include/expander.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/expander_preset.hpp
+++ b/include/expander_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/expander_ui.hpp
+++ b/include/expander_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/filter.hpp
+++ b/include/filter.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/filter_preset.hpp
+++ b/include/filter_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/filter_ui.hpp
+++ b/include/filter_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/fir_filter_bandpass.hpp
+++ b/include/fir_filter_bandpass.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/fir_filter_base.hpp
+++ b/include/fir_filter_base.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/fir_filter_highpass.hpp
+++ b/include/fir_filter_highpass.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/fir_filter_lowpass.hpp
+++ b/include/fir_filter_lowpass.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/gate.hpp
+++ b/include/gate.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/gate_preset.hpp
+++ b/include/gate_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/gate_ui.hpp
+++ b/include/gate_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/level_meter.hpp
+++ b/include/level_meter.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/level_meter_preset.hpp
+++ b/include/level_meter_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/level_meter_ui.hpp
+++ b/include/level_meter_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/libportal.hpp
+++ b/include/libportal.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/limiter.hpp
+++ b/include/limiter.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/limiter_preset.hpp
+++ b/include/limiter_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/limiter_ui.hpp
+++ b/include/limiter_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/loudness.hpp
+++ b/include/loudness.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/loudness_preset.hpp
+++ b/include/loudness_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/loudness_ui.hpp
+++ b/include/loudness_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/lv2_wrapper.hpp
+++ b/include/lv2_wrapper.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/maximizer.hpp
+++ b/include/maximizer.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/maximizer_preset.hpp
+++ b/include/maximizer_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/maximizer_ui.hpp
+++ b/include/maximizer_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/module_info_holder.hpp
+++ b/include/module_info_holder.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/multiband_compressor.hpp
+++ b/include/multiband_compressor.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/multiband_compressor_band_box.hpp
+++ b/include/multiband_compressor_band_box.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/multiband_compressor_preset.hpp
+++ b/include/multiband_compressor_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/multiband_compressor_ui.hpp
+++ b/include/multiband_compressor_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/multiband_gate.hpp
+++ b/include/multiband_gate.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/multiband_gate_band_box.hpp
+++ b/include/multiband_gate_band_box.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/multiband_gate_preset.hpp
+++ b/include/multiband_gate_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/multiband_gate_ui.hpp
+++ b/include/multiband_gate_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/node_info_holder.hpp
+++ b/include/node_info_holder.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/output_level.hpp
+++ b/include/output_level.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/pipe_manager.hpp
+++ b/include/pipe_manager.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/pipe_manager_box.hpp
+++ b/include/pipe_manager_box.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/pipeline_type.hpp
+++ b/include/pipeline_type.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/pitch.hpp
+++ b/include/pitch.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/pitch_preset.hpp
+++ b/include/pitch_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/pitch_ui.hpp
+++ b/include/pitch_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/plugin_base.hpp
+++ b/include/plugin_base.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/plugin_preset_base.hpp
+++ b/include/plugin_preset_base.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/plugins_box.hpp
+++ b/include/plugins_box.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/plugins_menu.hpp
+++ b/include/plugins_menu.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/preferences_general.hpp
+++ b/include/preferences_general.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/preferences_spectrum.hpp
+++ b/include/preferences_spectrum.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/preferences_window.hpp
+++ b/include/preferences_window.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/preset_type.hpp
+++ b/include/preset_type.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/presets_autoloading_holder.hpp
+++ b/include/presets_autoloading_holder.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/presets_manager.hpp
+++ b/include/presets_manager.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/presets_menu.hpp
+++ b/include/presets_menu.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/resampler.hpp
+++ b/include/resampler.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/reverb.hpp
+++ b/include/reverb.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/reverb_preset.hpp
+++ b/include/reverb_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/reverb_ui.hpp
+++ b/include/reverb_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/rnnoise.hpp
+++ b/include/rnnoise.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/rnnoise_preset.hpp
+++ b/include/rnnoise_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/rnnoise_ui.hpp
+++ b/include/rnnoise_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/spectrum.hpp
+++ b/include/spectrum.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/speex.hpp
+++ b/include/speex.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/speex_preset.hpp
+++ b/include/speex_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/speex_ui.hpp
+++ b/include/speex_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/stereo_tools.hpp
+++ b/include/stereo_tools.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/stereo_tools_preset.hpp
+++ b/include/stereo_tools_preset.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/stereo_tools_ui.hpp
+++ b/include/stereo_tools_ui.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/stream_input_effects.hpp
+++ b/include/stream_input_effects.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/stream_output_effects.hpp
+++ b/include/stream_output_effects.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/string_literal_wrapper.hpp
+++ b/include/string_literal_wrapper.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/tags_app.hpp
+++ b/include/tags_app.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/tags_equalizer.hpp
+++ b/include/tags_equalizer.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/tags_multiband_compressor.hpp
+++ b/include/tags_multiband_compressor.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/tags_multiband_gate.hpp
+++ b/include/tags_multiband_gate.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/tags_pipewire.hpp
+++ b/include/tags_pipewire.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/tags_plugin_name.hpp
+++ b/include/tags_plugin_name.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/tags_resources.hpp
+++ b/include/tags_resources.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/tags_schema.hpp
+++ b/include/tags_schema.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/test_signals.hpp
+++ b/include/test_signals.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/ui_helpers.hpp
+++ b/include/ui_helpers.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/app_info.cpp
+++ b/src/app_info.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/application_ui.cpp
+++ b/src/application_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/apps_box.cpp
+++ b/src/apps_box.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/autogain.cpp
+++ b/src/autogain.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/autogain_preset.cpp
+++ b/src/autogain_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/autogain_ui.cpp
+++ b/src/autogain_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/bass_enhancer.cpp
+++ b/src/bass_enhancer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/bass_enhancer_preset.cpp
+++ b/src/bass_enhancer_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/bass_enhancer_ui.cpp
+++ b/src/bass_enhancer_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/bass_loudness.cpp
+++ b/src/bass_loudness.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/bass_loudness_preset.cpp
+++ b/src/bass_loudness_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/bass_loudness_ui.cpp
+++ b/src/bass_loudness_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/blocklist_menu.cpp
+++ b/src/blocklist_menu.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/chart.cpp
+++ b/src/chart.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/client_info_holder.cpp
+++ b/src/client_info_holder.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/compressor_preset.cpp
+++ b/src/compressor_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/compressor_ui.cpp
+++ b/src/compressor_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/convolver.cpp
+++ b/src/convolver.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/convolver_menu_combine.cpp
+++ b/src/convolver_menu_combine.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/convolver_menu_impulses.cpp
+++ b/src/convolver_menu_impulses.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/convolver_preset.cpp
+++ b/src/convolver_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/convolver_ui_common.cpp
+++ b/src/convolver_ui_common.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/crossfeed.cpp
+++ b/src/crossfeed.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/crossfeed_preset.cpp
+++ b/src/crossfeed_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/crossfeed_ui.cpp
+++ b/src/crossfeed_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/crystalizer.cpp
+++ b/src/crystalizer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/crystalizer_preset.cpp
+++ b/src/crystalizer_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/crystalizer_ui.cpp
+++ b/src/crystalizer_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/deesser.cpp
+++ b/src/deesser.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/deesser_preset.cpp
+++ b/src/deesser_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/deesser_ui.cpp
+++ b/src/deesser_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/delay.cpp
+++ b/src/delay.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/delay_preset.cpp
+++ b/src/delay_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/delay_ui.cpp
+++ b/src/delay_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/easyeffects.cpp
+++ b/src/easyeffects.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/echo_canceller.cpp
+++ b/src/echo_canceller.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/echo_canceller_preset.cpp
+++ b/src/echo_canceller_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/echo_canceller_ui.cpp
+++ b/src/echo_canceller_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/effects_base.cpp
+++ b/src/effects_base.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/effects_box.cpp
+++ b/src/effects_box.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/equalizer.cpp
+++ b/src/equalizer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/equalizer_band_box.cpp
+++ b/src/equalizer_band_box.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/equalizer_preset.cpp
+++ b/src/equalizer_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -187,11 +187,7 @@ auto parse_apo_filter(const std::string& line, struct APO_Band& filter) -> bool 
   std::transform(filter.type.begin(), filter.type.end(), filter.type.begin(),
                  [](unsigned char c) { return std::toupper(c); });
 
-  if (filter.type.empty()) {
-    return false;
-  }
-
-  return true;
+  return !filter.type.empty();
 }
 
 auto parse_apo_frequency(const std::string& line, struct APO_Band& filter) -> bool {
@@ -241,34 +237,49 @@ auto parse_apo_quality(const std::string& line, struct APO_Band& filter) -> bool
 auto parse_apo_on_off(const std::string& line, struct APO_Band& filter) -> bool {
   std::smatch matches;
 
-  static const auto re_on_off =
-      std::regex(R"(Filter\s*\d*\s*:\s*(on|off)(?=\s+[a-z]+(?:\s+(?:6|12)db)?))", std::regex::icase);
+  static const auto re_on_off = std::regex(R"(filter\s*\d*\s*:\s*(on|off))", std::regex::icase);
 
   std::regex_search(line, matches, re_on_off);
 
-  // using the 2-group match format to comply with other functions, but maybe switch to non-capture groups?
   if (matches.size() != 2U) {
     return false;
   }
 
-  // idk if this is needed; used in parse_apo_filter
-  filter.on_off = std::regex_replace(matches.str(1), std::regex(R"(\s+)"), " ");
+  filter.on_off = matches.str(1);
+
+  // The regex is permissive using std::regex::icase flag, but we need
+  // on/off string in uppercase for string comparisons in import operations.
+  std::transform(filter.on_off.begin(), filter.on_off.end(), filter.on_off.begin(),
+                 [](unsigned char c) { return std::toupper(c); });
 
   return true;
 }
 
 auto parse_apo_config_line(const std::string& line, struct APO_Band& filter) -> bool {
+  // Retrieve filter type.
   if (!parse_apo_filter(line, filter)) {
     return false;
   }
 
-  // The configuration line refers to an existing APO filter, so we try to get the other parameters.
-  parse_apo_frequency(line, filter);
-  parse_apo_on_off(line, filter);
+  // Retrieve on/off state.
+  if (!parse_apo_on_off(line, filter)) {
+    return false;
+  }
 
-  // Inspired by function "para_equalizer_ui::import_rew_file(const LSPString*)"
+  // Retrieve frequency.
+  // To make it more permissive, we do not exit on false here (assume default).
+  parse_apo_frequency(line, filter);
+
+  // The following has been inspired by the function
+  // "para_equalizer_ui::import_rew_file(const LSPString*)"
   // inside 'lsp-plugins/src/ui/plugins/para_equalizer_ui.cpp' at
   // https://github.com/sadko4u/lsp-plugins
+
+  // Retrieve gain and/or quality parameters based on a specific filter type.
+  // Calculate frequency/quality if needed.
+  // If the APO filter type is different than the ones specified below,
+  // it's set as "Off" and default values are assumed since
+  // it may be not supported by LSP Equalizer.
   if (filter.type == "PK" || filter.type == "MODAL" || filter.type == "PEQ") {
     parse_apo_gain(line, filter);
 
@@ -307,9 +318,6 @@ auto parse_apo_config_line(const std::string& line, struct APO_Band& filter) -> 
     parse_apo_quality(line, filter);
   }
 
-  // If the APO filter type is different than the ones specified above,
-  // it's set as Off since it's not supported by LSP Equalizer.
-  // Default values are assumed.
   return true;
 }
 
@@ -491,11 +499,7 @@ auto export_apo_preset(EqualizerBox* self, GFile* file) {
     return false;
   }
 
-  if (!g_output_stream_close(G_OUTPUT_STREAM(output_stream), nullptr, nullptr)) {
-    return false;
-  }
-
-  return true;
+  return (!g_output_stream_close(G_OUTPUT_STREAM(output_stream), nullptr, nullptr)) ? false : true;
 }
 
 void on_export_apo_preset_clicked(EqualizerBox* self, GtkButton* btn) {

--- a/src/exciter.cpp
+++ b/src/exciter.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/exciter_preset.cpp
+++ b/src/exciter_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/exciter_ui.cpp
+++ b/src/exciter_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/expander.cpp
+++ b/src/expander.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/expander_preset.cpp
+++ b/src/expander_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/expander_ui.cpp
+++ b/src/expander_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/filter_preset.cpp
+++ b/src/filter_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/filter_ui.cpp
+++ b/src/filter_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/fir_filter_bandpass.cpp
+++ b/src/fir_filter_bandpass.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/fir_filter_base.cpp
+++ b/src/fir_filter_base.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/fir_filter_highpass.cpp
+++ b/src/fir_filter_highpass.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/fir_filter_lowpass.cpp
+++ b/src/fir_filter_lowpass.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/gate_preset.cpp
+++ b/src/gate_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/ladspa_wrapper.cpp
+++ b/src/ladspa_wrapper.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/level_meter.cpp
+++ b/src/level_meter.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/level_meter_preset.cpp
+++ b/src/level_meter_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/level_meter_ui.cpp
+++ b/src/level_meter_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/libportal.cpp
+++ b/src/libportal.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/limiter.cpp
+++ b/src/limiter.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/limiter_preset.cpp
+++ b/src/limiter_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/limiter_ui.cpp
+++ b/src/limiter_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/loudness.cpp
+++ b/src/loudness.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/loudness_preset.cpp
+++ b/src/loudness_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/loudness_ui.cpp
+++ b/src/loudness_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/lv2_wrapper.cpp
+++ b/src/lv2_wrapper.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/maximizer.cpp
+++ b/src/maximizer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/maximizer_preset.cpp
+++ b/src/maximizer_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/maximizer_ui.cpp
+++ b/src/maximizer_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/module_info_holder.cpp
+++ b/src/module_info_holder.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/multiband_compressor.cpp
+++ b/src/multiband_compressor.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/multiband_compressor_band_box.cpp
+++ b/src/multiband_compressor_band_box.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/multiband_compressor_preset.cpp
+++ b/src/multiband_compressor_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/multiband_compressor_ui.cpp
+++ b/src/multiband_compressor_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/multiband_gate.cpp
+++ b/src/multiband_gate.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/multiband_gate_band_box.cpp
+++ b/src/multiband_gate_band_box.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/multiband_gate_preset.cpp
+++ b/src/multiband_gate_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/multiband_gate_ui.cpp
+++ b/src/multiband_gate_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/node_info_holder.cpp
+++ b/src/node_info_holder.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/output_level.cpp
+++ b/src/output_level.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/pipe_manager.cpp
+++ b/src/pipe_manager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/pipe_manager_box.cpp
+++ b/src/pipe_manager_box.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/pitch.cpp
+++ b/src/pitch.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/pitch_preset.cpp
+++ b/src/pitch_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/pitch_ui.cpp
+++ b/src/pitch_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/plugin_base.cpp
+++ b/src/plugin_base.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/plugin_preset_base.cpp
+++ b/src/plugin_preset_base.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/plugins_box.cpp
+++ b/src/plugins_box.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/plugins_menu.cpp
+++ b/src/plugins_menu.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/preferences_general.cpp
+++ b/src/preferences_general.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/preferences_spectrum.cpp
+++ b/src/preferences_spectrum.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/preferences_window.cpp
+++ b/src/preferences_window.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/presets_autoloading_holder.cpp
+++ b/src/presets_autoloading_holder.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/presets_menu.cpp
+++ b/src/presets_menu.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/resampler.cpp
+++ b/src/resampler.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/reverb.cpp
+++ b/src/reverb.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/reverb_preset.cpp
+++ b/src/reverb_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/reverb_ui.cpp
+++ b/src/reverb_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/rnnoise.cpp
+++ b/src/rnnoise.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/rnnoise_preset.cpp
+++ b/src/rnnoise_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/rnnoise_ui.cpp
+++ b/src/rnnoise_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/speex.cpp
+++ b/src/speex.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/speex_preset.cpp
+++ b/src/speex_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/speex_ui.cpp
+++ b/src/speex_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/stereo_tools.cpp
+++ b/src/stereo_tools.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/stereo_tools_preset.cpp
+++ b/src/stereo_tools_preset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/stereo_tools_ui.cpp
+++ b/src/stereo_tools_ui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/tags_plugin_name.cpp
+++ b/src/tags_plugin_name.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/test_signals.cpp
+++ b/src/test_signals.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017-2023 Wellington Wallace
+ *  Copyright © 2017-2024 Wellington Wallace
  *
  *  This file is part of Easy Effects.
  *


### PR DESCRIPTION
The regex for on/off state only needs to check the initial part of the line. No need of the entire line or positive lookahead.

It uses the icase flag, so we need to force the string in uppercase, otherwise `Off` != `OFF`.

No need to remove duplicate whitespaces like in "parse_apo_filters".

@wwmm @iciclejj please, test it. No issues on my side.