### PR TITLE
Fix preset name in message dialog

### DIFF
--- a/include/ui_helpers.hpp
+++ b/include/ui_helpers.hpp
@@ -45,7 +45,7 @@ void show_autohiding_toast(AdwToastOverlay* toast_overlay,
                            const uint& timeout = 5U,
                            const AdwToastPriority& priority = ADW_TOAST_PRIORITY_HIGH);
 
-auto missing_plugin_box(const std::string& name, const std::string& package) -> GtkWidget*;
+auto missing_plugin_box(const std::string& base_name, const std::string& package) -> GtkWidget*;
 
 void show_simple_message_dialog(GtkWidget* parent, const std::string& title, const std::string& descr);
 

--- a/src/plugins_box.cpp
+++ b/src/plugins_box.cpp
@@ -631,7 +631,7 @@ void setup_listview(PluginsBox* self) {
 
         auto page = GTK_STACK_PAGE(child_item);
         auto page_name = gtk_stack_page_get_name(page);
-        auto base_name = tags::plugin_name::get_base_name(page_name);
+        const auto base_name = tags::plugin_name::get_base_name(page_name);
 
         g_object_set_data(G_OBJECT(top_box), "page-name", const_cast<char*>(page_name));
         g_object_set_data(G_OBJECT(remove), "page-name", const_cast<char*>(page_name));

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -769,7 +769,8 @@ void PresetsManager::notify_error(const PresetError& preset_error, const std::st
   std::string plugin_translated;
 
   try {
-    plugin_translated = tags::plugin_name::get_translated().at(plugin_name);
+    const auto base_name = tags::plugin_name::get_base_name(plugin_name);
+    plugin_translated = tags::plugin_name::get_translated().at(base_name) + ": ";
   } catch (...) {
   }
 
@@ -812,7 +813,7 @@ void PresetsManager::notify_error(const PresetError& preset_error, const std::st
                     "corrupted. Please check its content.");
 
       preset_load_error.emit(_("Preset Not Loaded Correctly"),
-                             plugin_translated + ": " + _("One or More Parameters Have a Wrong Format"));
+                             plugin_translated + _("One or More Parameters Have a Wrong Format"));
 
       break;
     }
@@ -820,7 +821,7 @@ void PresetsManager::notify_error(const PresetError& preset_error, const std::st
       util::warning("A generic error occurred while trying to load the " + plugin_name + " plugin from the preset.");
 
       preset_load_error.emit(_("Preset Not Loaded Correctly"),
-                             plugin_translated + ": " + _("Generic Error While Loading The Effect"));
+                             plugin_translated + _("Generic Error While Loading The Effect"));
 
       break;
     }

--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -53,7 +53,11 @@ void show_fixed_toast(AdwToastOverlay* toast_overlay, const std::string& text, c
   show_autohiding_toast(toast_overlay, text, 0U, priority);
 }
 
-auto missing_plugin_box(const std::string& name, const std::string& package) -> GtkWidget* {
+auto missing_plugin_box(const std::string& base_name, const std::string& package) -> GtkWidget* {
+  // Since the plugin name should be translated in the local language,
+  // this function needs the base name as parameter, retrieved from
+  // get_base_name() util.
+
   auto* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 6);
 
   gtk_widget_set_margin_start(box, 6);
@@ -73,7 +77,7 @@ auto missing_plugin_box(const std::string& name, const std::string& package) -> 
         fmt::runtime(_("The software required for the {} effect, \"{}\", is not installed. Consider using the Easy "
                        "Effects Flatpak package or installing the software yourself."));
 
-    if (name == tags::plugin_name::rnnoise) {
+    if (base_name == tags::plugin_name::rnnoise) {
       // For translators: the first {} is replaced by the effect name, the second {} is replaced by the package name.
       format_descr =
           fmt::runtime(_("The {} effect was disabled when Easy Effects was compiled. This is perhaps since the "
@@ -81,7 +85,7 @@ auto missing_plugin_box(const std::string& name, const std::string& package) -> 
                          "Effects Flatpak package or building your own Easy Effects package."));
     }
 
-    const std::string translated_name = tags::plugin_name::get_translated().at(name);
+    const std::string translated_name = tags::plugin_name::get_translated().at(base_name);
 
     adw_status_page_set_title(ADW_STATUS_PAGE(status_page), fmt::format(format_title, translated_name).c_str());
     adw_status_page_set_description(ADW_STATUS_PAGE(status_page),


### PR DESCRIPTION
This PR fix the following issue in the message dialog when a corrupted preset is loaded:

![Schermata del 2024-02-24 17-43-53](https://github.com/wwmm/easyeffects/assets/25790525/2295dd90-c82f-477a-a127-46ae27a2b9ad)

This is supposed to show the preset name which is missing because we try to convert the string using `get_translated()` util, but we get an empty string because the plugin name has a trailing `#` (added when the multiple instances were introduced).

This has been fixed retrieving the base name from `get_base_name()`, before passing it to `get_translated()`. Now fhe preset name is shown, but unfortunately the string remains in English without being translated in the local language. I will open a separate issue for this.

Besides, since `missing_plugin_box()` ui helper uses the same `get_translated()` util, I changed the parameter name to `base_name` to better understand at a first sight that the function needs the base name, not the one with trailing `#`.
