### PR TITLE
Fix appstream usage

### DIFF
--- a/data/com.github.wwmm.easyeffects.metainfo.xml.in
+++ b/data/com.github.wwmm.easyeffects.metainfo.xml.in
@@ -5,7 +5,6 @@
   <summary>Audio Effects for PipeWire Applications</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
-  <developer_name>Wellington Wallace</developer_name>
   <description>
     <p>Easy Effects is an advanced audio manipulation tool. It includes an equalizer, limiter, compressor and a reverberation tool, just to mention a few. To complement this there is also a built in spectrum analyzer.</p>
     <p>Easy Effects is the successor to PulseEffects. Easy Effects only supports PipeWire's audio server. PulseAudio users should instead use PulseEffects.</p>

--- a/data/com.github.wwmm.easyeffects.metainfo.xml.in
+++ b/data/com.github.wwmm.easyeffects.metainfo.xml.in
@@ -13,7 +13,7 @@
     <p>Besides manipulating sound output, Easy Effects is able to apply effects to an input device, such as a microphone. This is, for example, useful in audio recording, but it also works well during voice conversations.</p>
     <p>When Easy Effects is launched it will conveniently remember the configuration used in the last session. It is also possible to save all the current settings as profiles.</p>
   </description>
-  <developer>
+  <developer id="com.github.wwmm">
     <name>Wellington Wallace</name>
   </developer>
   <requires>

--- a/util/update-release-files.sh
+++ b/util/update-release-files.sh
@@ -324,11 +324,6 @@ convert_news_to_metainfo() {
   # replace ratio character with colon
   sed -i 's/∶/:/g' "${TEMP_METAINFO_FILE}"
 
-  # add back developer_name which appstreamcli removes since it's deprecated
-  # however flathub needs it
-  # https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/#name-summary-and-developer-name
-  sed -i '8i\  <developer_name>Wellington Wallace</developer_name>' "${TEMP_METAINFO_FILE}"
-
   rm "${TEMP_NEWS_CLEANED:?}"
 
 }


### PR DESCRIPTION
Since Flathub finally migrated to appstreamcli `developer_name` is not needed anymore so we can remove it. 

I wanted to also run `flatpak-builder-lint` in ci, but it seems tricky to configure since flathub runs it under different rules (notably allowing `com.github.` in the app name which is not allowed with newer apps). For the most part I don't expect too many random lint failures to pop up when submitting builds to Flathub so hopefully it won't matter much.