### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,20 +59,23 @@ GStreamer usage was replaced by native PipeWire filters.
 - Crystalizer
 - De-esser
 - Delay
-- Echo Canceller
+- Deep noise remover
+- Echo canceller
 - Equalizer
 - Exciter
+- Expander
 - Filter (low-pass, high-pass, band-pass and band-reject modes)
 - Gate
+- Level meter
 - Limiter
 - Loudness
 - Maximizer
 - Multiband compressor
 - Multiband gate
 - Noise reduction
-- Pitch
+- Pitch shift
 - Reverberation
-- Speech Processor
+- Speech processor
 - Stereo tools
 
 The user has full control over the effects order. Just use the up/down arrows
@@ -85,13 +88,16 @@ Some packages do not provide all plugin packages by default. In case some effect
 
 Plugins needed for effects:
 
-- [Linux Studio plugins](http://lsp-plug.in/?page=home). Version 1.1.24 or higher.
+- [Linux Studio plugins](https://lsp-plug.in/). Version 1.1.24 or higher.
 - [Calf Studio plugins](https://calf-studio-gear.org/). Version 0.90.1 or higher.
-- [libebur128](https://github.com/jiixyj/libebur128). For Auto Gain.
-- [ZamAudio plugins](http://www.zamaudio.com/). For Maximizer.
-- [zita-convolver](https://kokkinizita.linuxaudio.org/linuxaudio/). For Convolver.
-- [soundtouch](https://www.surina.net/soundtouch/). For Pitch Shift.
-- [RNNoise](https://github.com/xiph/rnnoise). For Noise Reduction.
+- [Libebur128](https://github.com/jiixyj/libebur128). For Auto gain and Level meter.
+- [ZamAudio plugins](https://www.zamaudio.com/). For Maximizer.
+- [Zita-convolver](https://kokkinizita.linuxaudio.org/linuxaudio/). For Convolver.
+- [MDA](https://gitlab.com/drobilla/mda-lv2). For Bass loudness.
+- [SpeexDSP](https://www.speex.org/). For Speech processor.
+- [SoundTouch](https://www.surina.net/soundtouch/). For Pitch shift.
+- [RNNoise](https://gitlab.xiph.org/xiph/rnnoise). For Noise reduction.
+- [DeepFilterNet](https://github.com/Rikorose/DeepFilterNet). For Deep noise remover.
 
 Other dependencies include:
 - [libsamplerate](http://www.mega-nerd.com/SRC/index.html)

--- a/data/ui/autogain.ui
+++ b/data/ui/autogain.ui
@@ -18,22 +18,12 @@
                     <object class="GtkBox">
                         <property name="spacing">12</property>
                         <property name="orientation">vertical</property>
-                        <child>
-                            <object class="GtkButton" id="reset_history">
-                                <property name="valign">center</property>
-                                <property name="halign">center</property>
-                                <property name="label" translatable="yes">Reset History</property>
-                                <signal name="clicked" handler="on_reset_history" object="AutogainBox" />
-                            </object>
-                        </child>
 
                         <child>
                             <object class="GtkBox">
                                 <property name="spacing">24</property>
                                 <child>
                                     <object class="AdwPreferencesPage">
-                                        <property name="valign">center</property>
-
                                         <child>
                                             <object class="AdwPreferencesGroup">
                                                 <property name="title" translatable="yes">Controls</property>
@@ -131,6 +121,20 @@
                                                         </property>
                                                     </object>
                                                 </child>
+
+                                                <child>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">History</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkButton" id="reset_history">
+                                                                <property name="valign">center</property>
+                                                                <property name="label" translatable="yes">Reset</property>
+                                                                <signal name="clicked" handler="on_reset_history" object="AutogainBox" />
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
                                             </object>
                                         </child>
                                     </object>
@@ -138,8 +142,6 @@
 
                                 <child>
                                     <object class="AdwPreferencesPage">
-                                        <property name="valign">center</property>
-
                                         <child>
                                             <object class="AdwPreferencesGroup">
                                                 <property name="title" translatable="yes">Loudness</property>
@@ -171,6 +173,7 @@
 
                                                                 <child>
                                                                     <object class="GtkLabel" id="m_label">
+                                                                        <property name="label">0</property>
                                                                         <property name="xalign">1</property>
                                                                         <property name="width-chars">8</property>
                                                                     </object>
@@ -208,6 +211,7 @@
 
                                                                 <child>
                                                                     <object class="GtkLabel" id="s_label">
+                                                                        <property name="label">0</property>
                                                                         <property name="xalign">1</property>
                                                                         <property name="width-chars">8</property>
                                                                     </object>
@@ -244,6 +248,7 @@
 
                                                                 <child>
                                                                     <object class="GtkLabel" id="i_label">
+                                                                        <property name="label">0</property>
                                                                         <property name="xalign">1</property>
                                                                         <property name="width-chars">8</property>
                                                                     </object>
@@ -280,6 +285,7 @@
 
                                                                 <child>
                                                                     <object class="GtkLabel" id="r_label">
+                                                                        <property name="label">0</property>
                                                                         <property name="xalign">1</property>
                                                                         <property name="width-chars">8</property>
                                                                     </object>
@@ -318,6 +324,7 @@
 
                                                                 <child>
                                                                     <object class="GtkLabel" id="lra_label">
+                                                                        <property name="label">0</property>
                                                                         <property name="xalign">1</property>
                                                                         <property name="width-chars">8</property>
                                                                     </object>
@@ -354,6 +361,7 @@
 
                                                                 <child>
                                                                     <object class="GtkLabel" id="l_label">
+                                                                        <property name="label">0</property>
                                                                         <property name="xalign">1</property>
                                                                         <property name="width-chars">8</property>
                                                                     </object>
@@ -391,6 +399,7 @@
 
                                                                 <child>
                                                                     <object class="GtkLabel" id="g_label">
+                                                                        <property name="label">0</property>
                                                                         <property name="xalign">1</property>
                                                                         <property name="width-chars">8</property>
                                                                     </object>

--- a/data/ui/filter.ui
+++ b/data/ui/filter.ui
@@ -29,244 +29,270 @@
                         </child>
 
                         <child>
-                            <object class="AdwPreferencesPage">
+                            <object class="GtkBox">
+                                <property name="spacing">24</property>
                                 <child>
-                                    <object class="AdwPreferencesGroup">
+                                    <object class="AdwPreferencesPage">
                                         <child>
-                                            <object class="AdwActionRow">
-                                                <property name="title" translatable="yes">Type</property>
+                                            <object class="AdwPreferencesGroup">
+                                                <property name="title" translatable="yes">Controls</property>
+
                                                 <child>
-                                                    <object class="GtkDropDown" id="type">
-                                                        <property name="valign">center</property>
-                                                        <property name="model">
-                                                            <object class="GtkStringList">
-                                                                <items>
-                                                                    <item translatable="yes">Low-Pass</item>
-                                                                    <item translatable="yes">High-Pass</item>
-                                                                    <item translatable="yes">Low-Shelf</item>
-                                                                    <item translatable="yes">High-Shelf</item>
-                                                                    <item translatable="yes">Bell</item>
-                                                                    <item translatable="yes">Band-Pass</item>
-                                                                    <item translatable="yes">Notch</item>
-                                                                    <item translatable="yes">Resonance</item>
-                                                                    <item translatable="yes">Ladder-Pass</item>
-                                                                    <item translatable="yes">Ladder-Rejection</item>
-                                                                    <item translatable="yes">All-Pass</item>
-                                                                </items>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Type</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkDropDown" id="type">
+                                                                <property name="valign">center</property>
+                                                                <property name="model">
+                                                                    <object class="GtkStringList">
+                                                                        <items>
+                                                                            <item translatable="yes">Low-Pass</item>
+                                                                            <item translatable="yes">High-Pass</item>
+                                                                            <item translatable="yes">Low-Shelf</item>
+                                                                            <item translatable="yes">High-Shelf</item>
+                                                                            <item translatable="yes">Bell</item>
+                                                                            <item translatable="yes">Band-Pass</item>
+                                                                            <item translatable="yes">Notch</item>
+                                                                            <item translatable="yes">Resonance</item>
+                                                                            <item translatable="yes">Ladder-Pass</item>
+                                                                            <item translatable="yes">Ladder-Rejection</item>
+                                                                            <item translatable="yes">All-Pass</item>
+                                                                        </items>
+                                                                    </object>
+                                                                </property>
+                                                                <accessibility>
+                                                                    <property name="label">Filter Type</property>
+                                                                </accessibility>
                                                             </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <property name="label">Filter Type</property>
-                                                        </accessibility>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Mode</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkDropDown" id="mode">
+                                                                <property name="valign">center</property>
+                                                                <property name="model">
+                                                                    <object class="GtkStringList">
+                                                                        <items>
+                                                                            <item>RLC (BT)</item>
+                                                                            <item>RLC (MT)</item>
+                                                                            <item>BWC (BT)</item>
+                                                                            <item>BWC (MT)</item>
+                                                                            <item>LRX (BT)</item>
+                                                                            <item>LRX (MT)</item>
+                                                                            <item>APO (DR)</item>
+                                                                        </items>
+                                                                    </object>
+                                                                </property>
+                                                                <accessibility>
+                                                                    <property name="label">Filter Mode</property>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Equalizer Mode</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkDropDown" id="equalizer_mode">
+                                                                <property name="valign">center</property>
+                                                                <property name="model">
+                                                                    <object class="GtkStringList">
+                                                                        <items>
+                                                                            <item>IIR</item>
+                                                                            <item>FIR</item>
+                                                                            <item>FFT</item>
+                                                                            <item>SPM</item>
+                                                                        </items>
+                                                                    </object>
+                                                                </property>
+                                                                <accessibility>
+                                                                    <property name="label">Equalizer Mode</property>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Slope</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkDropDown" id="slope">
+                                                                <property name="valign">center</property>
+                                                                <property name="model">
+                                                                    <object class="GtkStringList">
+                                                                        <items>
+                                                                            <item>x1</item>
+                                                                            <item>x2</item>
+                                                                            <item>x3</item>
+                                                                            <item>x4</item>
+                                                                            <item>x6</item>
+                                                                            <item>x8</item>
+                                                                            <item>x12</item>
+                                                                            <item>x16</item>
+                                                                        </items>
+                                                                    </object>
+                                                                </property>
+                                                                <accessibility>
+                                                                    <property name="label">Filter Slope</property>
+                                                                </accessibility>
+                                                            </object>
+                                                        </child>
                                                     </object>
                                                 </child>
                                             </object>
                                         </child>
+                                    </object>
+                                </child>
 
+                                <child>
+                                    <object class="AdwPreferencesPage">
                                         <child>
-                                            <object class="AdwActionRow">
-                                                <property name="title" translatable="yes">Mode</property>
+                                            <object class="AdwPreferencesGroup">
+                                                <property name="title" translatable="yes">Filter</property>
+
                                                 <child>
-                                                    <object class="GtkDropDown" id="mode">
-                                                        <property name="valign">center</property>
-                                                        <property name="model">
-                                                            <object class="GtkStringList">
-                                                                <items>
-                                                                    <item>RLC (BT)</item>
-                                                                    <item>RLC (MT)</item>
-                                                                    <item>BWC (BT)</item>
-                                                                    <item>BWC (MT)</item>
-                                                                    <item>LRX (BT)</item>
-                                                                    <item>LRX (MT)</item>
-                                                                    <item>APO (DR)</item>
-                                                                </items>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Frequency</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="frequency">
+                                                                <property name="valign">center</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">0</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">10</property>
+                                                                        <property name="upper">24000</property>
+                                                                        <property name="value">2000</property>
+                                                                        <property name="step-increment">1</property>
+                                                                        <property name="page-increment">100</property>
+                                                                    </object>
+                                                                </property>
+                                                                <accessibility>
+                                                                    <property name="label">Filter Frequency</property>
+                                                                </accessibility>
                                                             </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <property name="label">Filter Mode</property>
-                                                        </accessibility>
+                                                        </child>
                                                     </object>
                                                 </child>
-                                            </object>
-                                        </child>
 
-                                        <child>
-                                            <object class="AdwActionRow">
-                                                <property name="title" translatable="yes">Equalizer Mode</property>
                                                 <child>
-                                                    <object class="GtkDropDown" id="equalizer_mode">
-                                                        <property name="valign">center</property>
-                                                        <property name="model">
-                                                            <object class="GtkStringList">
-                                                                <items>
-                                                                    <item>IIR</item>
-                                                                    <item>FIR</item>
-                                                                    <item>FFT</item>
-                                                                    <item>SPM</item>
-                                                                </items>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Width</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="width">
+                                                                <property name="valign">center</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">0</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">0</property>
+                                                                        <property name="upper">12</property>
+                                                                        <property name="value">4</property>
+                                                                        <property name="step-increment">1</property>
+                                                                        <property name="page-increment">2</property>
+                                                                    </object>
+                                                                </property>
+                                                                <accessibility>
+                                                                    <property name="label">Filter Width</property>
+                                                                </accessibility>
                                                             </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <property name="label">Equalizer Mode</property>
-                                                        </accessibility>
+                                                        </child>
                                                     </object>
                                                 </child>
-                                            </object>
-                                        </child>
 
-                                        <child>
-                                            <object class="AdwActionRow">
-                                                <property name="title" translatable="yes">Slope</property>
                                                 <child>
-                                                    <object class="GtkDropDown" id="slope">
-                                                        <property name="valign">center</property>
-                                                        <property name="model">
-                                                            <object class="GtkStringList">
-                                                                <items>
-                                                                    <item>x1</item>
-                                                                    <item>x2</item>
-                                                                    <item>x3</item>
-                                                                    <item>x4</item>
-                                                                    <item>x6</item>
-                                                                    <item>x8</item>
-                                                                    <item>x12</item>
-                                                                    <item>x16</item>
-                                                                </items>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Gain</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="gain">
+                                                                <property name="valign">center</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">2</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-36</property>
+                                                                        <property name="upper">36</property>
+                                                                        <property name="value">1</property>
+                                                                        <property name="step-increment">0.01</property>
+                                                                        <property name="page-increment">1.0</property>
+                                                                    </object>
+                                                                </property>
+                                                                <accessibility>
+                                                                    <property name="label">Filter Gain</property>
+                                                                </accessibility>
                                                             </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <property name="label">Filter Slope</property>
-                                                        </accessibility>
+                                                        </child>
                                                     </object>
                                                 </child>
-                                            </object>
-                                        </child>
 
-                                        <child>
-                                            <object class="AdwActionRow">
-                                                <property name="title" translatable="yes">Frequency</property>
                                                 <child>
-                                                    <object class="GtkSpinButton" id="frequency">
-                                                        <property name="valign">center</property>
-                                                        <property name="width-chars">10</property>
-                                                        <property name="digits">0</property>
-                                                        <property name="update-policy">if-valid</property>
-                                                        <property name="adjustment">
-                                                            <object class="GtkAdjustment">
-                                                                <property name="lower">10</property>
-                                                                <property name="upper">24000</property>
-                                                                <property name="value">2000</property>
-                                                                <property name="step-increment">1</property>
-                                                                <property name="page-increment">100</property>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Quality</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="quality">
+                                                                <property name="valign">center</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">2</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">0</property>
+                                                                        <property name="upper">100</property>
+                                                                        <property name="value">0</property>
+                                                                        <property name="step-increment">0.01</property>
+                                                                        <property name="page-increment">0.1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <accessibility>
+                                                                    <property name="label">Filter Quality</property>
+                                                                </accessibility>
                                                             </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <property name="label">Filter Frequency</property>
-                                                        </accessibility>
+                                                        </child>
                                                     </object>
                                                 </child>
-                                            </object>
-                                        </child>
 
-                                        <child>
-                                            <object class="AdwActionRow">
-                                                <property name="title" translatable="yes">Width</property>
                                                 <child>
-                                                    <object class="GtkSpinButton" id="width">
-                                                        <property name="valign">center</property>
-                                                        <property name="width-chars">10</property>
-                                                        <property name="digits">0</property>
-                                                        <property name="update-policy">if-valid</property>
-                                                        <property name="adjustment">
-                                                            <object class="GtkAdjustment">
-                                                                <property name="lower">0</property>
-                                                                <property name="upper">12</property>
-                                                                <property name="value">4</property>
-                                                                <property name="step-increment">1</property>
-                                                                <property name="page-increment">2</property>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Balance</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="balance">
+                                                                <property name="valign">center</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">1</property>
+                                                                <property name="update-policy">if-valid</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-100</property>
+                                                                        <property name="upper">100</property>
+                                                                        <property name="value">0</property>
+                                                                        <property name="step-increment">0.1</property>
+                                                                        <property name="page-increment">1</property>
+                                                                    </object>
+                                                                </property>
+                                                                <accessibility>
+                                                                    <property name="label">Output Balance</property>
+                                                                </accessibility>
                                                             </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <property name="label">Filter Width</property>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="AdwActionRow">
-                                                <property name="title" translatable="yes">Gain</property>
-                                                <child>
-                                                    <object class="GtkSpinButton" id="gain">
-                                                        <property name="valign">center</property>
-                                                        <property name="width-chars">10</property>
-                                                        <property name="digits">2</property>
-                                                        <property name="update-policy">if-valid</property>
-                                                        <property name="adjustment">
-                                                            <object class="GtkAdjustment">
-                                                                <property name="lower">-36</property>
-                                                                <property name="upper">36</property>
-                                                                <property name="value">1</property>
-                                                                <property name="step-increment">0.01</property>
-                                                                <property name="page-increment">1.0</property>
-                                                            </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <property name="label">Filter Gain</property>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="AdwActionRow">
-                                                <property name="title" translatable="yes">Quality</property>
-                                                <child>
-                                                    <object class="GtkSpinButton" id="quality">
-                                                        <property name="valign">center</property>
-                                                        <property name="width-chars">10</property>
-                                                        <property name="digits">2</property>
-                                                        <property name="update-policy">if-valid</property>
-                                                        <property name="adjustment">
-                                                            <object class="GtkAdjustment">
-                                                                <property name="lower">0</property>
-                                                                <property name="upper">100</property>
-                                                                <property name="value">0</property>
-                                                                <property name="step-increment">0.01</property>
-                                                                <property name="page-increment">0.1</property>
-                                                            </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <property name="label">Filter Quality</property>
-                                                        </accessibility>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-
-                                        <child>
-                                            <object class="AdwActionRow">
-                                                <property name="title" translatable="yes">Balance</property>
-                                                <child>
-                                                    <object class="GtkSpinButton" id="balance">
-                                                        <property name="valign">center</property>
-                                                        <property name="width-chars">10</property>
-                                                        <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
-                                                        <property name="adjustment">
-                                                            <object class="GtkAdjustment">
-                                                                <property name="lower">-100</property>
-                                                                <property name="upper">100</property>
-                                                                <property name="value">0</property>
-                                                                <property name="step-increment">0.1</property>
-                                                                <property name="page-increment">1</property>
-                                                            </object>
-                                                        </property>
-                                                        <accessibility>
-                                                            <property name="label">Output Balance</property>
-                                                        </accessibility>
+                                                        </child>
                                                     </object>
                                                 </child>
                                             </object>

--- a/data/ui/level_meter.ui
+++ b/data/ui/level_meter.ui
@@ -19,21 +19,10 @@
                         <property name="spacing">12</property>
                         <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkButton" id="reset_history">
-                                <property name="valign">center</property>
-                                <property name="halign">center</property>
-                                <property name="label" translatable="yes">Reset History</property>
-                                <signal name="clicked" handler="on_reset_history" object="LevelMeterBox" />
-                            </object>
-                        </child>
-
-                        <child>
                             <object class="GtkBox">
                                 <property name="spacing">24</property>
                                 <child>
                                     <object class="AdwPreferencesPage">
-                                        <property name="valign">center</property>
-
                                         <child>
                                             <object class="AdwPreferencesGroup">
                                                 <property name="title" translatable="yes">True Peak</property>
@@ -326,6 +315,20 @@
                                 <property name="spacing">6</property>
                                 <property name="hexpand">1</property>
                                 <property name="homogeneous">1</property>
+
+                                <!-- Empty placeholder used only for layout reason -->
+                                <child>
+                                    <object class="GtkLabel"> </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkButton" id="reset_history">
+                                        <property name="valign">center</property>
+                                        <property name="halign">center</property>
+                                        <property name="label" translatable="yes">Reset History</property>
+                                        <signal name="clicked" handler="on_reset_history" object="LevelMeterBox" />
+                                    </object>
+                                </child>
 
                                 <child>
                                     <object class="GtkLabel" id="plugin_credit">

--- a/data/ui/pipe_manager_box.ui
+++ b/data/ui/pipe_manager_box.ui
@@ -218,6 +218,28 @@
                                                                 <property name="row-spacing">12</property>
                                                                 <property name="column-spacing">6</property>
                                                                 <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="label" translatable="yes">Device</property>
+                                                                        <layout>
+                                                                            <property name="column">0</property>
+                                                                            <property name="row">0</property>
+                                                                        </layout>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="label" translatable="yes">Preset</property>
+                                                                        <layout>
+                                                                            <property name="column">0</property>
+                                                                            <property name="row">1</property>
+                                                                        </layout>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
                                                                     <object class="GtkDropDown" id="dropdown_autoloading_output_devices">
                                                                         <property name="factory">
                                                                             <object class="GtkBuilderListItemFactory">
@@ -225,7 +247,7 @@
                                                                             </object>
                                                                         </property>
                                                                         <layout>
-                                                                            <property name="column">0</property>
+                                                                            <property name="column">1</property>
                                                                             <property name="row">0</property>
                                                                         </layout>
                                                                         <accessibility>
@@ -242,7 +264,7 @@
                                                                             </object>
                                                                         </property>
                                                                         <layout>
-                                                                            <property name="column">0</property>
+                                                                            <property name="column">1</property>
                                                                             <property name="row">1</property>
                                                                         </layout>
                                                                         <accessibility>
@@ -254,14 +276,13 @@
                                                                 <child>
                                                                     <object class="GtkButton" id="autoloading_add_output_profile">
                                                                         <property name="tooltip-text" translatable="yes">Create Association</property>
-                                                                        <property name="halign">center</property>
+                                                                        <property name="halign">start</property>
                                                                         <property name="valign">center</property>
                                                                         <property name="icon-name">list-add-symbolic</property>
                                                                         <signal name="clicked" handler="on_autoloading_add_output_profile" object="PipeManagerBox" />
                                                                         <layout>
-                                                                            <property name="column">1</property>
-                                                                            <property name="row">0</property>
-                                                                            <property name="row-span">2</property>
+                                                                            <property name="column">2</property>
+                                                                            <property name="row">1</property>
                                                                         </layout>
                                                                         <style>
                                                                             <class name="suggested-action" />
@@ -315,6 +336,28 @@
                                                                 <property name="row-spacing">12</property>
                                                                 <property name="column-spacing">6</property>
                                                                 <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="label" translatable="yes">Device</property>
+                                                                        <layout>
+                                                                            <property name="column">0</property>
+                                                                            <property name="row">0</property>
+                                                                        </layout>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="halign">end</property>
+                                                                        <property name="label" translatable="yes">Preset</property>
+                                                                        <layout>
+                                                                            <property name="column">0</property>
+                                                                            <property name="row">1</property>
+                                                                        </layout>
+                                                                    </object>
+                                                                </child>
+
+                                                                <child>
                                                                     <object class="GtkDropDown" id="dropdown_autoloading_input_devices">
                                                                         <property name="factory">
                                                                             <object class="GtkBuilderListItemFactory">
@@ -322,7 +365,7 @@
                                                                             </object>
                                                                         </property>
                                                                         <layout>
-                                                                            <property name="column">0</property>
+                                                                            <property name="column">1</property>
                                                                             <property name="row">0</property>
                                                                         </layout>
                                                                         <accessibility>
@@ -334,7 +377,7 @@
                                                                 <child>
                                                                     <object class="GtkDropDown" id="dropdown_autoloading_input_presets">
                                                                         <layout>
-                                                                            <property name="column">0</property>
+                                                                            <property name="column">1</property>
                                                                             <property name="row">1</property>
                                                                         </layout>
                                                                         <accessibility>
@@ -346,14 +389,13 @@
                                                                 <child>
                                                                     <object class="GtkButton" id="autoloading_add_input_profile">
                                                                         <property name="tooltip-text" translatable="yes">Create Association</property>
-                                                                        <property name="halign">center</property>
+                                                                        <property name="halign">start</property>
                                                                         <property name="valign">center</property>
                                                                         <property name="icon-name">list-add-symbolic</property>
                                                                         <signal name="clicked" handler="on_autoloading_add_input_profile" object="PipeManagerBox" />
                                                                         <layout>
-                                                                            <property name="column">1</property>
-                                                                            <property name="row">0</property>
-                                                                            <property name="row-span">2</property>
+                                                                            <property name="column">2</property>
+                                                                            <property name="row">1</property>
                                                                         </layout>
                                                                         <style>
                                                                             <class name="suggested-action" />

--- a/data/ui/rnnoise.ui
+++ b/data/ui/rnnoise.ui
@@ -44,7 +44,6 @@
 
                                 <child>
                                     <object class="AdwPreferencesGroup">
-                                        <property name="valign">center</property>
                                         <property name="title" translatable="yes">Voice Detection</property>
 
                                         <child>
@@ -149,6 +148,8 @@
                                         <property name="spacing">12</property>
                                         <child>
                                             <object class="GtkLabel">
+                                                <property name="margin-top">6</property>
+                                                <property name="margin-bottom">4</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Models</property>
                                                 <attributes>

--- a/util/NEWS.yaml
+++ b/util/NEWS.yaml
@@ -2,21 +2,21 @@
 Version: UNRELEASED_VERSION
 Date: UNRELEASED_DATE
 
-Description: 
+Description:
 - Features∶
-- 
+- Improved the pipeline management system. Non-limiter effects are placed before the limiter even if the last two plugins in the pipeline are a limiter followed by a level meter.   
 
 - Bug fixes∶
-- 
+-
 
 - Other notes∶
-- 
+-
 
 ---
 Version: 7.1.5
 Date: 2024-03-22
 
-Description: 
+Description:
 - Features∶
 - We now set `monitor.passthrough = true` in our virtual devices. This will allow latency offset to be properly applied by video players when PipeWire > 1.0.3 is released.
 - Updated translations.
@@ -29,7 +29,7 @@ Description:
 Version: 7.1.4
 Date: 2024-02-01
 
-Description: 
+Description:
 - Features∶
 - EasyEffects will try to avoid moving to its virtual sources streams for which the user has set a custom `target.object` that is different from the mic EE is recording from. THe stream has to be started when EE is already running for this logic to take effect.
 - Updated translations
@@ -46,7 +46,7 @@ Description:
 Version: 7.1.3
 Date: 2023-11-08
 
-Description: 
+Description:
 - Features∶
 - Updated translations
 
@@ -59,7 +59,7 @@ Description:
 Version: 7.1.2
 Date: 2023-11-08
 
-Description: 
+Description:
 - Features∶
 - Updated translations
 
@@ -72,7 +72,7 @@ Description:
 Version: 7.1.1
 Date: 2023-10-27
 
-Description: 
+Description:
 - Features∶
 - The spectrum has a new option that allows the dynamic vertical scale to be disabled.
 - Improved compatibility with the latest LSP releases.
@@ -86,7 +86,7 @@ Description:
 Version: 7.1.0
 Date: 2023-09-07
 
-Description: 
+Description:
 - Features∶
 
 - Bug fixes∶
@@ -98,7 +98,7 @@ Description:
 Version: 7.0.9
 Date: 2023-09-07
 
-Description: 
+Description:
 - Features∶
 - Added a new control to the noise reduction plugin that allows the voice detection to be disabled.
 
@@ -114,7 +114,7 @@ Description:
 - Features∶
 - The Filter effect has been improved with new parameters since it has been ported from Calf Studio to Linux Studio Plugins.
 - Noise reduction by RNNoise has been improved with the addition of Release and VAD Threshold controls.
-- Noise reduction by RNNoise can now mix the original and denoised signals to avoid the output to sound too "dry".  
+- Noise reduction by RNNoise can now mix the original and denoised signals to avoid the output to sound too "dry".
 
 - Bug fixes∶
 


### PR DESCRIPTION
This PR contains various changes.

The most important is the one about `add_new_plugin_to_pipeline` function. Many releases ago we introduced the "limiter protection" system that places a new "non-limiter" plugin at the second to last position when the limiter (or the maximizer) is in the last position.

Unfortunately this behavior broke when the level meter was introduced. The level meter does not change the signal, so we  put it directly at the bottom of the pipeline (this is the position where the user wants the meter in most cases).

This causes any additional non-limiter plugin to be placed at the bottom, so after the limiter, which is not preferable. I noticed this behavior adding all the plugins at once. In the previous releases I had always a limiter/maximizer at the bottom. Now that the level meter can be added to the pipeline, I don't see the limiter at the bottom anymore (in better words, I see it at the last position until the level meter is added).

This is not the original intended behavior, so I changed the algorithm to check if the level meter in the last position is preceded by a limiter. TLDR: a new non-limiter plugin is added in the third to last position if the level meter at the bottom is preceded by a limiter: new-plugin -> limiter -> level meter. @wwmm please test this behavior.

Then there are some UI changes:

- some plugins had adwpreferences aligned (see Pitch) while others not; now all are aligned;
- the reset history button in Autogain is now inside the Controls group (top space is not wasted);
- the reset history button in Level Meter has been moved at the bottom taking the opportunity to fill the empty space left by the missing reset controls button;
- the Filter had an adwpreferences too long; now it has been split in two groups like some of the other plugins (see Pitch);
- the preset autoload page now has labels for device/preset dropdowns
