### PR TITLE
fix deploy help ci workflow

### DIFF
--- a/.github/workflows/deploy-help.yaml
+++ b/.github/workflows/deploy-help.yaml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Build html help pages
         run: |
+          sudo apt-get update
+          sudo apt-get upgrade -y
           sudo apt-get install -y yelp-tools
           mkdir help/dist-html
           yelp-build html -o help/dist-html help/C


### PR DESCRIPTION
We should apt-get update before installing packages otherwise we get https://github.com/wwmm/easyeffects/actions/runs/8482342251/job/23241404801#step:4:144.