### PR TITLE
Community Presets: Implement the StatusPage

### DIFF
--- a/data/ui/presets_menu.ui
+++ b/data/ui/presets_menu.ui
@@ -175,109 +175,108 @@
                                     <object class="GtkBox">
                                         <property name="orientation">vertical</property>
                                         <property name="spacing">12</property>
-                                            <child>
-                                                <object class="GtkOverlay" id="overlay_community">
-                                                    <child>
-                                                        <object class="GtkBox">
-                                                            <property name="orientation">vertical</property>
-                                                            <property name="spacing">12</property>
-                                                            <child>
-                                                                <object class="GtkSearchEntry" id="search_community">
-                                                                    <property name="valign">start</property>
-                                                                    <property name="hexpand">1</property>
-                                                                    <property name="placeholder-text" translatable="yes">Search</property>
-                                                                    <accessibility>
-                                                                        <property name="label" translatable="yes">Search Community Preset</property>
-                                                                    </accessibility>
-                                                                </object>
-                                                            </child>
+                                        <child>
+                                            <object class="GtkBox" id="community_main_box">
+                                                <property name="visible">0</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="spacing">12</property>
+                                                <child>
+                                                    <object class="GtkSearchEntry" id="search_community">
+                                                        <property name="valign">start</property>
+                                                        <property name="hexpand">1</property>
+                                                        <property name="placeholder-text" translatable="yes">Search</property>
+                                                        <accessibility>
+                                                            <property name="label" translatable="yes">Search Community Preset</property>
+                                                        </accessibility>
+                                                    </object>
+                                                </child>
 
-                                                            <child>
-                                                                <object class="GtkFrame">
-                                                                    <property name="hexpand">1</property>
-                                                                    <property name="vexpand">1</property>
-                                                                    <child>
-                                                                        <object class="GtkScrolledWindow" id="scrolled_window_community">
-                                                                            <property name="hexpand">1</property>
-                                                                            <property name="vexpand">1</property>
-                                                                            <property name="propagate-natural-width">1</property>
-                                                                            <property name="propagate-natural-height">1</property>
-                                                                            <child>
-                                                                                <object class="GtkListView" id="listview_community">
-                                                                                    <property name="hexpand">1</property>
-                                                                                    <property name="vexpand">1</property>
-                                                                                    <property name="show-separators">1</property>
-                                                                                    <property name="model">
-                                                                                        <object class="GtkNoSelection">
-                                                                                            <property name="model">
-                                                                                                <object class="GtkSortListModel">
-                                                                                                    <property name="model">
-                                                                                                        <object class="GtkFilterListModel">
-                                                                                                            <property name="incremental">1</property>
+                                                <child>
+                                                    <object class="GtkFrame">
+                                                        <property name="hexpand">1</property>
+                                                        <property name="vexpand">1</property>
+                                                        <child>
+                                                            <object class="GtkScrolledWindow" id="scrolled_window_community">
+                                                                <property name="hexpand">1</property>
+                                                                <property name="vexpand">1</property>
+                                                                <property name="propagate-natural-width">1</property>
+                                                                <property name="propagate-natural-height">1</property>
+                                                                <child>
+                                                                    <object class="GtkListView" id="listview_community">
+                                                                        <property name="hexpand">1</property>
+                                                                        <property name="vexpand">1</property>
+                                                                        <property name="show-separators">1</property>
+                                                                        <property name="model">
+                                                                            <object class="GtkNoSelection">
+                                                                                <property name="model">
+                                                                                    <object class="GtkSortListModel">
+                                                                                        <property name="model">
+                                                                                            <object class="GtkFilterListModel">
+                                                                                                <property name="incremental">1</property>
 
-                                                                                                            <property name="model">
-                                                                                                                <object class="GtkStringList" id="presets_list_community"></object>
-                                                                                                            </property>
+                                                                                                <property name="model">
+                                                                                                    <object class="GtkStringList" id="presets_list_community"></object>
+                                                                                                </property>
 
-                                                                                                            <property name="filter">
-                                                                                                                <object class="GtkStringFilter" id="filter_string_community">
-                                                                                                                    <property name="search" bind-source="search_community" bind-property="text" />
-                                                                                                                </object>
-                                                                                                            </property>
-                                                                                                        </object>
-                                                                                                    </property>
+                                                                                                <property name="filter">
+                                                                                                    <object class="GtkStringFilter" id="filter_string_community">
+                                                                                                        <property name="search" bind-source="search_community" bind-property="text" />
+                                                                                                    </object>
+                                                                                                </property>
+                                                                                            </object>
+                                                                                        </property>
 
-                                                                                                    <property name="sorter">
-                                                                                                        <object class="GtkStringSorter">
-                                                                                                            <property name="expression">
-                                                                                                                <lookup name="string" type="GtkStringObject"></lookup>
-                                                                                                            </property>
-                                                                                                        </object>
-                                                                                                    </property>
-                                                                                                </object>
-                                                                                            </property>
-                                                                                        </object>
-                                                                                    </property>
+                                                                                        <property name="sorter">
+                                                                                            <object class="GtkStringSorter">
+                                                                                                <property name="expression">
+                                                                                                    <lookup name="string" type="GtkStringObject"></lookup>
+                                                                                                </property>
+                                                                                            </object>
+                                                                                        </property>
+                                                                                    </object>
+                                                                                </property>
+                                                                            </object>
+                                                                        </property>
 
-                                                                                    <style>
-                                                                                        <class name="rich-list" />
-                                                                                    </style>
+                                                                        <style>
+                                                                            <class name="rich-list" />
+                                                                        </style>
 
-                                                                                    <accessibility>
-                                                                                        <property name="label" translatable="yes">Community Presets List</property>
-                                                                                    </accessibility>
-                                                                                </object>
-                                                                            </child>
-                                                                        </object>
-                                                                    </child>
-                                                                </object>
-                                                            </child>
-                                                        </object>
-                                                    </child>
+                                                                        <accessibility>
+                                                                            <property name="label" translatable="yes">Community Presets List</property>
+                                                                        </accessibility>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
 
-                                                    <child type="overlay">
-                                                        <object class="AdwStatusPage" id="overlay_empty_community_list">
-                                                            <!-- TODO: remove visible property when the overlay system is implemented in the C++ code -->
-                                                            <property name="visible">0</property>
-                                                            <property name="icon-name">system-software-install-symbolic</property>
-                                                            <property name="title" translatable="yes">No Community Presets Installed</property>
-                                                            <property name="description" translatable="yes">Community Presets packages can be installed from Flatpak or the repository of your favorite distribution.</property>
-                                                        </object>
-                                                    </child>
-                                                </object>
-                                            </child>
+                                        <child>
+                                            <object class="AdwStatusPage" id="status_page_community_list">
+                                                <property name="hexpand">1</property>
+                                                <property name="vexpand">1</property>
+                                                <property name="title" translatable="yes">No Community Presets Installed</property>
+                                                <property name="description" translatable="yes">Community Presets packages can be installed from Flatpak or the repository of your favorite distribution.</property>
+                                                <style>
+                                                    <class name="compact" />
+                                                </style>
+                                            </object>
+                                        </child>
 
-                                            <child>
-                                                <object class="GtkButton" id="refresh_community_list">
-                                                    <property name="valign">start</property>
-                                                    <property name="halign">center</property>
-                                                    <property name="label" translatable="yes">Refresh</property>
-                                                    <property name="tooltip-text" translatable="yes">Refresh to show new installed community presets</property>
-                                                    <style>
-                                                        <class name="suggested-action" />
-                                                    </style>
-                                                </object>
-                                            </child>
+                                        <child>
+                                            <object class="GtkButton" id="refresh_community_list">
+                                                <property name="valign">start</property>
+                                                <property name="halign">center</property>
+                                                <property name="label" translatable="yes">Refresh</property>
+                                                <property name="tooltip-text" translatable="yes">Refresh to show new installed community presets</property>
+                                                <style>
+                                                    <class name="suggested-action" />
+                                                </style>
+                                            </object>
+                                        </child>
                                     </object>
                                 </property>
                             </object>

--- a/src/apps_box.cpp
+++ b/src/apps_box.cpp
@@ -88,7 +88,7 @@ auto app_is_blocklisted(AppsBox* self, const std::string& name) -> bool {
 
 void update_empty_list_overlay(AppsBox* self) {
   gtk_widget_set_visible(GTK_WIDGET(self->overlay_empty_list),
-                         (g_list_model_get_n_items(G_LIST_MODEL(self->apps_model)) == 0) ? 1 : 0);
+                         (g_list_model_get_n_items(G_LIST_MODEL(self->apps_model)) == 0U) ? 1 : 0);
 }
 
 void on_app_added(AppsBox* self, const NodeInfo& node_info) {

--- a/src/convolver_menu_combine.cpp
+++ b/src/convolver_menu_combine.cpp
@@ -197,8 +197,8 @@ void combine_kernels(ConvolverMenuCombine* self,
 }
 
 void on_combine_kernels(ConvolverMenuCombine* self, GtkButton* btn) {
-  if (g_list_model_get_n_items(G_LIST_MODEL(self->string_list_1)) == 0 ||
-      g_list_model_get_n_items(G_LIST_MODEL(self->string_list_2)) == 0) {
+  if (g_list_model_get_n_items(G_LIST_MODEL(self->string_list_1)) == 0U ||
+      g_list_model_get_n_items(G_LIST_MODEL(self->string_list_2)) == 0U) {
     return;
   }
 

--- a/src/presets_menu.cpp
+++ b/src/presets_menu.cpp
@@ -61,7 +61,11 @@ struct _PresetsMenu {
 
   GtkScrolledWindow *scrolled_window_local, *scrolled_window_community;
 
+  GtkBox* community_main_box;
+
   GtkListView *listview_local, *listview_community;
+
+  AdwStatusPage* status_page_community_list;
 
   GtkText* new_preset_name;
 
@@ -263,10 +267,23 @@ void setup_community_presets_listview(PresetsMenu* self,
       gtk_string_list_splice(self->presets_list_community, 0U, n_items, nullptr);
     }
 
-    // Fill the empty list
-    for (const auto& path : self->data->application->presets_manager->get_all_community_presets_paths(preset_type)) {
+    const auto cp_paths = self->data->application->presets_manager->get_all_community_presets_paths(preset_type);
+
+    // If there are no paths, show the AdwStatusPage and exit.
+    if (cp_paths.size() == 0U) {
+      gtk_widget_set_visible(GTK_WIDGET(self->community_main_box), 0);
+      gtk_widget_set_visible(GTK_WIDGET(self->status_page_community_list), 1);
+
+      return;
+    }
+
+    // If there are paths, fill the empty list and hide the AdwStatusPage.
+    for (const auto& path : cp_paths) {
       gtk_string_list_append(self->presets_list_community, path.c_str());
     }
+
+    gtk_widget_set_visible(GTK_WIDGET(self->status_page_community_list), 0);
+    gtk_widget_set_visible(GTK_WIDGET(self->community_main_box), 1);
   };
 
   g_signal_connect(self->refresh_community_list, "clicked", G_CALLBACK(refresh_community_listview), self);
@@ -669,13 +686,15 @@ void presets_menu_class_init(PresetsMenuClass* klass) {
 
   gtk_widget_class_bind_template_child(widget_class, PresetsMenu, scrolled_window_local);
   gtk_widget_class_bind_template_child(widget_class, PresetsMenu, scrolled_window_community);
-  gtk_widget_class_bind_template_child(widget_class, PresetsMenu, listview_local);
-  gtk_widget_class_bind_template_child(widget_class, PresetsMenu, listview_community);
+  gtk_widget_class_bind_template_child(widget_class, PresetsMenu, new_preset_name);
   gtk_widget_class_bind_template_child(widget_class, PresetsMenu, search_community);
   gtk_widget_class_bind_template_child(widget_class, PresetsMenu, filter_string_community);
-  gtk_widget_class_bind_template_child(widget_class, PresetsMenu, new_preset_name);
-  gtk_widget_class_bind_template_child(widget_class, PresetsMenu, last_used_name);
+  gtk_widget_class_bind_template_child(widget_class, PresetsMenu, listview_local);
+  gtk_widget_class_bind_template_child(widget_class, PresetsMenu, listview_community);
+  gtk_widget_class_bind_template_child(widget_class, PresetsMenu, community_main_box);
+  gtk_widget_class_bind_template_child(widget_class, PresetsMenu, status_page_community_list);
   gtk_widget_class_bind_template_child(widget_class, PresetsMenu, refresh_community_list);
+  gtk_widget_class_bind_template_child(widget_class, PresetsMenu, last_used_name);
 
   gtk_widget_class_bind_template_callback(widget_class, create_preset);
   gtk_widget_class_bind_template_callback(widget_class, import_preset_from_disk);

--- a/src/rnnoise_ui.cpp
+++ b/src/rnnoise_ui.cpp
@@ -210,7 +210,7 @@ void setup_listview(RNNoiseBox* self) {
     gtk_string_list_append(self->string_list, name.c_str());
   }
 
-  if (g_list_model_get_n_items(G_LIST_MODEL(self->string_list)) == 0) {
+  if (g_list_model_get_n_items(G_LIST_MODEL(self->string_list)) == 0U) {
     g_settings_set_string(self->settings, "model-path", "");
   }
 }


### PR DESCRIPTION
A StatusPage is shown when the Community Presets list is empty.

I first tried with the overlay, but it was not good when the local preset list was empty because the popover was not long enough to contain the StatusPage (it was partially hidden and covering the search bar).

So I removed the overlay and now the StatusPage is a child of the StackPage. When the list is empty, the main box (search and listview) are hidden while the StatusPage is made visible.

@violetmage please test this you too, if you can. See #2445.