### PR TITLE
Community presets: fix scanning function

### DIFF
--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -347,7 +347,8 @@ auto PresetsManager::scan_community_package_recursive(std::filesystem::directory
           cp_paths.append_range(scan_community_package_recursive(subdir_it, scan_level, path.filename().c_str()));
           */
 
-          const auto sub_cp_vect = scan_community_package_recursive(subdir_it, scan_level, path.filename().c_str());
+          const auto sub_cp_vect =
+              scan_community_package_recursive(subdir_it, scan_level, origin + "/" + path.filename().c_str());
 
           cp_paths.insert(cp_paths.end(), sub_cp_vect.cbegin(), sub_cp_vect.cend());
         }


### PR DESCRIPTION
@wwmm Thanks for the fix, the search is working properly now.

Meanwhile I fixed the scanning function for the presets in package subdirectories.