### PR TITLE
Little fixes + CP Guidelines

### DIFF
--- a/COMMUNITY_PRESETS_GUIDELINES.md
+++ b/COMMUNITY_PRESETS_GUIDELINES.md
@@ -1,0 +1,85 @@
+# Introduction to Easy Effects Community Presets
+
+From `7.2.0` version, Easy Effects introduces the new system of Community
+Presets which is an easy way for users to try and use presets made by the
+community.
+
+The Presets menu popover of the graphical application shows an additional tab
+where community presets are listed.
+The difference with Local Presets is that  community ones are intended to be
+easily installed since not all users were able  to find presets on the internet,
+which were practically reported in one of the  subpage of the Github project
+(that linked other repositories where the user  should manually download them on
+the local storage).
+Now it should be easier to discover them making a search on Flatpak or the
+repository or your favorite distribution.
+
+Instead the Local Presets list is intended to save self-made presets and/or a
+selected choice of presets imported by the community list.
+Importing presets locally is essential when the user wants to autoload and
+associate them to a  specific device.
+Indeed, Community Presets **cannot be autoloaded**.
+
+In order to list the Community Presets, the user should install one or more
+packages made and maintained by other Easy Effects users.
+The packages can be shipped by Linux distributions in their specific
+repositories or by extensions available on Flatpak.
+
+# Guidelines for packagers of Easy Effects Community Presets
+
+The followings are the guidelines that packagers should respect in order to make
+their presets available inside Easy Effects.
+
+## How to make a package
+
+- The package should contain an `easyeffects` directory installed under one of
+the paths listed in the `$XDG_DATA_DIRS` environment variable.
+- The `easyeffects` directory above mentioned should contain the following
+subfolders:
+- - `output`: for presets applied to output devices (showed only in the popover
+of the Output page).
+- - `input`: for presets applied to input devices (showed only in the popover of
+the Input page).
+- The input/output folders above mentioned should contain a subdirectory with
+the name associated to the installed package. In example:
+- - `XDG_DATA_DIR/easyeffects/output/package-name`
+
+## Guidelines for package directories structure
+
+The package name should be unique to avoid misunderstanding between different
+packages. Therefore try to use a name which is exclusive to your package.
+Easy Effects can still distinguish and list presets from packages having the
+same name but installed in different `XDG_DATA_DIR`.
+Nevertheless this would confuse users seeing multiple presets with the same
+package name in the menu list. For this reasons we recommend to try to use
+unique package names.
+So choose a name that you know it won't be used by other packagers, maybe
+including your nickname.
+
+In example:
+- `XDG_DATA_DIR/easyeffects/output/wwmm-presets`
+- `XDG_DATA_DIR/easyeffects/output/Digitalone`
+- `XDG_DATA_DIR/easyeffects/output/vchernin`
+
+### How Easy Effects looks for Community Presets
+Basically Easy Effects scans every directory with the package name looking for:
+- Files with the `.json` extention.
+- - The packager should take care of the integrity of those `.json` files being
+text files that can be correctly parsed by the application in order to be loaded
+without errors.  
+- The scan takes place only in the first and the second level of the directory
+with the package name. In other words, the presets files contained in the folder
+itself and its subfolder.
+
+In example, the following presets are correctly loaded and listed:
+- `XDG_DATA_DIR/easyeffects/output/wwmm-presets/generic-pop.json`
+- `XDG_DATA_DIR/easyeffects/output/wwmm-presets/generic-rock.json`
+- `XDG_DATA_DIR/easyeffects/output/wwmm-presets/device-1/pop.json`
+- `XDG_DATA_DIR/easyeffects/output/wwmm-presets/device-1/rock.json`
+- `XDG_DATA_DIR/easyeffects/output/wwmm-presets/device-2/pop.json`
+- `XDG_DATA_DIR/easyeffects/output/wwmm-presets/device-1/rock.json`
+
+Files with the wrong extention or presets placed more in depth are not shown.
+In example, the followings are ignored:
+- `XDG_DATA_DIR/easyeffects/output/wwmm-presets/rock.txt`
+- `XDG_DATA_DIR/easyeffects/output/wwmm-presets/device-3/alternative/rock.json`

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ If your distribution does not yet include packages required to build Easy Effect
 
 ## Warning
 
-**Don't set** Easy Effects' virtual devices as your default audio input/output.
-Easy Effects is designed assuming that your hardware stays as default.
+**Do not set** Easy Effects virtual devices as your default audio input/output.
+Easy Effects is designed assuming that your hardware stays as default device.
 
 ## Help
 

--- a/data/ui/preferences_general.ui
+++ b/data/ui/preferences_general.ui
@@ -117,7 +117,8 @@
 
                 <child>
                     <object class="AdwActionRow">
-                        <property name="title" translatable="yes">Update Interval (Level Meters and Spectrum)</property>
+                        <property name="title" translatable="yes">Update Interval</property>
+                        <property name="subtitle" translatable="yes">Related to Level Meters and Spectrum</property>
 
                         <child>
                             <object class="GtkSpinButton" id="meters_update_interval">
@@ -140,7 +141,8 @@
 
                 <child>
                     <object class="AdwActionRow">
-                        <property name="title" translatable="yes">Update Frequency (LV2 Plugins)</property>
+                        <property name="title" translatable="yes">Update Frequency</property>
+                        <property name="subtitle" translatable="yes">Related to LV2 Plugins</property>
 
                         <child>
                             <object class="GtkSpinButton" id="lv2ui_update_frequency">

--- a/include/ui_helpers.hpp
+++ b/include/ui_helpers.hpp
@@ -61,9 +61,9 @@ auto missing_plugin_box(const std::string& base_name, const std::string& package
 
 void show_simple_message_dialog(GtkWidget* parent, const std::string& title, const std::string& descr);
 
-auto parse_spinbutton_output(GtkSpinButton* button, const char* unit, const bool& lower_bound = true) -> bool;
+auto parse_spinbutton_output(GtkSpinButton* button, const char* unit, const bool& lower_bound = true) -> gboolean;
 
-auto parse_spinbutton_input(GtkSpinButton* button, double* new_value, const bool& lower_bound = true) -> int;
+auto parse_spinbutton_input(GtkSpinButton* button, double* new_value, const bool& lower_bound = true) -> gint;
 
 auto get_new_filter_serial() -> uint;
 

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -112,6 +112,9 @@ auto str_contains(const std::string& haystack, const std::string& needle) -> boo
 
 auto compare_versions(const std::string& v0, const std::string& v1) -> int;
 
+void str_trim_start(std::string& str);
+void str_trim_end(std::string& str);
+
 template <typename T>
 void print_type(T v) {
   warning(typeid(v).name());
@@ -125,7 +128,7 @@ auto str_to_num(const std::string& str, T& num) -> bool {
   // A left trim is performed on strings so that the conversion could success
   // even if there are leading whitespaces and/or the plus sign.
 
-  auto first_char = str.find_first_not_of(" +\n\r\t");
+  auto first_char = str.find_first_not_of(" +\n\r\t\v\f");
 
   if (first_char == std::string::npos) {
     return false;

--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -135,7 +135,7 @@ void show_simple_message_dialog(GtkWidget* parent, const std::string& title, con
   gtk_window_present(GTK_WINDOW(dialog));
 }
 
-auto parse_spinbutton_output(GtkSpinButton* button, const char* unit, const bool& lower_bound) -> bool {
+auto parse_spinbutton_output(GtkSpinButton* button, const char* unit, const bool& lower_bound) -> gboolean {
   auto* adjustment = gtk_spin_button_get_adjustment(button);
   const auto value = gtk_adjustment_get_value(adjustment);
   const auto precision = gtk_spin_button_get_digits(button);
@@ -149,10 +149,10 @@ auto parse_spinbutton_output(GtkSpinButton* button, const char* unit, const bool
 
   gtk_editable_set_text(GTK_EDITABLE(button), text.c_str());
 
-  return true;
+  return TRUE;
 }
 
-auto parse_spinbutton_input(GtkSpinButton* button, double* new_value, const bool& lower_bound) -> int {
+auto parse_spinbutton_input(GtkSpinButton* button, double* new_value, const bool& lower_bound) -> gint {
   auto min = 0.0;
   auto max = 0.0;
 

--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -163,6 +163,8 @@ auto parse_spinbutton_input(GtkSpinButton* button, double* new_value, const bool
   if (!lower_bound) {
     auto s = str.str();
 
+    util::str_trim_start(s);
+
     if (s.starts_with(_("-inf"))) {
       *new_value = util::minimum_db_d_level;
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -401,13 +401,18 @@ auto str_contains(const std::string& haystack, const std::string& needle) -> boo
   return (haystack.find(needle) != std::string::npos);
 }
 
-void str_trim(std::string& str) {
-  // This util removes whitespaces from the beginning and the end of
-  // the given string.
+void str_trim_start(std::string& str) {
+  // This util removes whitespaces such as simple space " ", new line "\n",
+  // carriage return "\r", tab "\t", vertical tab "\v" and form feed "\f"
+  // at the start of the given string.
   // No copy involved, the input string is just modified if needed.
 
-  str.erase(0U, str.find_first_not_of(" \n\r\t\v\f"));  // left trim
-  str.erase(str.find_last_not_of(" \n\r\t\v\f") + 1U);  // right trim
+  str.erase(0U, str.find_first_not_of(" \n\r\t\v\f"));
+}
+
+void str_trim_end(std::string& str) {
+  // Same as above, but at the end of the given string.
+  str.erase(str.find_last_not_of(" \n\r\t\v\f") + 1U);
 }
 
 auto compare_versions(const std::string& v0, const std::string& v1) -> int {


### PR DESCRIPTION
- use trim start in parse spinbutton output (`   -inf` with leading spaces was not caught)
- adjust the return type of parse_spinbutton callbacks
- avoid parenthesis in preferences row titles and use subtitles  