### PR TITLE
Various fixes and Update NEWS

### DIFF
--- a/data/ui/app_info.ui
+++ b/data/ui/app_info.ui
@@ -257,7 +257,6 @@
                                         <property name="hexpand">1</property>
                                         <property name="xalign">0.5</property>
                                         <property name="digits">0</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">0</property>

--- a/data/ui/autogain.ui
+++ b/data/ui/autogain.ui
@@ -46,7 +46,6 @@
                                                                     </object>
                                                                 </property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                             </object>
                                                         </child>
                                                     </object>
@@ -71,7 +70,6 @@
                                                                     </object>
                                                                 </property>
                                                                 <property name="digits">0</property>
-                                                                <property name="update-policy">if-valid</property>
                                                             </object>
                                                         </child>
                                                     </object>
@@ -95,7 +93,6 @@
                                                                     </object>
                                                                 </property>
                                                                 <property name="digits">0</property>
-                                                                <property name="update-policy">if-valid</property>
                                                             </object>
                                                         </child>
                                                     </object>

--- a/data/ui/bass_enhancer.ui
+++ b/data/ui/bass_enhancer.ui
@@ -126,7 +126,6 @@
                                             </object>
                                         </property>
                                         <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
                                         <layout>
                                             <property name="column">0</property>
                                             <property name="row">1</property>
@@ -161,7 +160,6 @@
                                             </object>
                                         </property>
                                         <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
                                         <layout>
                                             <property name="column">1</property>
                                             <property name="row">1</property>
@@ -195,7 +193,6 @@
                                                 <property name="page-increment">10</property>
                                             </object>
                                         </property>
-                                        <property name="update-policy">if-valid</property>
                                         <layout>
                                             <property name="column">2</property>
                                             <property name="row">1</property>
@@ -231,7 +228,6 @@
                                                 <property name="page-increment">10</property>
                                             </object>
                                         </property>
-                                        <property name="update-policy">if-valid</property>
                                         <layout>
                                             <property name="column">3</property>
                                             <property name="row">1</property>

--- a/data/ui/bass_loudness.ui
+++ b/data/ui/bass_loudness.ui
@@ -30,7 +30,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-100</property>
@@ -52,7 +51,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-100</property>
@@ -74,7 +72,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-100</property>

--- a/data/ui/compressor.ui
+++ b/data/ui/compressor.ui
@@ -103,7 +103,6 @@
                                                                 <property name="halign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <binding name="sensitive">
                                                                     <closure type="gboolean"
                                                                         function="set_boost_threshold_sensitive">
@@ -143,7 +142,6 @@
                                                                 <property name="halign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <binding name="sensitive">
                                                                     <closure type="gboolean"
                                                                         function="set_boost_amount_sensitive">
@@ -211,7 +209,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="digits">2</property>
                                                                 <property name="width-chars">10</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="upper">2000</property>
@@ -233,7 +230,6 @@
                                                             <object class="GtkSpinButton" id="threshold">
                                                                 <property name="valign">center</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-60</property>
@@ -266,7 +262,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="margin-end">6</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="upper">5000</property>
@@ -290,7 +285,6 @@
                                                                 <property name="margin-end">6</property>
                                                                 <property name="digits">1</property>
                                                                 <property name="width-chars">10</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-100</property>
@@ -325,7 +319,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">1</property>
@@ -361,7 +354,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-24</property>
@@ -396,7 +388,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-60</property>
@@ -431,7 +422,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-100</property>
@@ -466,7 +456,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-100</property>
@@ -757,7 +746,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-120</property>
@@ -794,7 +782,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="upper">250</property>
@@ -831,7 +818,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="upper">20</property>
@@ -933,7 +919,6 @@
                                                         <property name="margin-end">6</property>
                                                         <property name="digits">0</property>
                                                         <property name="width-chars">10</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">10</property>
@@ -993,7 +978,6 @@
                                                         <property name="margin-start">6</property>
                                                         <property name="digits">0</property>
                                                         <property name="width-chars">10</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">10</property>

--- a/data/ui/convolver.ui
+++ b/data/ui/convolver.ui
@@ -93,7 +93,6 @@
                                                 <property name="orientation">vertical</property>
                                                 <property name="width-chars">10</property>
                                                 <property name="digits">0</property>
-                                                <property name="update-policy">if-valid</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
                                                         <property name="upper">200</property>

--- a/data/ui/crossfeed.ui
+++ b/data/ui/crossfeed.ui
@@ -59,7 +59,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">0</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">300</property>
@@ -82,7 +81,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">1</property>

--- a/data/ui/deepfilternet.ui
+++ b/data/ui/deepfilternet.ui
@@ -73,7 +73,6 @@
                                                             </object>
                                                         </property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <accessibility>
                                                             <property name="label">Minimum Processing Threshold</property>
                                                         </accessibility>
@@ -100,7 +99,6 @@
                                                             </object>
                                                         </property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <accessibility>
                                                             <property name="label">Maximum ERB Processing Threshold</property>
                                                         </accessibility>
@@ -127,7 +125,6 @@
                                                             </object>
                                                         </property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <accessibility>
                                                             <property name="label">Maximum DF Processing Threshold</property>
                                                         </accessibility>
@@ -153,7 +150,6 @@
                                                                 <property name="page-increment">1</property>
                                                             </object>
                                                         </property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <accessibility>
                                                             <property name="label">Minimum Processing Buffer</property>
                                                         </accessibility>
@@ -180,7 +176,6 @@
                                                                 <property name="page-increment">0.01</property>
                                                             </object>
                                                         </property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <accessibility>
                                                             <property name="label">Post Filter Beta</property>
                                                         </accessibility>

--- a/data/ui/deesser.ui
+++ b/data/ui/deesser.ui
@@ -102,7 +102,6 @@
                                                 <property name="halign">center</property>
                                                 <property name="width-chars">10</property>
                                                 <property name="digits">0</property>
-                                                <property name="update-policy">if-valid</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
                                                         <property name="lower">10</property>
@@ -135,7 +134,6 @@
                                                 <property name="halign">center</property>
                                                 <property name="width-chars">10</property>
                                                 <property name="digits">0</property>
-                                                <property name="update-policy">if-valid</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
                                                         <property name="lower">10</property>
@@ -177,7 +175,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">-24</property>
@@ -212,7 +209,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">-24</property>
@@ -247,7 +243,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">0.1</property>
@@ -282,7 +277,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">0</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">1</property>
@@ -317,7 +311,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">-60</property>
@@ -351,7 +344,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">0</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">1</property>
@@ -386,7 +378,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="upper">36</property>

--- a/data/ui/delay.ui
+++ b/data/ui/delay.ui
@@ -45,7 +45,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="upper">1000</property>
@@ -67,7 +66,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-100</property>
@@ -91,7 +89,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-100</property>
@@ -135,7 +132,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="upper">1000</property>
@@ -157,7 +153,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-100</property>
@@ -181,7 +176,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-100</property>

--- a/data/ui/echo_canceller.ui
+++ b/data/ui/echo_canceller.ui
@@ -30,7 +30,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">0</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">1</property>
@@ -53,7 +52,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">0</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-100</property>
@@ -75,7 +73,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">0</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-100</property>

--- a/data/ui/equalizer.ui
+++ b/data/ui/equalizer.ui
@@ -37,7 +37,6 @@
                                     <object class="GtkSpinButton" id="nbands">
                                         <property name="halign">center</property>
                                         <property name="digits">0</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">1</property>
@@ -103,7 +102,6 @@
                                         <property name="halign">center</property>
                                         <property name="width-chars">11</property>
                                         <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">-100</property>
@@ -136,7 +134,6 @@
                                         <property name="halign">center</property>
                                         <property name="width-chars">11</property>
                                         <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">-120</property>
@@ -169,7 +166,6 @@
                                         <property name="halign">center</property>
                                         <property name="width-chars">11</property>
                                         <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">-120</property>

--- a/data/ui/equalizer_band.ui
+++ b/data/ui/equalizer_band.ui
@@ -196,7 +196,6 @@
                                     <object class="GtkSpinButton" id="band_frequency">
                                         <property name="valign">center</property>
                                         <property name="digits">0</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="width-chars">10</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
@@ -228,7 +227,6 @@
                                     <object class="GtkSpinButton" id="band_gain">
                                         <property name="valign">center</property>
                                         <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="width-chars">10</property>
 
                                         <property name="sensitive" bind-source="band_scale" bind-property="sensitive" bind-flags="sync-create" />
@@ -264,7 +262,6 @@
                                     <object class="GtkSpinButton" id="band_quality">
                                         <property name="valign">center</property>
                                         <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="width-chars">10</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
@@ -295,7 +292,6 @@
                                     <object class="GtkSpinButton" id="band_width">
                                         <property name="valign">center</property>
                                         <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="width-chars">10</property>
 
                                         <binding name="sensitive">

--- a/data/ui/exciter.ui
+++ b/data/ui/exciter.ui
@@ -126,7 +126,6 @@
                                             </object>
                                         </property>
                                         <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
                                         <layout>
                                             <property name="column">0</property>
                                             <property name="row">1</property>
@@ -161,7 +160,6 @@
                                             </object>
                                         </property>
                                         <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
                                         <layout>
                                             <property name="column">1</property>
                                             <property name="row">1</property>
@@ -195,7 +193,6 @@
                                                 <property name="page-increment">100</property>
                                             </object>
                                         </property>
-                                        <property name="update-policy">if-valid</property>
                                         <layout>
                                             <property name="column">2</property>
                                             <property name="row">1</property>
@@ -231,7 +228,6 @@
                                                 <property name="page-increment">100</property>
                                             </object>
                                         </property>
-                                        <property name="update-policy">if-valid</property>
                                         <layout>
                                             <property name="column">3</property>
                                             <property name="row">1</property>

--- a/data/ui/expander.ui
+++ b/data/ui/expander.ui
@@ -130,7 +130,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="digits">2</property>
                                                                 <property name="width-chars">10</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="upper">2000</property>
@@ -152,7 +151,6 @@
                                                             <object class="GtkSpinButton" id="threshold">
                                                                 <property name="valign">center</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-60</property>
@@ -185,7 +183,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="margin-end">6</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="upper">5000</property>
@@ -209,7 +206,6 @@
                                                                 <property name="margin-end">6</property>
                                                                 <property name="digits">1</property>
                                                                 <property name="width-chars">10</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-100</property>
@@ -244,7 +240,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">1</property>
@@ -280,7 +275,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-24</property>
@@ -315,7 +309,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-60</property>
@@ -350,7 +343,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-100</property>
@@ -385,7 +377,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-100</property>
@@ -675,7 +666,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-120</property>
@@ -712,7 +702,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="upper">250</property>
@@ -749,7 +738,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="upper">20</property>
@@ -851,7 +839,6 @@
                                                         <property name="margin-end">6</property>
                                                         <property name="digits">0</property>
                                                         <property name="width-chars">10</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">10</property>
@@ -911,7 +898,6 @@
                                                         <property name="margin-start">6</property>
                                                         <property name="digits">0</property>
                                                         <property name="width-chars">10</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">10</property>

--- a/data/ui/filter.ui
+++ b/data/ui/filter.ui
@@ -170,7 +170,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">0</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">10</property>
@@ -197,7 +196,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">0</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">0</property>
@@ -224,7 +222,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-36</property>
@@ -251,7 +248,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">0</property>
@@ -278,7 +274,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-100</property>

--- a/data/ui/gate.ui
+++ b/data/ui/gate.ui
@@ -96,7 +96,6 @@
                                                                         <property name="orientation">vertical</property>
                                                                         <property name="digits">2</property>
                                                                         <property name="width-chars">11</property>
-                                                                        <property name="update-policy">if-valid</property>
                                                                         <property name="adjustment">
                                                                             <object class="GtkAdjustment">
                                                                                 <property name="upper">2000</property>
@@ -116,7 +115,6 @@
                                                                         <property name="orientation">vertical</property>
                                                                         <property name="digits">2</property>
                                                                         <property name="width-chars">11</property>
-                                                                        <property name="update-policy">if-valid</property>
                                                                         <property name="adjustment">
                                                                             <object class="GtkAdjustment">
                                                                                 <property name="upper">5000</property>
@@ -189,7 +187,6 @@
                                                                         <property name="orientation">vertical</property>
                                                                         <property name="digits">1</property>
                                                                         <property name="width-chars">10</property>
-                                                                        <property name="update-policy">if-valid</property>
                                                                         <property name="adjustment">
                                                                             <object class="GtkAdjustment">
                                                                                 <property name="lower">-60</property>
@@ -209,7 +206,6 @@
                                                                         <property name="orientation">vertical</property>
                                                                         <property name="digits">1</property>
                                                                         <property name="width-chars">10</property>
-                                                                        <property name="update-policy">if-valid</property>
                                                                         <property name="adjustment">
                                                                             <object class="GtkAdjustment">
                                                                                 <property name="lower">-60</property>
@@ -282,7 +278,6 @@
                                                                         <property name="orientation">vertical</property>
                                                                         <property name="digits">1</property>
                                                                         <property name="width-chars">10</property>
-                                                                        <property name="update-policy">if-valid</property>
                                                                         <property name="sensitive" bind-source="hysteresis" bind-property="active" bind-flags="sync-create" />
                                                                         <property name="adjustment">
                                                                             <object class="GtkAdjustment">
@@ -303,7 +298,6 @@
                                                                         <property name="orientation">vertical</property>
                                                                         <property name="digits">1</property>
                                                                         <property name="width-chars">10</property>
-                                                                        <property name="update-policy">if-valid</property>
                                                                         <property name="sensitive" bind-source="hysteresis" bind-property="active" bind-flags="sync-create" />
                                                                         <property name="adjustment">
                                                                             <object class="GtkAdjustment">
@@ -378,7 +372,6 @@
                                                                         <property name="orientation">vertical</property>
                                                                         <property name="width-chars">10</property>
                                                                         <property name="digits">1</property>
-                                                                        <property name="update-policy">if-valid</property>
                                                                         <property name="adjustment">
                                                                             <object class="GtkAdjustment">
                                                                                 <property name="lower">-100</property>
@@ -399,7 +392,6 @@
                                                                         <property name="orientation">vertical</property>
                                                                         <property name="width-chars">10</property>
                                                                         <property name="digits">1</property>
-                                                                        <property name="update-policy">if-valid</property>
                                                                         <property name="adjustment">
                                                                             <object class="GtkAdjustment">
                                                                                 <property name="lower">-100</property>
@@ -458,7 +450,6 @@
                                                                         <property name="orientation">vertical</property>
                                                                         <property name="width-chars">10</property>
                                                                         <property name="digits">1</property>
-                                                                        <property name="update-policy">if-valid</property>
                                                                         <property name="adjustment">
                                                                             <object class="GtkAdjustment">
                                                                                 <property name="lower">-72</property>
@@ -478,7 +469,6 @@
                                                                         <property name="orientation">vertical</property>
                                                                         <property name="width-chars">10</property>
                                                                         <property name="digits">1</property>
-                                                                        <property name="update-policy">if-valid</property>
                                                                         <property name="adjustment">
                                                                             <object class="GtkAdjustment">
                                                                                 <property name="lower">-60</property>
@@ -889,7 +879,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-120</property>
@@ -926,7 +915,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="upper">250</property>
@@ -963,7 +951,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="upper">20</property>
@@ -1065,7 +1052,6 @@
                                                         <property name="margin-end">6</property>
                                                         <property name="digits">0</property>
                                                         <property name="width-chars">10</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">10</property>
@@ -1125,7 +1111,6 @@
                                                         <property name="margin-start">6</property>
                                                         <property name="digits">0</property>
                                                         <property name="width-chars">10</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">10</property>

--- a/data/ui/limiter.ui
+++ b/data/ui/limiter.ui
@@ -213,7 +213,6 @@
                                                 <property name="orientation">vertical</property>
                                                 <property name="width-chars">10</property>
                                                 <property name="digits">1</property>
-                                                <property name="update-policy">if-valid</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
                                                         <property name="lower">-120</property>
@@ -254,7 +253,6 @@
                                                 <property name="orientation">vertical</property>
                                                 <property name="width-chars">10</property>
                                                 <property name="digits">2</property>
-                                                <property name="update-policy">if-valid</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
                                                         <property name="lower">0.1</property>
@@ -296,7 +294,6 @@
                                                 <property name="orientation">vertical</property>
                                                 <property name="width-chars">10</property>
                                                 <property name="digits">2</property>
-                                                <property name="update-policy">if-valid</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
                                                         <property name="lower">0.25</property>
@@ -338,7 +335,6 @@
                                                 <property name="orientation">vertical</property>
                                                 <property name="width-chars">10</property>
                                                 <property name="digits">2</property>
-                                                <property name="update-policy">if-valid</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
                                                         <property name="lower">0.25</property>
@@ -380,7 +376,6 @@
                                                 <property name="orientation">vertical</property>
                                                 <property name="width-chars">10</property>
                                                 <property name="digits">2</property>
-                                                <property name="update-policy">if-valid</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
                                                         <property name="lower">-48</property>
@@ -432,7 +427,6 @@
                                                 <property name="orientation">vertical</property>
                                                 <property name="width-chars">10</property>
                                                 <property name="digits">2</property>
-                                                <property name="update-policy">if-valid</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
                                                         <property name="lower">0</property>
@@ -518,7 +512,6 @@
                                                 <property name="orientation">vertical</property>
                                                 <property name="width-chars">10</property>
                                                 <property name="digits">2</property>
-                                                <property name="update-policy">if-valid</property>
                                                 <property name="sensitive" bind-source="alr" bind-property="active" bind-flags="sync-create" />
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
@@ -554,7 +547,6 @@
                                                 <property name="orientation">vertical</property>
                                                 <property name="width-chars">11</property>
                                                 <property name="digits">2</property>
-                                                <property name="update-policy">if-valid</property>
                                                 <property name="sensitive" bind-source="alr" bind-property="active" bind-flags="sync-create" />
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
@@ -590,7 +582,6 @@
                                                 <property name="orientation">vertical</property>
                                                 <property name="width-chars">10</property>
                                                 <property name="digits">1</property>
-                                                <property name="update-policy">if-valid</property>
                                                 <property name="sensitive" bind-source="alr" bind-property="active" bind-flags="sync-create" />
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">

--- a/data/ui/loudness.ui
+++ b/data/ui/loudness.ui
@@ -85,7 +85,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-83</property>
@@ -113,7 +112,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">0</property>

--- a/data/ui/maximizer.ui
+++ b/data/ui/maximizer.ui
@@ -30,7 +30,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">2</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">1</property>
@@ -53,7 +52,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-30</property>
@@ -74,7 +72,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-30</property>

--- a/data/ui/multiband_compressor.ui
+++ b/data/ui/multiband_compressor.ui
@@ -183,7 +183,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-100</property>
@@ -217,7 +216,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-100</property>

--- a/data/ui/multiband_compressor_band.ui
+++ b/data/ui/multiband_compressor_band.ui
@@ -34,7 +34,6 @@
                             <object class="GtkSpinButton" id="split_frequency">
                                 <property name="digits">0</property>
                                 <property name="width-chars">10</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
                                         <property name="lower">10</property>
@@ -209,7 +208,6 @@
                         <property name="margin-end">6</property>
                         <property name="digits">2</property>
                         <property name="width-chars">10</property>
-                        <property name="update-policy">if-valid</property>
                         <property name="adjustment">
                             <object class="GtkAdjustment">
                                 <property name="upper">2000</property>
@@ -234,7 +232,6 @@
                         <property name="valign">center</property>
                         <property name="digits">1</property>
                         <property name="width-chars">10</property>
-                        <property name="update-policy">if-valid</property>
                         <property name="adjustment">
                             <object class="GtkAdjustment">
                                 <property name="lower">-60</property>
@@ -261,7 +258,6 @@
                         <property name="margin-start">12</property>
                         <property name="digits">2</property>
                         <property name="width-chars">10</property>
-                        <property name="update-policy">if-valid</property>
                         <property name="adjustment">
                             <object class="GtkAdjustment">
                                 <property name="upper">2000</property>
@@ -288,7 +284,6 @@
                         <property name="margin-start">12</property>
                         <property name="digits">1</property>
                         <property name="width-chars">10</property>
-                        <property name="update-policy">if-valid</property>
                         <property name="adjustment">
                             <object class="GtkAdjustment">
                                 <property name="lower">-100</property>
@@ -325,7 +320,6 @@
                         <property name="orientation">vertical</property>
                         <property name="width-chars">10</property>
                         <property name="digits">2</property>
-                        <property name="update-policy">if-valid</property>
                         <property name="adjustment">
                             <object class="GtkAdjustment">
                                 <property name="lower">1</property>
@@ -363,7 +357,6 @@
                         <property name="orientation">vertical</property>
                         <property name="width-chars">10</property>
                         <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
                         <property name="adjustment">
                             <object class="GtkAdjustment">
                                 <property name="lower">-24</property>
@@ -401,7 +394,6 @@
                         <property name="orientation">vertical</property>
                         <property name="width-chars">10</property>
                         <property name="digits">1</property>
-                        <property name="update-policy">if-valid</property>
                         <property name="adjustment">
                             <object class="GtkAdjustment">
                                 <property name="lower">-60</property>
@@ -600,7 +592,6 @@
                                         <property name="valign">center</property>
                                         <property name="digits">0</property>
                                         <property name="width-chars">10</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">10</property>
@@ -639,7 +630,6 @@
                                         <property name="margin-top">6</property>
                                         <property name="digits">0</property>
                                         <property name="width-chars">10</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">10</property>
@@ -686,7 +676,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">-120</property>
@@ -720,7 +709,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="upper">250</property>
@@ -754,7 +742,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="upper">20</property>
@@ -787,7 +774,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
 
                                         <binding name="sensitive">
                                             <closure type="gboolean" function="set_boost_amount_sensitive">
@@ -831,7 +817,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
 
                                         <binding name="sensitive">
                                             <closure type="gboolean" function="set_boost_threshold_sensitive">

--- a/data/ui/multiband_gate.ui
+++ b/data/ui/multiband_gate.ui
@@ -183,7 +183,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-100</property>
@@ -217,7 +216,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-100</property>

--- a/data/ui/multiband_gate_band.ui
+++ b/data/ui/multiband_gate_band.ui
@@ -34,7 +34,6 @@
                             <object class="GtkSpinButton" id="split_frequency">
                                 <property name="digits">0</property>
                                 <property name="width-chars">10</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
                                         <property name="lower">10</property>
@@ -170,7 +169,6 @@
                                 <property name="orientation">vertical</property>
                                 <property name="digits">2</property>
                                 <property name="width-chars">11</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
                                         <property name="upper">2000</property>
@@ -190,7 +188,6 @@
                                 <property name="orientation">vertical</property>
                                 <property name="digits">2</property>
                                 <property name="width-chars">11</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
                                         <property name="upper">5000</property>
@@ -263,7 +260,6 @@
                                 <property name="orientation">vertical</property>
                                 <property name="digits">1</property>
                                 <property name="width-chars">10</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
                                         <property name="lower">-60</property>
@@ -283,7 +279,6 @@
                                 <property name="orientation">vertical</property>
                                 <property name="digits">1</property>
                                 <property name="width-chars">10</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
                                         <property name="lower">-60</property>
@@ -356,7 +351,6 @@
                                 <property name="orientation">vertical</property>
                                 <property name="digits">1</property>
                                 <property name="width-chars">10</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="sensitive" bind-source="hysteresis" bind-property="active" bind-flags="sync-create" />
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
@@ -377,7 +371,6 @@
                                 <property name="orientation">vertical</property>
                                 <property name="digits">1</property>
                                 <property name="width-chars">10</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="sensitive" bind-source="hysteresis" bind-property="active" bind-flags="sync-create" />
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
@@ -438,7 +431,6 @@
                                 <property name="orientation">vertical</property>
                                 <property name="width-chars">10</property>
                                 <property name="digits">1</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
                                         <property name="lower">-72</property>
@@ -458,7 +450,6 @@
                                 <property name="orientation">vertical</property>
                                 <property name="width-chars">10</property>
                                 <property name="digits">1</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
                                         <property name="lower">-60</property>
@@ -659,7 +650,6 @@
                                         <property name="valign">center</property>
                                         <property name="digits">0</property>
                                         <property name="width-chars">10</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">10</property>
@@ -698,7 +688,6 @@
                                         <property name="margin-top">6</property>
                                         <property name="digits">0</property>
                                         <property name="width-chars">10</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">10</property>
@@ -744,7 +733,6 @@
                                         <property name="halign">center</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">-120</property>
@@ -777,7 +765,6 @@
                                         <property name="halign">center</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="upper">250</property>
@@ -810,7 +797,6 @@
                                         <property name="halign">center</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="upper">20</property>

--- a/data/ui/pipe_manager_box.ui
+++ b/data/ui/pipe_manager_box.ui
@@ -640,7 +640,6 @@
                                                             </object>
                                                         </property>
                                                         <property name="digits">0</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="width-chars">10</property>
                                                     </object>
                                                 </child>

--- a/data/ui/pitch.ui
+++ b/data/ui/pitch.ui
@@ -62,7 +62,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">0</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">0</property>
@@ -85,7 +84,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">0</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">0</property>
@@ -108,7 +106,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">0</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">0</property>
@@ -141,7 +138,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-12</property>
@@ -164,7 +160,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">0</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-50</property>
@@ -187,7 +182,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">0</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-50</property>

--- a/data/ui/preferences_general.ui
+++ b/data/ui/preferences_general.ui
@@ -100,7 +100,6 @@
                                 <property name="valign">center</property>
                                 <property name="width-chars">7</property>
                                 <property name="digits">0</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="sensitive" bind-source="inactivity_timer_enable" bind-property="active" bind-flags="sync-create" />
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
@@ -125,7 +124,6 @@
                                 <property name="valign">center</property>
                                 <property name="width-chars">7</property>
                                 <property name="digits">0</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
                                         <property name="lower">1</property>
@@ -149,7 +147,6 @@
                                 <property name="valign">center</property>
                                 <property name="width-chars">7</property>
                                 <property name="digits">0</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
                                         <property name="lower">1</property>

--- a/data/ui/preferences_spectrum.ui
+++ b/data/ui/preferences_spectrum.ui
@@ -53,7 +53,6 @@
                             <object class="GtkSpinButton" id="n_points">
                                 <property name="valign">center</property>
                                 <property name="digits">0</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
                                         <property name="lower">2</property>
@@ -75,7 +74,6 @@
                             <object class="GtkSpinButton" id="height">
                                 <property name="valign">center</property>
                                 <property name="digits">0</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
                                         <property name="lower">1</property>
@@ -97,7 +95,6 @@
                         <child>
                             <object class="GtkSpinButton" id="line_width">
                                 <property name="valign">center</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="digits">1</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
@@ -215,7 +212,6 @@
                             <object class="GtkSpinButton" id="minimum_frequency">
                                 <property name="valign">center</property>
                                 <property name="width-chars">10</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
                                         <property name="lower">20</property>
@@ -238,7 +234,6 @@
                             <object class="GtkSpinButton" id="maximum_frequency">
                                 <property name="valign">center</property>
                                 <property name="width-chars">10</property>
-                                <property name="update-policy">if-valid</property>
                                 <property name="adjustment">
                                     <object class="GtkAdjustment">
                                         <property name="lower">20</property>

--- a/data/ui/presets_menu.ui
+++ b/data/ui/presets_menu.ui
@@ -42,6 +42,7 @@
                                                         <property name="hexpand">1</property>
                                                         <property name="placeholder-text" translatable="yes">Name</property>
                                                         <property name="input-purpose">name</property>
+                                                        <property name="truncate-multiline">1</property>
                                                         <property name="accessible-role">text-box</property>
                                                         <accessibility>
                                                             <property name="label" translatable="yes">New Preset Name</property>

--- a/data/ui/reverb.ui
+++ b/data/ui/reverb.ui
@@ -46,7 +46,6 @@
                                             <object class="GtkSpinButton" id="hf_damp">
                                                 <property name="width-chars">10</property>
                                                 <property name="digits">0</property>
-                                                <property name="update-policy">if-valid</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
                                                         <property name="lower">2000</property>
@@ -113,7 +112,6 @@
                                                 <property name="halign">center</property>
                                                 <property name="width-chars">10</property>
                                                 <property name="digits">2</property>
-                                                <property name="update-policy">if-valid</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
                                                         <property name="upper">1</property>
@@ -154,7 +152,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="upper">500</property>
@@ -187,7 +184,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">2</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">0.4</property>
@@ -222,7 +218,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">-100</property>
@@ -256,7 +251,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">1</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">-100</property>
@@ -291,7 +285,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">0</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">20</property>
@@ -326,7 +319,6 @@
                                         <property name="orientation">vertical</property>
                                         <property name="width-chars">10</property>
                                         <property name="digits">0</property>
-                                        <property name="update-policy">if-valid</property>
                                         <property name="adjustment">
                                             <object class="GtkAdjustment">
                                                 <property name="lower">20</property>

--- a/data/ui/rnnoise.ui
+++ b/data/ui/rnnoise.ui
@@ -69,7 +69,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">0</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">0</property>
@@ -96,7 +95,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">2</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-100</property>
@@ -123,7 +121,6 @@
                                                         <property name="valign">center</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">2</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">0</property>

--- a/data/ui/speex.ui
+++ b/data/ui/speex.ui
@@ -99,7 +99,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">0</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">0</property>
@@ -122,7 +121,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">0</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">0</property>
@@ -152,7 +150,6 @@
                                                                 <property name="valign">center</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-100</property>

--- a/data/ui/stereo_tools.ui
+++ b/data/ui/stereo_tools.ui
@@ -62,7 +62,6 @@
                                                         <property name="orientation">vertical</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">2</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-1</property>
@@ -98,7 +97,6 @@
                                                         <property name="orientation">vertical</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">2</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">1</property>
@@ -246,7 +244,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-36</property>
@@ -282,7 +279,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-1</property>
@@ -318,7 +314,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">1</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-36</property>
@@ -354,7 +349,6 @@
                                                                 <property name="orientation">vertical</property>
                                                                 <property name="width-chars">10</property>
                                                                 <property name="digits">2</property>
-                                                                <property name="update-policy">if-valid</property>
                                                                 <property name="adjustment">
                                                                     <object class="GtkAdjustment">
                                                                         <property name="lower">-1</property>
@@ -407,7 +401,6 @@
                                                         <property name="orientation">vertical</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">2</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-1</property>
@@ -443,7 +436,6 @@
                                                         <property name="orientation">vertical</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">2</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-20</property>
@@ -479,7 +471,6 @@
                                                         <property name="orientation">vertical</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">2</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-1</property>
@@ -515,7 +506,6 @@
                                                         <property name="orientation">vertical</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">2</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="upper">360</property>
@@ -548,7 +538,6 @@
                                                         <property name="orientation">vertical</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-100</property>
@@ -584,7 +573,6 @@
                                                         <property name="orientation">vertical</property>
                                                         <property name="width-chars">10</property>
                                                         <property name="digits">1</property>
-                                                        <property name="update-policy">if-valid</property>
                                                         <property name="adjustment">
                                                             <object class="GtkAdjustment">
                                                                 <property name="lower">-100</property>

--- a/include/ui_helpers.hpp
+++ b/include/ui_helpers.hpp
@@ -63,7 +63,7 @@ void show_simple_message_dialog(GtkWidget* parent, const std::string& title, con
 
 auto parse_spinbutton_output(GtkSpinButton* button, const char* unit, const bool& lower_bound = true) -> gboolean;
 
-auto parse_spinbutton_input(GtkSpinButton* button, double* new_value, const bool& lower_bound = true) -> gint;
+auto parse_spinbutton_input(GtkSpinButton* button, gdouble* new_value, const bool& lower_bound = true) -> gint;
 
 auto get_new_filter_serial() -> uint;
 

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -114,6 +114,7 @@ auto compare_versions(const std::string& v0, const std::string& v1) -> int;
 
 void str_trim_start(std::string& str);
 void str_trim_end(std::string& str);
+void str_trim(std::string& str);
 
 template <typename T>
 void print_type(T v) {

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -273,6 +273,8 @@ auto PresetsManager::search_names(std::filesystem::directory_iterator& it) -> st
 }
 
 void PresetsManager::add(const PresetType& preset_type, const std::string& name) {
+  // This method assumes the filename is valid.
+
   for (const auto& p : get_local_presets_name(preset_type)) {
     if (p == name) {
       return;

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -389,7 +389,8 @@ auto PresetsManager::get_community_preset_info(const PresetType& preset_type, co
     }
 
     // Check if the preset is contained in the selected system data directory.
-    if (!path.starts_with(cp_dir)) {
+    // starts_with gets a string_view, so we use the version with character array.
+    if (!path.starts_with(cp_dir.c_str())) {
       continue;
     }
 

--- a/src/presets_menu.cpp
+++ b/src/presets_menu.cpp
@@ -102,18 +102,31 @@ auto closure_community_search_filter(PresetsMenu* self, const char* text) -> con
 void create_preset(PresetsMenu* self, GtkButton* button) {
   auto name = std::string(g_utf8_make_valid(gtk_editable_get_text(GTK_EDITABLE(self->new_preset_name)), -1));
 
+  // Reset input field.
+  gtk_editable_set_text(GTK_EDITABLE(self->new_preset_name), "");
+
+  // Remove leading and trailing whitespaces.
+  util::str_trim(name);
+
+  static const auto json_ext_re = std::regex(R"(\.json)", std::regex::icase);
+
+  // Remove the json extension, if present
+  // (it will be added in PresetsManager::add()).
+  if (std::smatch sm; std::regex_search(name, sm, json_ext_re)) {
+    name.resize(name.size() - 5U);
+  }
+
+  // Check if empty.
   if (name.empty()) {
     return;
   }
 
-  gtk_editable_set_text(GTK_EDITABLE(self->new_preset_name), "");
-
-  // Truncate if longer than 100 characters
-
-  if (name.size() > 100U) {
-    name.resize(100U);
+  // Truncate if the name is longer than 100 characters.
+  if (const auto max_length = 100U; name.size() > max_length) {
+    name.resize(max_length);
   }
 
+  // Check for illegal characters.
   if (name.find_first_of("\\/") != std::string::npos) {
     util::debug(" name " + name + " has illegal file name characters. Aborting preset creation!");
 

--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -152,7 +152,7 @@ auto parse_spinbutton_output(GtkSpinButton* button, const char* unit, const bool
   return TRUE;
 }
 
-auto parse_spinbutton_input(GtkSpinButton* button, double* new_value, const bool& lower_bound) -> gint {
+auto parse_spinbutton_input(GtkSpinButton* button, gdouble* new_value, const bool& lower_bound) -> gint {
   auto min = 0.0;
   auto max = 0.0;
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -414,6 +414,11 @@ void str_trim_end(std::string& str) {
   // Same as above, but at the end of the given string.
   str.erase(str.find_last_not_of(" \n\r\t\v\f") + 1U);
 }
+void str_trim(std::string& str) {
+  // Trim both sides of the given string. See above.
+  str_trim_end(str);
+  str_trim_start(str);
+}
 
 auto compare_versions(const std::string& v0, const std::string& v1) -> int {
   /* This is an util to compare two strings as semver, mainly used to compare

--- a/util/NEWS.yaml
+++ b/util/NEWS.yaml
@@ -2,15 +2,15 @@
 Version: UNRELEASED_VERSION
 Date: UNRELEASED_DATE
 
-Description: 
+Description:
 - Features∶
-- 
+- Community Presets have been implemented. Users can install packages containing multiple Easy Effects presets to be imported and applied inside the application. These packages will be maintained and shipped by volunteers. You can search them on Flathub or the repositories of your favorite distribution.
 
 - Bug fixes∶
-- 
+- A change in GTK 4.14.1 prevented to apply the values inserted into the text field of our SpinButton widgets. This issue is now resolved.
 
 - Other notes∶
-- 
+- In order for Community Presets to be correctly shipped, packagers are invited to read and follow the guidelines linked inside the README of EasyEffects master branch.
 
 ---
 Version: 7.1.6


### PR DESCRIPTION
- reduce some implicit conversions
- removed `update-policy` property to all spinbuttons; fixes #3033
- update NEWS
- improved sanitizer when adding new preset names

Without trimming the string, the used could add an empty row in the list, which is not preferable:

![Schermata del 2024-04-04 12-29-46](https://github.com/wwmm/easyeffects/assets/25790525/0b1c67f1-ab18-49d5-bbcd-014bb704c6bf)
