### PR TITLE
Toggle plugins list visibility

### DIFF
--- a/data/schemas/com.github.wwmm.easyeffects.streaminputs.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.streaminputs.gschema.xml
@@ -20,5 +20,8 @@
         <key name="show-blocklisted-apps" type="b">
             <default>false</default>
         </key>
+        <key name="show-plugins-list" type="b">
+            <default>true</default>
+        </key>
     </schema>
 </schemalist>

--- a/data/schemas/com.github.wwmm.easyeffects.streamoutputs.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.streamoutputs.gschema.xml
@@ -20,5 +20,8 @@
         <key name="show-blocklisted-apps" type="b">
             <default>false</default>
         </key>
+        <key name="show-plugins-list" type="b">
+            <default>true</default>
+        </key>
     </schema>
 </schemalist>

--- a/data/ui/plugins_box.ui
+++ b/data/ui/plugins_box.ui
@@ -9,19 +9,43 @@
                 <property name="spacing">6</property>
                 <property name="css-name">listview</property>
                 <child>
-                    <object class="GtkMenuButton" id="menubutton_plugins">
+                    <object class="GtkBox">
+                        <property name="halign">center</property>
+                        <property name="valign">center</property>
                         <property name="margin-start">6</property>
                         <property name="margin-end">6</property>
                         <property name="margin-top">6</property>
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
-                        <property name="direction">right</property>
-                        <property name="label" translatable="yes">Add Effect</property>
-                        <property name="cursor">
-                            <object class="GdkCursor">
-                                <property name="name">pointer</property>
+                        <property name="spacing">6</property>
+                        <child>
+                            <object class="GtkToggleButton" id="toggle_plugins_list">
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="icon-name">sidebar-show-symbolic</property>
+                                <property name="active">1</property>
+                                <property name="active" bind-source="menubutton_plugins" bind-property="visible" bind-flags="sync-create|bidirectional" />
+                                <property name="active" bind-source="plugins_stack_box" bind-property="visible" bind-flags="sync-create|bidirectional" />
+                                <property name="tooltip-text" translatable="yes">Show/hide effects list</property>
+                                <property name="cursor">
+                                    <object class="GdkCursor">
+                                        <property name="name">pointer</property>
+                                    </object>
+                                </property>
                             </object>
-                        </property>
+                        </child>
+
+                        <child>
+                            <object class="GtkMenuButton" id="menubutton_plugins">
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="direction">right</property>
+                                <property name="label" translatable="yes">Add Effect</property>
+                                <property name="cursor">
+                                    <object class="GdkCursor">
+                                        <property name="name">pointer</property>
+                                    </object>
+                                </property>
+                            </object>
+                        </child>
                     </object>
                 </child>
 
@@ -30,7 +54,7 @@
                         <property name="propagate-natural-width">1</property>
                         <property name="propagate-natural-height">1</property>
                         <child>
-                            <object class="GtkBox">
+                            <object class="GtkBox" id="plugins_stack_box">
                                 <property name="orientation">vertical</property>
                                 <child>
                                     <object class="GtkBox" id="startpoint_box">

--- a/src/plugins_box.cpp
+++ b/src/plugins_box.cpp
@@ -130,6 +130,8 @@ struct Data {
 struct _PluginsBox {
   GtkBox parent_instance;
 
+  GtkToggleButton* toggle_plugins_list;
+
   GtkMenuButton* menubutton_plugins;
 
   GtkOverlay* plugin_overlay;
@@ -797,6 +799,8 @@ void setup(PluginsBox* self, app::Application* application, PipelineType pipelin
     }
   }
 
+  gsettings_bind_widget(self->settings, "show-plugins-list", self->toggle_plugins_list);
+
   ui::plugins_menu::setup(self->plugins_menu, application, pipeline_type);
 
   setup_listview(self);
@@ -890,6 +894,7 @@ void plugins_box_class_init(PluginsBoxClass* klass) {
 
   gtk_widget_class_set_template_from_resource(widget_class, tags::resources::plugins_box_ui);
 
+  gtk_widget_class_bind_template_child(widget_class, PluginsBox, toggle_plugins_list);
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, menubutton_plugins);
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, plugin_overlay);
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, overlay_no_plugins);


### PR DESCRIPTION
This should improve the corner case in #2955.

I was inspired by [this](https://brave.com/blog/vertical-tabs/) which has a top toggle button always visible. Libadwaita has some native widgets to implement the same stuff, but we have to add a top/header bar which I don't like since it reduces the vertical space of the plugin box.

Feel free to discard if you don't like it, but it's not a big change since it's true/visible by default. For users not interested, only a small toggle button is added.