### PR TITLE
Flatpak presets

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -46,7 +46,7 @@ jobs:
       FLATPAK_BUILD_PATH: flatpak_app/files/share
     needs: prepare
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-45
+      image: bilelmoussaoui/flatpak-github-actions:gnome-46
       options: --privileged
     steps:
     - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,7 @@ ppastats
 .autobuild
 
 # exclude flatpak build directories
-build-dir
+build-dir*
 util/flatpak/repo
 .flatpak
 .flatpak-builder

--- a/COMMUNITY_PRESETS_GUIDELINES.md
+++ b/COMMUNITY_PRESETS_GUIDELINES.md
@@ -47,6 +47,101 @@ Noise Reduction effect.
 - The folders above mentioned should contain a subdirectory with the name
 associated to the installed package. In example:
 - - `XDG_DATA_DIR/easyeffects/output/package-name`
+- The name of the package should be something descriptive e.g. `easyeffects-presets-LoudnessEqualizer`. If your package contains a group of presets without a particular "theme", naming a package `easyeffects-USERNAME-presets` is reasonable.
+
+### Flatpak
+
+Flatpak extension packages do not use `$XDG_DATA_DIRS`, and instead place and search for files under a different directory (detailed in examples below). Besides this detail, flatpak and distribution packages should behave the same in regard to community presets.
+
+In order to package a flatpak on flathub you do the following general steps:
+
+1. Create AppStream metainfo file (should be stored in your preset repository as it is not flatpak-specific).
+2. Create flatpak json file
+3. Submit to flathub, described following [flathub's guide](https://docs.flathub.org/docs/for-app-authors/submission/).
+
+#### Step by step instructions
+
+1. Decide on a name. It should be e.g. `io.github.wwmm.easyeffects.Presets.PRESET_PACKAGE_NAME`. The name must be consistent across the files used for flatpak otherwise the package will not build/work properly.
+
+> [!NOTE]  
+> flatpak uses `io.github.wwmm.easyeffects.Presets` as the extension point name (which preset packages must use), while `com.github.wwmm.easyeffects` is the name of the easyeffects package itself. This is necessary since `com.github.*` is only allowed for backwards compatibility reasons on flathub, and newer packages must use `io.github.*`. 
+
+2. Clone the flathub repo following [flathub's guide](https://docs.flathub.org/docs/for-app-authors/submission/).
+
+3. Create the AppStream metainfo file, which should go in your preset repository, not the flathub repository. Name it `io.github.wwmm.easyeffects.Presets.PRESET_PACKAGE_NAME.metainfo.xml`. Replace `PRESET_PACKAGE_NAME`, `PRESET_PACKAGE_NAME_PRETTY`, `DEVELOPER_NAME_ID`, `DEVELOPER_NAME`, `REPO_URL`. You may add more information to this file (which may help improve visibility of the package on flathub/software stores) as described in the [appstream docs](https://www.freedesktop.org/software/appstream/docs/).
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>io.github.wwmm.easyeffects.Presets.PRESET_PACKAGE_NAME</id>
+  <extends>com.github.wwmm.easyeffects</extends>
+  <name>PRESET_PACKAGE_NAME_PRETTY Easy Effects Presets</name>
+  <developer id="DEVELOPER_NAME_ID">
+    <name>DEVELOPER_NAME</name>
+  </developer>
+  <summary>Some helpful and brief summary which gives crucial information</summary>
+  <url type="homepage">REPO_URL</url>
+  <url type="vcs-browser">REPO_URL</url>
+  <url type="help">REPO_URL</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+</component>
+```
+
+4. Create the flatpak manifest file named `io.github.wwmm.easyeffects.Presets.PRESET_PACKAGE_NAME.json`, this should go in your flathub repository. Replace `PRESET_PACKAGE_NAME`, `PRESET_FILE_NAME`, `REPO_NAME` (e.g. `wwmm/easyeffects` is the name for `github.com/wwmm/easyeffects`). You can add more `install` commands in `build-commands` if you want to install multiple presets. Make sure you carefully install to the correct directory for each type of preset, with the options of `input`, `output`, `irs`, and `rnnoise`. If the preset repo is not on github remove or replace the `x-checker-data` section.
+
+```json
+{
+    "id": "io.github.wwmm.easyeffects.Presets.PRESET_PACKAGE_NAME",
+    "runtime": "com.github.wwmm.easyeffects",
+    "sdk": "org.freedesktop.Sdk//23.08",
+    "branch": "stable",
+    "runtime-version": "stable",
+    "build-extension": true,
+    "separate-locales": false,
+    "modules": [
+        {
+            "name": "presets",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm644 io.github.wwmm.easyeffects.Presets.PRESET_PACKAGE_NAME.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo",
+                "install -Dm644 PRESET_FILE_NAME.json -t ${FLATPAK_DEST}/input/PRESET_PACKAGE_NAME",
+                "install -Dm644 PRESET_FILE_NAME.json -t ${FLATPAK_DEST}/output/PRESET_PACKAGE_NAME",
+                "install -Dm644 PRESET_FILE_NAME.json -t ${FLATPAK_DEST}/irs/PRESET_PACKAGE_NAME",
+                "install -Dm644 PRESET_FILE_NAME.json -t ${FLATPAK_DEST}/rnnoise/PRESET_PACKAGE_NAME"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "REPO_NAME",
+                    "commit": "LATEST_COMMIT",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/REPO_NAME/commits",
+                        "commit-query": "first( .[].sha )",
+                        "version-query": "first( .[].sha )",
+                        "timestamp-query": "first( .[].commit.committer.date )"
+                    }
+                }
+            ]
+        }
+    ]
+}
+
+```
+
+5. It is also necessary to add the following file called `flathub.json` in the flathub repo. The skip icons check is stricly necessary, since unlike a normal app we are not providing icons. We also recommended enabled a bot to automatically merge PRs with updates from the upstream repo. Given these are only preset files, this should not be a very risky thing to do and avoids manual maintenance hassle.
+
+```json
+{
+    "skip-icons-check": true,
+    "automerge-flathubbot-prs": true
+}
+
+```
+
+6. Now you can submit this to flathub via a PR, following [flathub's instructions](https://docs.flathub.org/docs/for-app-authors/submission/).
+
 
 ## Guidelines for package directories structure
 

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -97,6 +97,14 @@ PresetsManager::PresetsManager()
     system_data_dir_rnnoise.push_back(dir + "easyeffects/rnnoise");
   }
 
+  // flatpak always creates this file for apps running in the flatpak sandbox
+  if (std::filesystem::is_regular_file("/.flatpak-info")) {
+    system_data_dir_input.push_back("/app/extensions/Presets/input");
+    system_data_dir_output.push_back("/app/extensions/Presets/output");
+    system_data_dir_irs.push_back("/app/extensions/Presets/irs");
+    system_data_dir_rnnoise.push_back("/app/extensions/Presets/rnnoise");
+  }
+
   // create user presets directories
 
   create_user_directory(user_input_dir);

--- a/util/flatpak/com.github.wwmm.easyeffects.Devel.json
+++ b/util/flatpak/com.github.wwmm.easyeffects.Devel.json
@@ -3,6 +3,7 @@
     "runtime": "org.gnome.Platform",
     "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
+    "branch": "stable",
     "command": "easyeffects",
     "finish-args": [
         "--share=ipc",
@@ -26,6 +27,13 @@
         "/share/info"
     ],
     "add-extensions": {
+        "io.github.wwmm.easyeffects.Presets": {
+            "directory": "extensions/Presets",
+            "merge-dirs": "input;output;irs;rnnoise",
+            "subdirectories": true,
+            "no-autodownload": true,
+            "autodelete": true
+        },
         "org.freedesktop.LinuxAudio.Plugins": {
             "directory": "extensions/Plugins",
             "version": "23.08",
@@ -87,6 +95,7 @@
             ],
             "post-install": [
                 "install -Dm644 -t $FLATPAK_DEST/share/licenses/$FLATPAK_ID ../LICENSE",
+                "mkdir -pm755 $FLATPAK_DEST/extensions/Presets",
                 "mkdir -pm755 $FLATPAK_DEST/extensions/Plugins"
             ],
             "modules": [

--- a/util/flatpak/com.github.wwmm.easyeffects.Devel.json
+++ b/util/flatpak/com.github.wwmm.easyeffects.Devel.json
@@ -1,7 +1,7 @@
 {
     "id": "com.github.wwmm.easyeffects.Devel",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "45",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "easyeffects",
     "finish-args": [

--- a/util/flatpak/easyeffects-modules.json
+++ b/util/flatpak/easyeffects-modules.json
@@ -146,16 +146,21 @@
             "name": "rnnoise",
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/xiph/rnnoise.git",
-                    "commit": "372f7b4b76cde4ca1ec4605353dd17898a99de38",
+                    "type": "archive",
+                    "url": "https://github.com/xiph/rnnoise/releases/download/v0.2/rnnoise-0.2.tar.gz",
+                    "sha256": "90fce4b00b9ff24c08dbfe31b82ffd43bae383d85c5535676d28b0a2b11c0d37",
                     "x-checker-data": {
                         "type": "json",
-                        "url": "https://api.github.com/repos/xiph/rnnoise/commits",
-                        "commit-query": "first( .[].sha )",
-                        "version-query": "first( .[].sha )",
-                        "timestamp-query": "first( .[].commit.committer.date )"
+                        "url": "https://api.github.com/repos/xiph/rnnoise/releases/latest",
+                        "version-query": ".tag_name | sub(\"^v\"; \"\")",
+                        "url-query": ".assets[] | select(.name==\"rnnoise-\" + $version + \".tar.gz\") | .browser_download_url"
                     }
+                },
+                {
+                    "//": "downloads the file as found by this script https://github.com/xiph/rnnoise/blob/904a876dce1f9ab8860c0a5000ed151f9f6eef58/download_model.sh",
+                    "type": "archive",
+                    "url": "https://media.xiph.org/rnnoise/models/rnnoise_data-0b50c45.tar.gz",
+                    "sha256": "4ac81c5c0884ec4bd5907026aaae16209b7b76cd9d7f71af582094a2f98f4b43"
                 }
             ],
             "cleanup": [


### PR DESCRIPTION
This should be fairly complete. I also did some fixes for the flathub build being broken due to rnnoise updates.

A couple of questions:
- ~~should the `irs` and `rnnoise` subfolders also be added to the flatpak packages for forward compatibility? Right now it only checks `output` and `input`. I mostly wrote this before I realized irs and rnnoise were actively supported now, but it should be fairly trivial to add.~~ it was easy to fix so I did it anyways.
- the `com.github.wwmm.easyeffects` vs `io.github.wwmm.easyeffects` issue (see the updated docs) is a bit of a nuisance and might confuse packagers. Flathub has a fairly nice mechanism to rename packages which could do now to avoid pain later on, and then there is no ambiguity what the names of the flatpak packages are.