### PR TITLE
Add navigation box in the collapsed sidebar

### DIFF
--- a/data/ui/plugins_box.ui
+++ b/data/ui/plugins_box.ui
@@ -52,7 +52,6 @@
                     <object class="GtkBox" id="navigation_box">
                         <property name="halign">center</property>
                         <property name="valign">center</property>
-                        <property name="margin-top">6</property>
                         <property name="spacing">6</property>
                         <property name="orientation">vertical</property>
                         <child>
@@ -61,6 +60,12 @@
                                 <property name="valign">center</property>
                                 <property name="icon-name">go-up-symbolic</property>
                                 <signal name="clicked" handler="on_prev_plugin" object="PluginsBox" />
+                                <property name="tooltip-text" translatable="yes">Go to the previous effect</property>
+                                <property name="cursor">
+                                    <object class="GdkCursor">
+                                        <property name="name">pointer</property>
+                                    </object>
+                                </property>
                             </object>
                         </child>
 
@@ -70,6 +75,12 @@
                                 <property name="valign">center</property>
                                 <property name="icon-name">go-down-symbolic</property>
                                 <signal name="clicked" handler="on_next_plugin" object="PluginsBox" />
+                                <property name="tooltip-text" translatable="yes">Go to the next effect</property>
+                                <property name="cursor">
+                                    <object class="GdkCursor">
+                                        <property name="name">pointer</property>
+                                    </object>
+                                </property>
                             </object>
                         </child>
                     </object>

--- a/data/ui/plugins_box.ui
+++ b/data/ui/plugins_box.ui
@@ -12,8 +12,6 @@
                     <object class="GtkBox">
                         <property name="halign">center</property>
                         <property name="valign">center</property>
-                        <property name="margin-start">6</property>
-                        <property name="margin-end">6</property>
                         <property name="margin-top">6</property>
                         <property name="spacing">6</property>
                         <child>
@@ -24,6 +22,7 @@
                                 <property name="active">1</property>
                                 <property name="active" bind-source="menubutton_plugins" bind-property="visible" bind-flags="sync-create|bidirectional" />
                                 <property name="active" bind-source="plugins_stack_box" bind-property="visible" bind-flags="sync-create|bidirectional" />
+                                <property name="active" bind-source="navigation_box" bind-property="visible" bind-flags="sync-create|invert-boolean|bidirectional" />
                                 <property name="tooltip-text" translatable="yes">Show/hide effects list</property>
                                 <property name="cursor">
                                     <object class="GdkCursor">
@@ -44,6 +43,33 @@
                                         <property name="name">pointer</property>
                                     </object>
                                 </property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+
+                <child>
+                    <object class="GtkBox" id="navigation_box">
+                        <property name="halign">center</property>
+                        <property name="valign">center</property>
+                        <property name="margin-top">6</property>
+                        <property name="spacing">6</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                            <object class="GtkButton" id="prev_plugin">
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="icon-name">go-up-symbolic</property>
+                                <signal name="clicked" handler="on_prev_plugin" object="PluginsBox" />
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkButton" id="next_plugin">
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="icon-name">go-down-symbolic</property>
+                                <signal name="clicked" handler="on_next_plugin" object="PluginsBox" />
                             </object>
                         </child>
                     </object>

--- a/src/plugins_box.cpp
+++ b/src/plugins_box.cpp
@@ -561,6 +561,39 @@ void add_plugins_to_stack(PluginsBox* self) {
   }
 }
 
+void show_adjacent_plugin(PluginsBox* self, const int& increment) {
+  const auto plugins_list = util::gchar_array_to_vector(g_settings_get_strv(self->settings, "plugins"));
+
+  if (plugins_list.empty()) {
+    return;
+  }
+
+  std::string visible_page_name =
+      (gtk_stack_get_visible_child_name(self->stack) != nullptr) ? gtk_stack_get_visible_child_name(self->stack) : "";
+
+  if (visible_page_name.empty()) {
+    return;
+  }
+
+  auto it = std::ranges::find(plugins_list, visible_page_name);
+
+  if (it == plugins_list.end()) {
+    return;
+  }
+
+  if (auto adj_it = it + increment; adj_it >= plugins_list.begin() && adj_it < plugins_list.end()) {
+    gtk_stack_set_visible_child_name(self->stack, (*adj_it).c_str());
+  }
+}
+
+void on_prev_plugin(PluginsBox* self, GtkButton* button) {
+  show_adjacent_plugin(self, -1);
+}
+
+void on_next_plugin(PluginsBox* self, GtkButton* button) {
+  show_adjacent_plugin(self, 1);
+}
+
 void setup_listview(PluginsBox* self) {
   auto* factory = gtk_signal_list_item_factory_new();
 
@@ -906,6 +939,9 @@ void plugins_box_class_init(PluginsBoxClass* klass) {
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, endpoint_box);
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, endpoint_icon);
   gtk_widget_class_bind_template_child(widget_class, PluginsBox, endpoint_name);
+
+  gtk_widget_class_bind_template_callback(widget_class, on_prev_plugin);
+  gtk_widget_class_bind_template_callback(widget_class, on_next_plugin);
 }
 
 void plugins_box_init(PluginsBox* self) {

--- a/src/plugins_box.cpp
+++ b/src/plugins_box.cpp
@@ -170,7 +170,7 @@ void add_plugins_to_stack(PluginsBox* self) {
 
   // saving the current visible page name for later usage
 
-  std::string visible_page_name =
+  const std::string visible_page_name =
       (gtk_stack_get_visible_child_name(self->stack) != nullptr) ? gtk_stack_get_visible_child_name(self->stack) : "";
 
   // removing all plugins
@@ -568,7 +568,7 @@ void show_adjacent_plugin(PluginsBox* self, const int& increment) {
     return;
   }
 
-  std::string visible_page_name =
+  const std::string visible_page_name =
       (gtk_stack_get_visible_child_name(self->stack) != nullptr) ? gtk_stack_get_visible_child_name(self->stack) : "";
 
   if (visible_page_name.empty()) {


### PR DESCRIPTION
We added the ability to reduce the sidebar hiding the plugins list, but at the moment this feature is somewhat limited because it forces the user to reenable the plugins list to show other effects in the pipeline.

Considering that collapsing the sidebar is useful only if the user has few plugins, maybe they want the ability to move between them easily without having the plugins list always visible. So I added a navigation box to move up and down through the pipeline, only visible when the sidebar is collapsed.

This widget does not affect the existing configurations since it's disabled by default, just like the collapsed sidebar.  