### PR TITLE
Add flatpak extension path also for Convolver and RNNoise

### DIFF
--- a/include/convolver.hpp
+++ b/include/convolver.hpp
@@ -58,8 +58,8 @@ class Convolver : public PluginBase {
   auto search_irs_path(const std::string& name) -> std::string;
 
  private:
-  std::string local_irs_dir;
-  std::vector<std::string> system_data_irs_dir;
+  std::string local_dir_irs;
+  std::vector<std::string> system_data_dir_irs;
 
   bool kernel_is_initialized = false;
   bool n_samples_is_power_of_2 = true;

--- a/include/rnnoise.hpp
+++ b/include/rnnoise.hpp
@@ -70,8 +70,8 @@ class RNNoise : public PluginBase {
   sigc::signal<void(const bool load_error)> model_changed;
 
  private:
-  std::string local_model_dir;
-  std::vector<std::string> system_data_model_dir;
+  std::string local_dir_rnnoise;
+  std::vector<std::string> system_data_dir_rnnoise;
 
   bool resample = false;
   bool notify_latency = false;

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -82,11 +82,17 @@ PresetsManager::PresetsManager()
       settings(g_settings_new(tags::app::id)),
       soe_settings(g_settings_new(tags::schema::id_output)),
       sie_settings(g_settings_new(tags::schema::id_input)) {
-  // initialize input and output directories for community presets
+  // Initialize input and output directories for community presets.
+  // Flatpak specific path (.flatpak-info always present for apps running in the flatpak sandbox).
+  if (std::filesystem::is_regular_file("/.flatpak-info")) {
+    system_data_dir_input.push_back("/app/extensions/Presets/input");
+    system_data_dir_output.push_back("/app/extensions/Presets/output");
+    system_data_dir_irs.push_back("/app/extensions/Presets/irs");
+    system_data_dir_rnnoise.push_back("/app/extensions/Presets/rnnoise");
+  }
 
-  const gchar* const* xdg_data_dirs = g_get_system_data_dirs();
-
-  while (*xdg_data_dirs != nullptr) {
+  // Regular paths.
+  for (const gchar* const* xdg_data_dirs = g_get_system_data_dirs(); *xdg_data_dirs != nullptr;) {
     std::string dir = *xdg_data_dirs++;
 
     dir += dir.ends_with("/") ? "" : "/";
@@ -95,14 +101,6 @@ PresetsManager::PresetsManager()
     system_data_dir_output.push_back(dir + "easyeffects/output");
     system_data_dir_irs.push_back(dir + "easyeffects/irs");
     system_data_dir_rnnoise.push_back(dir + "easyeffects/rnnoise");
-  }
-
-  // flatpak always creates this file for apps running in the flatpak sandbox
-  if (std::filesystem::is_regular_file("/.flatpak-info")) {
-    system_data_dir_input.push_back("/app/extensions/Presets/input");
-    system_data_dir_output.push_back("/app/extensions/Presets/output");
-    system_data_dir_irs.push_back("/app/extensions/Presets/irs");
-    system_data_dir_rnnoise.push_back("/app/extensions/Presets/rnnoise");
   }
 
   // create user presets directories

--- a/util/NEWS.yaml
+++ b/util/NEWS.yaml
@@ -5,6 +5,7 @@ Date: UNRELEASED_DATE
 Description:
 - Features∶
 - Community Presets have been implemented. Users can install packages containing multiple Easy Effects presets to be imported and applied inside the application. These packages will be maintained and shipped by volunteers. You can search them on Flathub or the repositories of your favorite distribution.
+- Added the ability of collapsing the sidebar to hide the effects list and expand the area of the effects user interface.
 
 - Bug fixes∶
 - A change in GTK 4.14.1 prevented to apply the values inserted into the text field of our SpinButton widgets. This issue is now resolved.


### PR DESCRIPTION
@vchernin This is related to [this issue](https://github.com/wwmm/easyeffects/issues/2445#issuecomment-2071074699).

Please test it.

I wonder if it's better to use `/app/extensions/easyeffects-presets`. Maybe `Presets` is too generic? Could `/app/extensions` path be used also by other Flatpak apps?