### PR TITLE
Optimize search file util

### DIFF
--- a/include/presets_manager.hpp
+++ b/include/presets_manager.hpp
@@ -79,7 +79,7 @@ class PresetsManager {
 
   auto load_local_preset_file(const PresetType& preset_type, const std::string& name) -> bool;
 
-  auto load_community_preset_file(const PresetType& preset_type, const std::string& full_path) -> bool;
+  auto load_community_preset_file(const PresetType& preset_type, const std::string& full_path_stem) -> bool;
 
   auto read_effects_pipeline_from_preset(const PresetType& preset_type,
                                          const std::filesystem::path& input_file,

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -369,7 +369,7 @@ auto import_apo_preset(EqualizerBox* self, const std::string& file_path) -> bool
   double preamp = 0.0;
 
   if (const auto re = std::regex(R"(^[ \t]*#)"); eq_file.is_open()) {
-    for (std::string line; getline(eq_file, line);) {
+    for (std::string line; std::getline(eq_file, line);) {
       if (std::regex_search(line, re)) {  // Avoid commented lines
         continue;
       }
@@ -666,7 +666,7 @@ auto import_graphiceq_preset(EqualizerBox* self, const std::string& file_path) -
   std::vector<struct GraphicEQ_Band> bands;
 
   if (const auto re = std::regex(R"(^[ \t]*#)"); eq_file.is_open()) {
-    for (std::string line; getline(eq_file, line);) {
+    for (std::string line; std::getline(eq_file, line);) {
       if (std::regex_search(line, re)) {  // Avoid commented lines
         continue;
       }

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -620,12 +620,13 @@ auto PresetsManager::load_local_preset_file(const PresetType& preset_type, const
   return false;
 }
 
-auto PresetsManager::load_community_preset_file(const PresetType& preset_type, const std::string& full_path) -> bool {
-  const auto input_file = std::filesystem::path{full_path + json_ext};
+auto PresetsManager::load_community_preset_file(const PresetType& preset_type, const std::string& full_path_stem)
+    -> bool {
+  const auto input_file = std::filesystem::path{full_path_stem + json_ext};
 
   // Check preset existence
   if (!std::filesystem::exists(input_file)) {
-    util::warning("the community preset \"" + full_path + "\" does not exist on the filesystem");
+    util::warning("the community preset \"" + input_file.string() + "\" does not exist on the filesystem");
 
     return false;
   }


### PR DESCRIPTION
`search_filename` util was derived from `scan_community_package_recursive` which loops over every file to build the listview. But in order to search only a filename, this is not really necessary since we can just check the existence in the directory (and its subfolders).