### PR TITLE
Improve community presets management

### DIFF
--- a/data/schemas/com.github.wwmm.easyeffects.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.gschema.xml
@@ -10,11 +10,17 @@
         <key name="use-dark-theme" type="b">
             <default>false</default>
         </key>
-        <key name="last-used-input-preset" type="s">
-            <default l10n="messages">"Presets"</default>
+        <key name="last-loaded-input-preset" type="s">
+            <default>""</default>
         </key>
-        <key name="last-used-output-preset" type="s">
-            <default l10n="messages">"Presets"</default>
+        <key name="last-loaded-output-preset" type="s">
+            <default>""</default>
+        </key>
+        <key name="last-loaded-input-community-package" type="s">
+            <default>""</default>
+        </key>
+        <key name="last-loaded-output-community-package" type="s">
+            <default>""</default>
         </key>
         <key name="window-maximized" type="b">
             <default>false</default>

--- a/data/ui/plugins_box.ui
+++ b/data/ui/plugins_box.ui
@@ -13,6 +13,8 @@
                         <property name="halign">center</property>
                         <property name="valign">center</property>
                         <property name="margin-top">6</property>
+                        <property name="margin-start">12</property>
+                        <property name="margin-end">12</property>
                         <property name="spacing">6</property>
                         <child>
                             <object class="GtkToggleButton" id="toggle_plugins_list">

--- a/data/ui/presets_menu.ui
+++ b/data/ui/presets_menu.ui
@@ -154,12 +154,30 @@
                                         </child>
 
                                         <child>
-                                            <object class="GtkLabel" id="last_used_name">
+                                            <object class="GtkBox">
                                                 <property name="halign">center</property>
-                                                <property name="valign">end</property>
-                                                <style>
-                                                    <class name="dim-label" />
-                                                </style>
+                                                <property name="valign">center</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="spacing">6</property>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="last_loaded_preset_title">
+                                                        <property name="halign">center</property>
+                                                        <property name="valign">center</property>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="GtkLabel" id="last_loaded_preset_value">
+                                                        <property name="halign">center</property>
+                                                        <property name="valign">center</property>
+                                                        <property name="wrap">1</property>
+                                                        <property name="wrap-mode">word</property>
+                                                        <style>
+                                                            <class name="dim-label" />
+                                                        </style>
+                                                    </object>
+                                                </child>
                                             </object>
                                         </child>
                                     </object>

--- a/include/autogain.hpp
+++ b/include/autogain.hpp
@@ -34,7 +34,8 @@ class AutoGain : public PluginBase {
   AutoGain(const std::string& tag,
            const std::string& schema,
            const std::string& schema_path,
-           PipeManager* pipe_manager);
+           PipeManager* pipe_manager,
+           PipelineType pipe_type);
   AutoGain(const AutoGain&) = delete;
   auto operator=(const AutoGain&) -> AutoGain& = delete;
   AutoGain(const AutoGain&&) = delete;

--- a/include/bass_enhancer.hpp
+++ b/include/bass_enhancer.hpp
@@ -30,7 +30,8 @@ class BassEnhancer : public PluginBase {
   BassEnhancer(const std::string& tag,
                const std::string& schema,
                const std::string& schema_path,
-               PipeManager* pipe_manager);
+               PipeManager* pipe_manager,
+               PipelineType pipe_type);
   BassEnhancer(const BassEnhancer&) = delete;
   auto operator=(const BassEnhancer&) -> BassEnhancer& = delete;
   BassEnhancer(const BassEnhancer&&) = delete;

--- a/include/bass_loudness.hpp
+++ b/include/bass_loudness.hpp
@@ -29,7 +29,8 @@ class BassLoudness : public PluginBase {
   BassLoudness(const std::string& tag,
                const std::string& schema,
                const std::string& schema_path,
-               PipeManager* pipe_manager);
+               PipeManager* pipe_manager,
+               PipelineType pipe_type);
   BassLoudness(const BassLoudness&) = delete;
   auto operator=(const BassLoudness&) -> BassLoudness& = delete;
   BassLoudness(const BassLoudness&&) = delete;

--- a/include/compressor.hpp
+++ b/include/compressor.hpp
@@ -33,7 +33,8 @@ class Compressor : public PluginBase {
   Compressor(const std::string& tag,
              const std::string& schema,
              const std::string& schema_path,
-             PipeManager* pipe_manager);
+             PipeManager* pipe_manager,
+             PipelineType pipe_type);
   Compressor(const Compressor&) = delete;
   auto operator=(const Compressor&) -> Compressor& = delete;
   Compressor(const Compressor&&) = delete;

--- a/include/convolver.hpp
+++ b/include/convolver.hpp
@@ -35,7 +35,8 @@ class Convolver : public PluginBase {
   Convolver(const std::string& tag,
             const std::string& schema,
             const std::string& schema_path,
-            PipeManager* pipe_manager);
+            PipeManager* pipe_manager,
+            PipelineType pipe_type);
   Convolver(const Convolver&) = delete;
   auto operator=(const Convolver&) -> Convolver& = delete;
   Convolver(const Convolver&&) = delete;

--- a/include/convolver_menu_impulses.hpp
+++ b/include/convolver_menu_impulses.hpp
@@ -39,7 +39,10 @@ G_END_DECLS
 
 auto create() -> ConvolverMenuImpulses*;
 
-void setup(ConvolverMenuImpulses* self, const std::string& schema_path, app::Application* application);
+void setup(ConvolverMenuImpulses* self,
+           const std::string& schema_path,
+           app::Application* application,
+           std::shared_ptr<Convolver> convolver);
 
 void append_to_string_list(ConvolverMenuImpulses* self, const std::string& irs_filename);
 

--- a/include/crossfeed.hpp
+++ b/include/crossfeed.hpp
@@ -31,7 +31,8 @@ class Crossfeed : public PluginBase {
   Crossfeed(const std::string& tag,
             const std::string& schema,
             const std::string& schema_path,
-            PipeManager* pipe_manager);
+            PipeManager* pipe_manager,
+            PipelineType pipe_type);
   Crossfeed(const Crossfeed&) = delete;
   auto operator=(const Crossfeed&) -> Crossfeed& = delete;
   Crossfeed(const Crossfeed&&) = delete;

--- a/include/crystalizer.hpp
+++ b/include/crystalizer.hpp
@@ -36,7 +36,8 @@ class Crystalizer : public PluginBase {
   Crystalizer(const std::string& tag,
               const std::string& schema,
               const std::string& schema_path,
-              PipeManager* pipe_manager);
+              PipeManager* pipe_manager,
+              PipelineType pipe_type);
   Crystalizer(const Crystalizer&) = delete;
   auto operator=(const Crystalizer&) -> Crystalizer& = delete;
   Crystalizer(const Crystalizer&&) = delete;

--- a/include/deepfilternet.hpp
+++ b/include/deepfilternet.hpp
@@ -33,7 +33,8 @@ class DeepFilterNet : public PluginBase {
   DeepFilterNet(const std::string& tag,
                 const std::string& schema,
                 const std::string& schema_path,
-                PipeManager* pipe_manager);
+                PipeManager* pipe_manager,
+                PipelineType pipe_type);
   DeepFilterNet(const DeepFilterNet&) = delete;
   auto operator=(const DeepFilterNet&) -> DeepFilterNet& = delete;
   DeepFilterNet(const DeepFilterNet&&) = delete;

--- a/include/deesser.hpp
+++ b/include/deesser.hpp
@@ -27,7 +27,11 @@
 
 class Deesser : public PluginBase {
  public:
-  Deesser(const std::string& tag, const std::string& schema, const std::string& schema_path, PipeManager* pipe_manager);
+  Deesser(const std::string& tag,
+          const std::string& schema,
+          const std::string& schema_path,
+          PipeManager* pipe_manager,
+          PipelineType pipe_type);
   Deesser(const Deesser&) = delete;
   auto operator=(const Deesser&) -> Deesser& = delete;
   Deesser(const Deesser&&) = delete;

--- a/include/delay.hpp
+++ b/include/delay.hpp
@@ -27,7 +27,11 @@
 
 class Delay : public PluginBase {
  public:
-  Delay(const std::string& tag, const std::string& schema, const std::string& schema_path, PipeManager* pipe_manager);
+  Delay(const std::string& tag,
+        const std::string& schema,
+        const std::string& schema_path,
+        PipeManager* pipe_manager,
+        PipelineType pipe_type);
   Delay(const Delay&) = delete;
   auto operator=(const Delay&) -> Delay& = delete;
   Delay(const Delay&&) = delete;

--- a/include/echo_canceller.hpp
+++ b/include/echo_canceller.hpp
@@ -36,7 +36,8 @@ class EchoCanceller : public PluginBase {
   EchoCanceller(const std::string& tag,
                 const std::string& schema,
                 const std::string& schema_path,
-                PipeManager* pipe_manager);
+                PipeManager* pipe_manager,
+                PipelineType pipe_type);
   EchoCanceller(const EchoCanceller&) = delete;
   auto operator=(const EchoCanceller&) -> EchoCanceller& = delete;
   EchoCanceller(const EchoCanceller&&) = delete;

--- a/include/effects_base.hpp
+++ b/include/effects_base.hpp
@@ -61,7 +61,7 @@
 
 class EffectsBase {
  public:
-  EffectsBase(std::string tag, const std::string& schema, PipeManager* pipe_manager);
+  EffectsBase(std::string tag, const std::string& schema, PipeManager* pipe_manager, PipelineType pipe_type);
   EffectsBase(const EffectsBase&) = delete;
   auto operator=(const EffectsBase&) -> EffectsBase& = delete;
   EffectsBase(const EffectsBase&&) = delete;
@@ -71,6 +71,8 @@ class EffectsBase {
   const std::string log_tag;
 
   PipeManager* pm = nullptr;
+
+  PipelineType pipeline_type;
 
   std::shared_ptr<OutputLevel> output_level;
   std::shared_ptr<Spectrum> spectrum;

--- a/include/equalizer.hpp
+++ b/include/equalizer.hpp
@@ -39,7 +39,8 @@ class Equalizer : public PluginBase {
             const std::string& schema_channel,
             const std::string& schema_channel_left_path,
             const std::string& schema_channel_right_path,
-            PipeManager* pipe_manager);
+            PipeManager* pipe_manager,
+            PipelineType pipe_type);
   Equalizer(const Equalizer&) = delete;
   auto operator=(const Equalizer&) -> Equalizer& = delete;
   Equalizer(const Equalizer&&) = delete;

--- a/include/exciter.hpp
+++ b/include/exciter.hpp
@@ -27,7 +27,11 @@
 
 class Exciter : public PluginBase {
  public:
-  Exciter(const std::string& tag, const std::string& schema, const std::string& schema_path, PipeManager* pipe_manager);
+  Exciter(const std::string& tag,
+          const std::string& schema,
+          const std::string& schema_path,
+          PipeManager* pipe_manager,
+          PipelineType pipe_type);
   Exciter(const Exciter&) = delete;
   auto operator=(const Exciter&) -> Exciter& = delete;
   Exciter(const Exciter&&) = delete;

--- a/include/expander.hpp
+++ b/include/expander.hpp
@@ -33,7 +33,8 @@ class Expander : public PluginBase {
   Expander(const std::string& tag,
            const std::string& schema,
            const std::string& schema_path,
-           PipeManager* pipe_manager);
+           PipeManager* pipe_manager,
+           PipelineType pipe_type);
   Expander(const Expander&) = delete;
   auto operator=(const Expander&) -> Expander& = delete;
   Expander(const Expander&&) = delete;

--- a/include/filter.hpp
+++ b/include/filter.hpp
@@ -26,7 +26,11 @@
 
 class Filter : public PluginBase {
  public:
-  Filter(const std::string& tag, const std::string& schema, const std::string& schema_path, PipeManager* pipe_manager);
+  Filter(const std::string& tag,
+         const std::string& schema,
+         const std::string& schema_path,
+         PipeManager* pipe_manager,
+         PipelineType pipe_type);
   Filter(const Filter&) = delete;
   auto operator=(const Filter&) -> Filter& = delete;
   Filter(const Filter&&) = delete;

--- a/include/gate.hpp
+++ b/include/gate.hpp
@@ -30,7 +30,11 @@
 
 class Gate : public PluginBase {
  public:
-  Gate(const std::string& tag, const std::string& schema, const std::string& schema_path, PipeManager* pipe_manager);
+  Gate(const std::string& tag,
+       const std::string& schema,
+       const std::string& schema_path,
+       PipeManager* pipe_manager,
+       PipelineType pipe_type);
   Gate(const Gate&) = delete;
   auto operator=(const Gate&) -> Gate& = delete;
   Gate(const Gate&&) = delete;

--- a/include/level_meter.hpp
+++ b/include/level_meter.hpp
@@ -34,7 +34,8 @@ class LevelMeter : public PluginBase {
   LevelMeter(const std::string& tag,
              const std::string& schema,
              const std::string& schema_path,
-             PipeManager* pipe_manager);
+             PipeManager* pipe_manager,
+             PipelineType pipe_type);
   LevelMeter(const LevelMeter&) = delete;
   auto operator=(const LevelMeter&) -> LevelMeter& = delete;
   LevelMeter(const LevelMeter&&) = delete;

--- a/include/limiter.hpp
+++ b/include/limiter.hpp
@@ -30,7 +30,11 @@
 
 class Limiter : public PluginBase {
  public:
-  Limiter(const std::string& tag, const std::string& schema, const std::string& schema_path, PipeManager* pipe_manager);
+  Limiter(const std::string& tag,
+          const std::string& schema,
+          const std::string& schema_path,
+          PipeManager* pipe_manager,
+          PipelineType pipe_type);
   Limiter(const Limiter&) = delete;
   auto operator=(const Limiter&) -> Limiter& = delete;
   Limiter(const Limiter&&) = delete;

--- a/include/loudness.hpp
+++ b/include/loudness.hpp
@@ -30,7 +30,8 @@ class Loudness : public PluginBase {
   Loudness(const std::string& tag,
            const std::string& schema,
            const std::string& schema_path,
-           PipeManager* pipe_manager);
+           PipeManager* pipe_manager,
+           PipelineType pipe_type);
   Loudness(const Loudness&) = delete;
   auto operator=(const Loudness&) -> Loudness& = delete;
   Loudness(const Loudness&&) = delete;

--- a/include/maximizer.hpp
+++ b/include/maximizer.hpp
@@ -31,7 +31,8 @@ class Maximizer : public PluginBase {
   Maximizer(const std::string& tag,
             const std::string& schema,
             const std::string& schema_path,
-            PipeManager* pipe_manager);
+            PipeManager* pipe_manager,
+            PipelineType pipe_type);
   Maximizer(const Maximizer&) = delete;
   auto operator=(const Maximizer&) -> Maximizer& = delete;
   Maximizer(const Maximizer&&) = delete;

--- a/include/multiband_compressor.hpp
+++ b/include/multiband_compressor.hpp
@@ -40,7 +40,8 @@ class MultibandCompressor : public PluginBase {
   MultibandCompressor(const std::string& tag,
                       const std::string& schema,
                       const std::string& schema_path,
-                      PipeManager* pipe_manager);
+                      PipeManager* pipe_manager,
+                      PipelineType pipe_type);
   MultibandCompressor(const MultibandCompressor&) = delete;
   auto operator=(const MultibandCompressor&) -> MultibandCompressor& = delete;
   MultibandCompressor(const MultibandCompressor&&) = delete;

--- a/include/multiband_gate.hpp
+++ b/include/multiband_gate.hpp
@@ -40,7 +40,8 @@ class MultibandGate : public PluginBase {
   MultibandGate(const std::string& tag,
                 const std::string& schema,
                 const std::string& schema_path,
-                PipeManager* pipe_manager);
+                PipeManager* pipe_manager,
+                PipelineType pipe_type);
   MultibandGate(const MultibandGate&) = delete;
   auto operator=(const MultibandGate&) -> MultibandGate& = delete;
   MultibandGate(const MultibandGate&&) = delete;

--- a/include/output_level.hpp
+++ b/include/output_level.hpp
@@ -29,7 +29,8 @@ class OutputLevel : public PluginBase {
   OutputLevel(const std::string& tag,
               const std::string& schema,
               const std::string& schema_path,
-              PipeManager* pipe_manager);
+              PipeManager* pipe_manager,
+              PipelineType pipe_type);
   OutputLevel(const OutputLevel&) = delete;
   auto operator=(const OutputLevel&) -> OutputLevel& = delete;
   OutputLevel(const OutputLevel&&) = delete;

--- a/include/pitch.hpp
+++ b/include/pitch.hpp
@@ -30,7 +30,11 @@
 
 class Pitch : public PluginBase {
  public:
-  Pitch(const std::string& tag, const std::string& schema, const std::string& schema_path, PipeManager* pipe_manager);
+  Pitch(const std::string& tag,
+        const std::string& schema,
+        const std::string& schema_path,
+        PipeManager* pipe_manager,
+        PipelineType pipe_type);
   Pitch(const Pitch&) = delete;
   auto operator=(const Pitch&) -> Pitch& = delete;
   Pitch(const Pitch&&) = delete;

--- a/include/plugin_base.hpp
+++ b/include/plugin_base.hpp
@@ -33,6 +33,7 @@
 #include <vector>
 #include "lv2_wrapper.hpp"
 #include "pipe_manager.hpp"
+#include "pipeline_type.hpp"
 #include "util.hpp"
 
 class PluginBase {
@@ -43,6 +44,7 @@ class PluginBase {
              const std::string& schema,
              const std::string& schema_path,
              PipeManager* pipe_manager,
+             PipelineType pipe_type,
              const bool& enable_probe = false);
   PluginBase(const PluginBase&) = delete;
   auto operator=(const PluginBase&) -> PluginBase& = delete;
@@ -72,6 +74,8 @@ class PluginBase {
   const std::string log_tag;
 
   std::string name, package;
+
+  PipelineType pipeline_type{};
 
   pw_filter* filter = nullptr;
 
@@ -146,7 +150,7 @@ class PluginBase {
  protected:
   std::mutex data_mutex;
 
-  GSettings* settings = nullptr;
+  GSettings *settings = nullptr, *global_settings = nullptr;
 
   PipeManager* pm = nullptr;
 

--- a/include/presets_manager.hpp
+++ b/include/presets_manager.hpp
@@ -79,7 +79,9 @@ class PresetsManager {
 
   auto load_local_preset_file(const PresetType& preset_type, const std::string& name) -> bool;
 
-  auto load_community_preset_file(const PresetType& preset_type, const std::string& full_path_stem) -> bool;
+  auto load_community_preset_file(const PresetType& preset_type,
+                                  const std::string& full_path_stem,
+                                  const std::string& package_name) -> bool;
 
   auto read_effects_pipeline_from_preset(const PresetType& preset_type,
                                          const std::filesystem::path& input_file,
@@ -92,7 +94,9 @@ class PresetsManager {
 
   void import_from_filesystem(const PresetType& preset_type, const std::string& file_path);
 
-  void import_from_community_package(const PresetType& preset_type, const std::string& file_path);
+  void import_from_community_package(const PresetType& preset_type,
+                                     const std::string& file_path,
+                                     const std::string& package);
 
   void add_autoload(const PresetType& preset_type,
                     const std::string& preset_name,
@@ -138,7 +142,13 @@ class PresetsManager {
 
   static void create_user_directory(const std::filesystem::path& path);
 
-  auto import_addons_from_community_package(const PresetType& preset_type, const std::filesystem::path& path) -> bool;
+  auto import_addons_from_community_package(const PresetType& preset_type,
+                                            const std::filesystem::path& path,
+                                            const std::string& package) -> bool;
+
+  void set_last_preset_keys(const PresetType& preset_type,
+                            const std::string& preset_name = "",
+                            const std::string& package_name = "");
 
   auto load_preset_file(const PresetType& preset_type, const std::filesystem::path& input_file) -> bool;
 

--- a/include/reverb.hpp
+++ b/include/reverb.hpp
@@ -26,7 +26,11 @@
 
 class Reverb : public PluginBase {
  public:
-  Reverb(const std::string& tag, const std::string& schema, const std::string& schema_path, PipeManager* pipe_manager);
+  Reverb(const std::string& tag,
+         const std::string& schema,
+         const std::string& schema_path,
+         PipeManager* pipe_manager,
+         PipelineType pipe_type);
   Reverb(const Reverb&) = delete;
   auto operator=(const Reverb&) -> Reverb& = delete;
   Reverb(const Reverb&&) = delete;

--- a/include/rnnoise.hpp
+++ b/include/rnnoise.hpp
@@ -39,7 +39,11 @@
 
 class RNNoise : public PluginBase {
  public:
-  RNNoise(const std::string& tag, const std::string& schema, const std::string& schema_path, PipeManager* pipe_manager);
+  RNNoise(const std::string& tag,
+          const std::string& schema,
+          const std::string& schema_path,
+          PipeManager* pipe_manager,
+          PipelineType pipe_type);
   RNNoise(const RNNoise&) = delete;
   auto operator=(const RNNoise&) -> RNNoise& = delete;
   RNNoise(const RNNoise&&) = delete;

--- a/include/spectrum.hpp
+++ b/include/spectrum.hpp
@@ -34,7 +34,8 @@ class Spectrum : public PluginBase {
   Spectrum(const std::string& tag,
            const std::string& schema,
            const std::string& schema_path,
-           PipeManager* pipe_manager);
+           PipeManager* pipe_manager,
+           PipelineType pipe_type);
   Spectrum(const Spectrum&) = delete;
   auto operator=(const Spectrum&) -> Spectrum& = delete;
   Spectrum(const Spectrum&&) = delete;

--- a/include/speex.hpp
+++ b/include/speex.hpp
@@ -31,7 +31,11 @@
 
 class Speex : public PluginBase {
  public:
-  Speex(const std::string& tag, const std::string& schema, const std::string& schema_path, PipeManager* pipe_manager);
+  Speex(const std::string& tag,
+        const std::string& schema,
+        const std::string& schema_path,
+        PipeManager* pipe_manager,
+        PipelineType pipe_type);
   Speex(const Speex&) = delete;
   auto operator=(const Speex&) -> Speex& = delete;
   Speex(const Speex&&) = delete;

--- a/include/stereo_tools.hpp
+++ b/include/stereo_tools.hpp
@@ -29,7 +29,8 @@ class StereoTools : public PluginBase {
   StereoTools(const std::string& tag,
               const std::string& schema,
               const std::string& schema_path,
-              PipeManager* pipe_manager);
+              PipeManager* pipe_manager,
+              PipelineType pipe_type);
   StereoTools(const StereoTools&) = delete;
   auto operator=(const StereoTools&) -> StereoTools& = delete;
   StereoTools(const StereoTools&&) = delete;

--- a/include/stream_input_effects.hpp
+++ b/include/stream_input_effects.hpp
@@ -25,7 +25,7 @@
 
 class StreamInputEffects : public EffectsBase {
  public:
-  StreamInputEffects(PipeManager* pipe_manager);
+  StreamInputEffects(PipeManager* pipe_manager, PipelineType pipeline_type);
   StreamInputEffects(const StreamInputEffects&) = delete;
   auto operator=(const StreamInputEffects&) -> StreamInputEffects& = delete;
   StreamInputEffects(const StreamInputEffects&&) = delete;

--- a/include/stream_output_effects.hpp
+++ b/include/stream_output_effects.hpp
@@ -25,7 +25,7 @@
 
 class StreamOutputEffects : public EffectsBase {
  public:
-  StreamOutputEffects(PipeManager* pipe_manager);
+  StreamOutputEffects(PipeManager* pipe_manager, PipelineType pipeline_type);
   StreamOutputEffects(const StreamOutputEffects&) = delete;
   auto operator=(const StreamOutputEffects&) -> StreamOutputEffects& = delete;
   StreamOutputEffects(const StreamOutputEffects&&) = delete;

--- a/include/ui_helpers.hpp
+++ b/include/ui_helpers.hpp
@@ -213,7 +213,9 @@ void gsettings_bind_enum_to_combo_widget(GSettings* settings,
 
         g_settings_set_enum(d->settings, d->key, static_cast<gint>(g_value_get_uint(value)));
 
-        return g_variant_new_string(g_settings_get_string(d->settings, d->key));
+        const auto str_value = util::gsettings_get_string(d->settings, d->key);
+
+        return g_variant_new_string(str_value.c_str());
       },
       new Data({.settings = settings, .key = key}),
       +[](gpointer user_data) {

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -87,8 +87,8 @@ void on_startup(GApplication* gapp) {
   self->soe_settings = g_settings_new(tags::schema::id_output);
 
   self->pm = new PipeManager();
-  self->soe = new StreamOutputEffects(self->pm);
-  self->sie = new StreamInputEffects(self->pm);
+  self->soe = new StreamOutputEffects(self->pm, PipelineType::output);
+  self->sie = new StreamInputEffects(self->pm, PipelineType::input);
 
   if (self->settings == nullptr) {
     self->settings = g_settings_new(tags::app::id);
@@ -337,21 +337,13 @@ void application_class_init(ApplicationClass* klass) {
 
       if (g_variant_dict_lookup(options, "load-preset", "&s", &name) != 0) {
         if (self->presets_manager->preset_file_exists(PresetType::input, name)) {
-          if (self->presets_manager->load_local_preset_file(PresetType::input, name)) {
-            g_settings_set_string(self->settings, "last-used-input-preset", name);
-          } else {
-            g_settings_reset(self->settings, "last-used-input-preset");
-          }
+          self->presets_manager->load_local_preset_file(PresetType::input, name);
 
           return EXIT_SUCCESS;
         }
 
         if (self->presets_manager->preset_file_exists(PresetType::output, name)) {
-          if (self->presets_manager->load_local_preset_file(PresetType::output, name)) {
-            g_settings_set_string(self->settings, "last-used-output-preset", name);
-          } else {
-            g_settings_reset(self->settings, "last-used-output-preset");
-          }
+          self->presets_manager->load_local_preset_file(PresetType::output, name);
 
           return EXIT_SUCCESS;
         }

--- a/src/autogain.cpp
+++ b/src/autogain.cpp
@@ -37,8 +37,15 @@
 AutoGain::AutoGain(const std::string& tag,
                    const std::string& schema,
                    const std::string& schema_path,
-                   PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::autogain, tags::plugin_package::ebur128, schema, schema_path, pipe_manager),
+                   PipeManager* pipe_manager,
+                   PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::autogain,
+                 tags::plugin_package::ebur128,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type),
       target(g_settings_get_double(settings, "target")),
       silence_threshold(g_settings_get_double(settings, "silence-threshold")) {
   reference = parse_reference_key(util::gsettings_get_string(settings, "reference"));

--- a/src/bass_enhancer.cpp
+++ b/src/bass_enhancer.cpp
@@ -31,8 +31,15 @@
 BassEnhancer::BassEnhancer(const std::string& tag,
                            const std::string& schema,
                            const std::string& schema_path,
-                           PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::bass_enhancer, tags::plugin_package::calf, schema, schema_path, pipe_manager) {
+                           PipeManager* pipe_manager,
+                           PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::bass_enhancer,
+                 tags::plugin_package::calf,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://calf.sourceforge.net/plugins/BassEnhancer");
 
   package_installed = lv2_wrapper->found_plugin;

--- a/src/bass_loudness.cpp
+++ b/src/bass_loudness.cpp
@@ -31,8 +31,15 @@
 BassLoudness::BassLoudness(const std::string& tag,
                            const std::string& schema,
                            const std::string& schema_path,
-                           PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::bass_loudness, tags::plugin_package::mda, schema, schema_path, pipe_manager) {
+                           PipeManager* pipe_manager,
+                           PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::bass_loudness,
+                 tags::plugin_package::mda,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://drobilla.net/plugins/mda/Loudness");
 
   package_installed = lv2_wrapper->found_plugin;

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -36,13 +36,15 @@
 Compressor::Compressor(const std::string& tag,
                        const std::string& schema,
                        const std::string& schema_path,
-                       PipeManager* pipe_manager)
+                       PipeManager* pipe_manager,
+                       PipelineType pipe_type)
     : PluginBase(tag,
                  tags::plugin_name::compressor,
                  tags::plugin_package::lsp,
                  schema,
                  schema_path,
                  pipe_manager,
+                 pipe_type,
                  true) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/sc_compressor_stereo");
 

--- a/src/convolver_preset.cpp
+++ b/src/convolver_preset.cpp
@@ -78,7 +78,7 @@ void ConvolverPreset::load(const nlohmann::json& json) {
     }
   }
 
-  auto* current_kernel_name = g_settings_get_string(settings, kernel_name_key);
+  const auto current_kernel_name = util::gsettings_get_string(settings, kernel_name_key);
 
   if (new_kernel_name != current_kernel_name) {
     g_settings_set_string(settings, kernel_name_key, new_kernel_name.c_str());

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -516,7 +516,7 @@ void setup(ConvolverBox* self,
 
   convolver->set_post_messages(true);
 
-  ui::convolver_menu_impulses::setup(self->impulses_menu, schema_path, application);
+  ui::convolver_menu_impulses::setup(self->impulses_menu, schema_path, application, convolver);
 
   self->data->connections.push_back(convolver->input_level.connect([=](const float left, const float right) {
     util::idle_add([=]() {

--- a/src/crossfeed.cpp
+++ b/src/crossfeed.cpp
@@ -34,8 +34,15 @@
 Crossfeed::Crossfeed(const std::string& tag,
                      const std::string& schema,
                      const std::string& schema_path,
-                     PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::crossfeed, tags::plugin_package::bs2b, schema, schema_path, pipe_manager) {
+                     PipeManager* pipe_manager,
+                     PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::crossfeed,
+                 tags::plugin_package::bs2b,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type) {
   bs2b.set_level_fcut(g_settings_get_int(settings, "fcut"));
 
   bs2b.set_level_feed(10 * static_cast<int>(g_settings_get_double(settings, "feed")));

--- a/src/crystalizer.cpp
+++ b/src/crystalizer.cpp
@@ -38,8 +38,15 @@
 Crystalizer::Crystalizer(const std::string& tag,
                          const std::string& schema,
                          const std::string& schema_path,
-                         PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::crystalizer, tags::plugin_package::ee, schema, schema_path, pipe_manager) {
+                         PipeManager* pipe_manager,
+                         PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::crystalizer,
+                 tags::plugin_package::ee,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type) {
   for (uint n = 0U; n < nbands; n++) {
     filters.at(n) = std::make_unique<FirFilterBandpass>(log_tag + name + " band" + util::to_string(n));
   }

--- a/src/deepfilternet.cpp
+++ b/src/deepfilternet.cpp
@@ -34,13 +34,15 @@
 DeepFilterNet::DeepFilterNet(const std::string& tag,
                              const std::string& schema,
                              const std::string& schema_path,
-                             PipeManager* pipe_manager)
+                             PipeManager* pipe_manager,
+                             PipelineType pipe_type)
     : PluginBase(tag,
                  tags::plugin_name::deepfilternet,
                  tags::plugin_package::deepfilternet,
                  schema,
                  schema_path,
-                 pipe_manager) {
+                 pipe_manager,
+                 pipe_type) {
   ladspa_wrapper = std::make_unique<ladspa::LadspaWrapper>("libdeep_filter_ladspa.so", "deep_filter_stereo");
 
   package_installed = ladspa_wrapper->found_plugin();

--- a/src/deesser.cpp
+++ b/src/deesser.cpp
@@ -31,8 +31,15 @@
 Deesser::Deesser(const std::string& tag,
                  const std::string& schema,
                  const std::string& schema_path,
-                 PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::deesser, tags::plugin_package::calf, schema, schema_path, pipe_manager) {
+                 PipeManager* pipe_manager,
+                 PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::deesser,
+                 tags::plugin_package::calf,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://calf.sourceforge.net/plugins/Deesser");
 
   package_installed = lv2_wrapper->found_plugin;

--- a/src/delay.cpp
+++ b/src/delay.cpp
@@ -32,8 +32,15 @@
 Delay::Delay(const std::string& tag,
              const std::string& schema,
              const std::string& schema_path,
-             PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::delay, tags::plugin_package::lsp, schema, schema_path, pipe_manager) {
+             PipeManager* pipe_manager,
+             PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::delay,
+                 tags::plugin_package::lsp,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/comp_delay_x2_stereo");
 
   package_installed = lv2_wrapper->found_plugin;

--- a/src/echo_canceller.cpp
+++ b/src/echo_canceller.cpp
@@ -39,13 +39,15 @@
 EchoCanceller::EchoCanceller(const std::string& tag,
                              const std::string& schema,
                              const std::string& schema_path,
-                             PipeManager* pipe_manager)
+                             PipeManager* pipe_manager,
+                             PipelineType pipe_type)
     : PluginBase(tag,
                  tags::plugin_name::echo_canceller,
                  tags::plugin_package::speex,
                  schema,
                  schema_path,
                  pipe_manager,
+                 pipe_type,
                  true),
       residual_echo_suppression(g_settings_get_int(settings, "residual-echo-suppression")),
       near_end_suppression(g_settings_get_int(settings, "near-end-suppression")) {

--- a/src/equalizer.cpp
+++ b/src/equalizer.cpp
@@ -44,8 +44,15 @@ Equalizer::Equalizer(const std::string& tag,
                      const std::string& schema_channel,
                      const std::string& schema_channel_left_path,
                      const std::string& schema_channel_right_path,
-                     PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::equalizer, tags::plugin_package::lsp, schema, schema_path, pipe_manager),
+                     PipeManager* pipe_manager,
+                     PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::equalizer,
+                 tags::plugin_package::lsp,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type),
       settings_left(g_settings_new_with_path(schema_channel.c_str(), schema_channel_left_path.c_str())),
       settings_right(g_settings_new_with_path(schema_channel.c_str(), schema_channel_right_path.c_str())) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/para_equalizer_x32_lr");

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -502,7 +502,7 @@ auto export_apo_preset(EqualizerBox* self, GFile* file) {
   }
 
   std::ostringstream write_buffer;
-  double preamp = g_settings_get_double(self->settings, "input-gain");
+  const double preamp = g_settings_get_double(self->settings, "input-gain");
 
   write_buffer << "Preamp: " << preamp << "db"
                << "\n";
@@ -510,8 +510,8 @@ auto export_apo_preset(EqualizerBox* self, GFile* file) {
   int nbands = gtk_spin_button_get_value_as_int(self->nbands);
 
   for (int i = 0; i < nbands; ++i) {
-    bool curr_band_mute = g_settings_get_boolean(self->settings_left, tags::equalizer::band_mute[i].data());
-    std::string curr_band_type = g_settings_get_string(self->settings_left, tags::equalizer::band_type[i].data());
+    const bool curr_band_mute = g_settings_get_boolean(self->settings_left, tags::equalizer::band_mute[i].data());
+    const auto curr_band_type = util::gsettings_get_string(self->settings_left, tags::equalizer::band_type[i].data());
 
     if (curr_band_type == "Off") {
       continue;

--- a/src/exciter.cpp
+++ b/src/exciter.cpp
@@ -31,8 +31,15 @@
 Exciter::Exciter(const std::string& tag,
                  const std::string& schema,
                  const std::string& schema_path,
-                 PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::exciter, tags::plugin_package::calf, schema, schema_path, pipe_manager) {
+                 PipeManager* pipe_manager,
+                 PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::exciter,
+                 tags::plugin_package::calf,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://calf.sourceforge.net/plugins/Exciter");
 
   package_installed = lv2_wrapper->found_plugin;

--- a/src/expander.cpp
+++ b/src/expander.cpp
@@ -36,8 +36,16 @@
 Expander::Expander(const std::string& tag,
                    const std::string& schema,
                    const std::string& schema_path,
-                   PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::expander, tags::plugin_package::lsp, schema, schema_path, pipe_manager, true) {
+                   PipeManager* pipe_manager,
+                   PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::expander,
+                 tags::plugin_package::lsp,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type,
+                 true) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/sc_expander_stereo");
 
   package_installed = lv2_wrapper->found_plugin;

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -31,8 +31,15 @@
 Filter::Filter(const std::string& tag,
                const std::string& schema,
                const std::string& schema_path,
-               PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::filter, tags::plugin_package::lsp, schema, schema_path, pipe_manager) {
+               PipeManager* pipe_manager,
+               PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::filter,
+                 tags::plugin_package::lsp,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/filter_stereo");
 
   package_installed = lv2_wrapper->found_plugin;

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -33,8 +33,19 @@
 #include "tags_plugin_name.hpp"
 #include "util.hpp"
 
-Gate::Gate(const std::string& tag, const std::string& schema, const std::string& schema_path, PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::gate, tags::plugin_package::lsp, schema, schema_path, pipe_manager, true) {
+Gate::Gate(const std::string& tag,
+           const std::string& schema,
+           const std::string& schema_path,
+           PipeManager* pipe_manager,
+           PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::gate,
+                 tags::plugin_package::lsp,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type,
+                 true) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/sc_gate_stereo");
 
   package_installed = lv2_wrapper->found_plugin;

--- a/src/level_meter.cpp
+++ b/src/level_meter.cpp
@@ -32,13 +32,15 @@
 LevelMeter::LevelMeter(const std::string& tag,
                        const std::string& schema,
                        const std::string& schema_path,
-                       PipeManager* pipe_manager)
+                       PipeManager* pipe_manager,
+                       PipelineType pipe_type)
     : PluginBase(tag,
                  tags::plugin_name::level_meter,
                  tags::plugin_package::ebur128,
                  schema,
                  schema_path,
-                 pipe_manager) {}
+                 pipe_manager,
+                 pipe_type) {}
 
 LevelMeter::~LevelMeter() {
   if (connected_to_pw) {

--- a/src/limiter.cpp
+++ b/src/limiter.cpp
@@ -36,8 +36,16 @@
 Limiter::Limiter(const std::string& tag,
                  const std::string& schema,
                  const std::string& schema_path,
-                 PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::limiter, tags::plugin_package::lsp, schema, schema_path, pipe_manager, true) {
+                 PipeManager* pipe_manager,
+                 PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::limiter,
+                 tags::plugin_package::lsp,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type,
+                 true) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/sc_limiter_stereo");
 
   package_installed = lv2_wrapper->found_plugin;

--- a/src/loudness.cpp
+++ b/src/loudness.cpp
@@ -32,8 +32,15 @@
 Loudness::Loudness(const std::string& tag,
                    const std::string& schema,
                    const std::string& schema_path,
-                   PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::loudness, tags::plugin_package::lsp, schema, schema_path, pipe_manager) {
+                   PipeManager* pipe_manager,
+                   PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::loudness,
+                 tags::plugin_package::lsp,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/loud_comp_stereo");
 
   package_installed = lv2_wrapper->found_plugin;

--- a/src/maximizer.cpp
+++ b/src/maximizer.cpp
@@ -32,8 +32,15 @@
 Maximizer::Maximizer(const std::string& tag,
                      const std::string& schema,
                      const std::string& schema_path,
-                     PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::maximizer, tags::plugin_package::zam, schema, schema_path, pipe_manager) {
+                     PipeManager* pipe_manager,
+                     PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::maximizer,
+                 tags::plugin_package::zam,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("urn:zamaudio:ZaMaximX2");
 
   package_installed = lv2_wrapper->found_plugin;

--- a/src/multiband_compressor.cpp
+++ b/src/multiband_compressor.cpp
@@ -37,13 +37,15 @@
 MultibandCompressor::MultibandCompressor(const std::string& tag,
                                          const std::string& schema,
                                          const std::string& schema_path,
-                                         PipeManager* pipe_manager)
+                                         PipeManager* pipe_manager,
+                                         PipelineType pipe_type)
     : PluginBase(tag,
                  tags::plugin_name::multiband_compressor,
                  tags::plugin_package::lsp,
                  schema,
                  schema_path,
                  pipe_manager,
+                 pipe_type,
                  true) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/sc_mb_compressor_stereo");
 

--- a/src/multiband_gate.cpp
+++ b/src/multiband_gate.cpp
@@ -37,13 +37,15 @@
 MultibandGate::MultibandGate(const std::string& tag,
                              const std::string& schema,
                              const std::string& schema_path,
-                             PipeManager* pipe_manager)
+                             PipeManager* pipe_manager,
+                             PipelineType pipe_type)
     : PluginBase(tag,
                  tags::plugin_name::multiband_gate,
                  tags::plugin_package::lsp,
                  schema,
                  schema_path,
                  pipe_manager,
+                 pipe_type,
                  true) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/sc_mb_gate_stereo");
 

--- a/src/output_level.cpp
+++ b/src/output_level.cpp
@@ -29,8 +29,9 @@
 OutputLevel::OutputLevel(const std::string& tag,
                          const std::string& schema,
                          const std::string& schema_path,
-                         PipeManager* pipe_manager)
-    : PluginBase(tag, "output_level", tags::plugin_package::ee, schema, schema_path, pipe_manager) {}
+                         PipeManager* pipe_manager,
+                         PipelineType pipe_type)
+    : PluginBase(tag, "output_level", tags::plugin_package::ee, schema, schema_path, pipe_manager, pipe_type) {}
 
 OutputLevel::~OutputLevel() {
   if (connected_to_pw) {

--- a/src/pitch.cpp
+++ b/src/pitch.cpp
@@ -36,8 +36,15 @@
 Pitch::Pitch(const std::string& tag,
              const std::string& schema,
              const std::string& schema_path,
-             PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::pitch, tags::plugin_package::sound_touch, schema, schema_path, pipe_manager) {
+             PipeManager* pipe_manager,
+             PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::pitch,
+                 tags::plugin_package::sound_touch,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type) {
   quick_seek = g_settings_get_boolean(settings, "quick-seek") != 0;
   anti_alias = g_settings_get_boolean(settings, "anti-alias") != 0;
 

--- a/src/plugin_base.cpp
+++ b/src/plugin_base.cpp
@@ -205,12 +205,15 @@ PluginBase::PluginBase(std::string tag,
                        const std::string& schema,
                        const std::string& schema_path,
                        PipeManager* pipe_manager,
+                       PipelineType pipe_type,
                        const bool& enable_probe)
     : log_tag(std::move(tag)),
       name(std::move(plugin_name)),
       package(std::move(package)),
+      pipeline_type(pipe_type),
       enable_probe(enable_probe),
       settings(g_settings_new_with_path(schema.c_str(), schema_path.c_str())),
+      global_settings(g_settings_new(tags::app::id)),
       pm(pipe_manager) {
   std::string description;
 

--- a/src/presets_menu.cpp
+++ b/src/presets_menu.cpp
@@ -570,7 +570,7 @@ void setup(PresetsMenu* self, app::Application* application, PresetType preset_t
     const std::string community_package = util::gsettings_get_string(settings, lcp_key);
 
     const std::string preset_title =
-        ((community_package.empty()) ? _("Last Loaded Local Preset") : _("Last Loaded Community Preset"));
+        ((community_package.empty()) ? _("Last Local Preset Loaded") : _("Last Community Preset Loaded"));
 
     gtk_label_set_text(self->last_loaded_preset_title, preset_title.c_str());
   };

--- a/src/reverb.cpp
+++ b/src/reverb.cpp
@@ -31,8 +31,15 @@
 Reverb::Reverb(const std::string& tag,
                const std::string& schema,
                const std::string& schema_path,
-               PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::reverb, tags::plugin_package::calf, schema, schema_path, pipe_manager) {
+               PipeManager* pipe_manager,
+               PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::reverb,
+                 tags::plugin_package::calf,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://calf.sourceforge.net/plugins/Reverb");
 
   package_installed = lv2_wrapper->found_plugin;

--- a/src/rnnoise.cpp
+++ b/src/rnnoise.cpp
@@ -41,8 +41,15 @@
 RNNoise::RNNoise(const std::string& tag,
                  const std::string& schema,
                  const std::string& schema_path,
-                 PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::rnnoise, tags::plugin_package::rnnoise, schema, schema_path, pipe_manager),
+                 PipeManager* pipe_manager,
+                 PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::rnnoise,
+                 tags::plugin_package::rnnoise,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type),
       enable_vad(g_settings_get_boolean(settings, "enable-vad")),
       vad_thres(g_settings_get_double(settings, "vad-thres") / 100.0F),
       data_L(0),

--- a/src/rnnoise_preset.cpp
+++ b/src/rnnoise_preset.cpp
@@ -86,7 +86,7 @@ void RNNoisePreset::load(const nlohmann::json& json) {
     }
   }
 
-  auto* current_model_name = g_settings_get_string(settings, model_name_key);
+  const auto current_model_name = util::gsettings_get_string(settings, model_name_key);
 
   if (new_model_name != current_model_name) {
     g_settings_set_string(settings, model_name_key, new_model_name.c_str());

--- a/src/rnnoise_ui.cpp
+++ b/src/rnnoise_ui.cpp
@@ -322,7 +322,13 @@ void setup(RNNoiseBox* self,
         for (guint n = 0U; n < g_list_model_get_n_items(G_LIST_MODEL(self->selection_model)); n++) {
           auto item = g_list_model_get_item(G_LIST_MODEL(self->selection_model), n);
 
-          const std::string model_name = gtk_string_object_get_string(GTK_STRING_OBJECT(item));
+          auto* string_object = GTK_STRING_OBJECT(item);
+
+          if (string_object == nullptr) {
+            continue;
+          }
+
+          const std::string model_name = gtk_string_object_get_string(string_object);
 
           g_object_unref(item);
 
@@ -364,7 +370,7 @@ void setup(RNNoiseBox* self,
         auto string_object =
             GTK_STRING_OBJECT(gtk_single_selection_get_selected_item(GTK_SINGLE_SELECTION(self->selection_model)));
 
-        const std::string selected_name = gtk_string_object_get_string(string_object);
+        const std::string selected_name = (string_object != nullptr) ? gtk_string_object_get_string(string_object) : "";
 
         const std::string default_model_name = _("Standard Model");
 

--- a/src/rnnoise_ui.cpp
+++ b/src/rnnoise_ui.cpp
@@ -299,6 +299,24 @@ void setup(RNNoiseBox* self,
 
         const std::string gsettings_model_name = g_variant_get_string(variant, nullptr);
 
+        const auto* lcp_key = (self->data->rnnoise->pipeline_type == PipelineType::input)
+                                  ? "last-loaded-input-community-package"
+                                  : "last-loaded-output-community-package";
+
+        const auto community_package = util::gsettings_get_string(self->data->application->settings, lcp_key);
+
+        if (!community_package.empty()) {
+          // Model from community package used, so unselect the selection.
+          g_value_set_uint(value, GTK_INVALID_LIST_POSITION);
+
+          // Since no item is selected, we set the community model name in
+          // the active_model_name label manually.
+          gtk_label_set_text(self->active_model_name, gsettings_model_name.c_str());
+
+          return 1;
+        }
+
+        // Local model used.
         int standard_model_id = 0;
 
         for (guint n = 0U; n < g_list_model_get_n_items(G_LIST_MODEL(self->selection_model)); n++) {
@@ -319,20 +337,15 @@ void setup(RNNoiseBox* self,
           }
         }
 
-        // If the model name is not in the list, determine if we should
-        // select the standard model or unselect the selection.
-
         if (gsettings_model_name.empty()) {
           // If the model name is empty, select the standard model.
           g_value_set_uint(value, standard_model_id);
         } else {
-          // If the model name is not empty:
-          // 1. A local preset is loaded, but the model file on the filesystem is missing;
-          // 2. A community preset is being tried and the model file may be correctly loaded.
-          // In both cases we unselect the selection using GTK_INVALID_LIST_POSITION.
+          // A local preset is loaded, but the model file on the filesystem is missing.
+          // Unselect the selection.
           g_value_set_uint(value, GTK_INVALID_LIST_POSITION);
 
-          // Since no item is selected, we set the active_model_name label manually.
+          // Update the active_model_name anyway.
           gtk_label_set_text(self->active_model_name, gsettings_model_name.c_str());
         }
 
@@ -340,6 +353,13 @@ void setup(RNNoiseBox* self,
       },
       +[](const GValue* value, const GVariantType* expected_type, gpointer user_data) {
         auto* self = EE_RNNOISE_BOX(user_data);
+
+        const auto* lcp_key = (self->data->rnnoise->pipeline_type == PipelineType::input)
+                                  ? "last-loaded-input-community-package"
+                                  : "last-loaded-output-community-package";
+
+        // irs loaded from the convolver menu are always local.
+        g_settings_reset(self->data->application->settings, lcp_key);
 
         auto string_object =
             GTK_STRING_OBJECT(gtk_single_selection_get_selected_item(GTK_SINGLE_SELECTION(self->selection_model)));

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -38,8 +38,10 @@
 Spectrum::Spectrum(const std::string& tag,
                    const std::string& schema,
                    const std::string& schema_path,
-                   PipeManager* pipe_manager)
-    : PluginBase(tag, "spectrum", tags::plugin_package::ee, schema, schema_path, pipe_manager), fftw_ready(true) {
+                   PipeManager* pipe_manager,
+                   PipelineType pipe_type)
+    : PluginBase(tag, "spectrum", tags::plugin_package::ee, schema, schema_path, pipe_manager, pipe_type),
+      fftw_ready(true) {
   real_input.resize(n_bands);
   output.resize(n_bands / 2U + 1U);
 

--- a/src/speex.cpp
+++ b/src/speex.cpp
@@ -36,8 +36,15 @@
 Speex::Speex(const std::string& tag,
              const std::string& schema,
              const std::string& schema_path,
-             PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::speex, tags::plugin_package::speex, schema, schema_path, pipe_manager),
+             PipeManager* pipe_manager,
+             PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::speex,
+                 tags::plugin_package::speex,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type),
       enable_denoise(g_settings_get_boolean(settings, "enable-denoise")),
       noise_suppression(g_settings_get_int(settings, "noise-suppression")),
       enable_agc(g_settings_get_boolean(settings, "enable-agc")),

--- a/src/stereo_tools.cpp
+++ b/src/stereo_tools.cpp
@@ -35,8 +35,15 @@
 StereoTools::StereoTools(const std::string& tag,
                          const std::string& schema,
                          const std::string& schema_path,
-                         PipeManager* pipe_manager)
-    : PluginBase(tag, tags::plugin_name::stereo_tools, tags::plugin_package::calf, schema, schema_path, pipe_manager) {
+                         PipeManager* pipe_manager,
+                         PipelineType pipe_type)
+    : PluginBase(tag,
+                 tags::plugin_name::stereo_tools,
+                 tags::plugin_package::calf,
+                 schema,
+                 schema_path,
+                 pipe_manager,
+                 pipe_type) {
   lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://calf.sourceforge.net/plugins/StereoTools");
 
   package_installed = lv2_wrapper->found_plugin;

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -41,8 +41,8 @@
 #include "tags_schema.hpp"
 #include "util.hpp"
 
-StreamInputEffects::StreamInputEffects(PipeManager* pipe_manager)
-    : EffectsBase("sie: ", tags::schema::id_input, pipe_manager) {
+StreamInputEffects::StreamInputEffects(PipeManager* pipe_manager, PipelineType pipeline_type)
+    : EffectsBase("sie: ", tags::schema::id_input, pipe_manager, pipeline_type) {
   auto* PULSE_SOURCE = std::getenv("PULSE_SOURCE");
 
   if (PULSE_SOURCE != nullptr && PULSE_SOURCE != tags::pipewire::ee_source_name) {

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -41,8 +41,8 @@
 #include "tags_schema.hpp"
 #include "util.hpp"
 
-StreamOutputEffects::StreamOutputEffects(PipeManager* pipe_manager)
-    : EffectsBase("soe: ", tags::schema::id_output, pipe_manager) {
+StreamOutputEffects::StreamOutputEffects(PipeManager* pipe_manager, PipelineType pipeline_type)
+    : EffectsBase("soe: ", tags::schema::id_output, pipe_manager, pipeline_type) {
   auto* PULSE_SINK = std::getenv("PULSE_SINK");
 
   if (PULSE_SINK != nullptr && PULSE_SINK != tags::pipewire::ee_sink_name) {


### PR DESCRIPTION
This is a big load of improvements for community presets management.

Since we used the kernel/model-name to search the files, we could fall in some misunderstandings when multiple packages had the same filename. In example `irs/pack-1/device.irs` and `irs/pack-2/device.irs` were always picking one file, no matter the preset chosen.

In order to avoid this behavior, I had to introduce a mechanism to signal the selection of a community package name. In practice, when a community preset is loaded, we save the community package name to gsettings. Otherwise, when a local preset is loaded, the previous community package name is reset. With this key, we can select a file from the right path and the search is also restricted to the paths belonging to chosen package, not everyone installed. 

Now we are also aware if we have loaded a preset from the local path or from a community package. But that required to introduce the pipeline type (in/out) and global settings to all plugins instances.

@wwmm one thing to notice is how the community package is retrieved after the import/try button is clicked. The only way I found it to work is setting the package name label object on the gtk button object. See [here](https://github.com/Digitalone1/easyeffects/blob/master/src/presets_menu.cpp#L297-L299). I tried to pass only the label string, but I kept getting errors on the compiler. Don't know if there's a better way to do it.

Another fix I noticed is the use of `g_settings_get_string` in various parts of the code which it seems to require to free the string, but we didn't. I switched them to the relative `util::gsettings_get_string` which frees it internally.

This should be heavily tested. I did it on my system and it seems good at the moment. I hope there's no edge case where race conditions could show hidden bugs.

@vchernin Please test you too on Flatpak with the newly created extensions. Thanks.  