### PR TITLE
SOE/SIE: Set pipeline type internally

### DIFF
--- a/include/stream_input_effects.hpp
+++ b/include/stream_input_effects.hpp
@@ -25,7 +25,7 @@
 
 class StreamInputEffects : public EffectsBase {
  public:
-  StreamInputEffects(PipeManager* pipe_manager, PipelineType pipeline_type);
+  StreamInputEffects(PipeManager* pipe_manager);
   StreamInputEffects(const StreamInputEffects&) = delete;
   auto operator=(const StreamInputEffects&) -> StreamInputEffects& = delete;
   StreamInputEffects(const StreamInputEffects&&) = delete;

--- a/include/stream_output_effects.hpp
+++ b/include/stream_output_effects.hpp
@@ -25,7 +25,7 @@
 
 class StreamOutputEffects : public EffectsBase {
  public:
-  StreamOutputEffects(PipeManager* pipe_manager, PipelineType pipeline_type);
+  StreamOutputEffects(PipeManager* pipe_manager);
   StreamOutputEffects(const StreamOutputEffects&) = delete;
   auto operator=(const StreamOutputEffects&) -> StreamOutputEffects& = delete;
   StreamOutputEffects(const StreamOutputEffects&&) = delete;

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -87,8 +87,8 @@ void on_startup(GApplication* gapp) {
   self->soe_settings = g_settings_new(tags::schema::id_output);
 
   self->pm = new PipeManager();
-  self->soe = new StreamOutputEffects(self->pm, PipelineType::output);
-  self->sie = new StreamInputEffects(self->pm, PipelineType::input);
+  self->soe = new StreamOutputEffects(self->pm);
+  self->sie = new StreamInputEffects(self->pm);
 
   if (self->settings == nullptr) {
     self->settings = g_settings_new(tags::app::id);

--- a/src/rnnoise_ui.cpp
+++ b/src/rnnoise_ui.cpp
@@ -364,7 +364,7 @@ void setup(RNNoiseBox* self,
                                   ? "last-loaded-input-community-package"
                                   : "last-loaded-output-community-package";
 
-        // irs loaded from the convolver menu are always local.
+        // models loaded from the rnnoise ui are always local.
         g_settings_reset(self->data->application->settings, lcp_key);
 
         auto string_object =

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -41,8 +41,8 @@
 #include "tags_schema.hpp"
 #include "util.hpp"
 
-StreamInputEffects::StreamInputEffects(PipeManager* pipe_manager, PipelineType pipeline_type)
-    : EffectsBase("sie: ", tags::schema::id_input, pipe_manager, pipeline_type) {
+StreamInputEffects::StreamInputEffects(PipeManager* pipe_manager)
+    : EffectsBase("sie: ", tags::schema::id_input, pipe_manager, PipelineType::input) {
   auto* PULSE_SOURCE = std::getenv("PULSE_SOURCE");
 
   if (PULSE_SOURCE != nullptr && PULSE_SOURCE != tags::pipewire::ee_source_name) {

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -41,8 +41,8 @@
 #include "tags_schema.hpp"
 #include "util.hpp"
 
-StreamOutputEffects::StreamOutputEffects(PipeManager* pipe_manager, PipelineType pipeline_type)
-    : EffectsBase("soe: ", tags::schema::id_output, pipe_manager, pipeline_type) {
+StreamOutputEffects::StreamOutputEffects(PipeManager* pipe_manager)
+    : EffectsBase("soe: ", tags::schema::id_output, pipe_manager, PipelineType::output) {
   auto* PULSE_SINK = std::getenv("PULSE_SINK");
 
   if (PULSE_SINK != nullptr && PULSE_SINK != tags::pipewire::ee_sink_name) {


### PR DESCRIPTION
Set the pipeline type at the construction passing it to the base class internally rather than specifying it from the outside. 