### PR TITLE
Update Flatpak state for Community Presets + little fixes

### DIFF
--- a/COMMUNITY_PRESETS_GUIDELINES.md
+++ b/COMMUNITY_PRESETS_GUIDELINES.md
@@ -11,8 +11,8 @@ easily installed since not all users were able to find presets on the internet,
 which were practically reported in one of the subpage of the Github project
 (that linked other repositories where the user should manually download them on
 the local storage).
-Now it should be easier to discover them making a search on Flatpak or the
-repository or your favorite distribution.
+Now it should be easier to discover them making a search on the repository or
+your favorite distribution.
 
 Instead the Local Presets list is intended to save self-made presets and/or a
 selected choice of presets imported by the community list.
@@ -23,7 +23,7 @@ Indeed, Community Presets **cannot be autoloaded**.
 In order to list the Community Presets, the user should install one or more
 packages made and maintained by other Easy Effects users.
 The packages can be shipped by Linux distributions in their specific
-repositories or by extensions available on Flatpak.
+repositories.
 
 # Guidelines for packagers of Easy Effects Community Presets
 
@@ -47,28 +47,55 @@ Noise Reduction effect.
 - The folders above mentioned should contain a subdirectory with the name
 associated to the installed package. In example:
 - - `XDG_DATA_DIR/easyeffects/output/package-name`
-- The name of the package should be something descriptive e.g. `easyeffects-presets-LoudnessEqualizer`. If your package contains a group of presets without a particular "theme", naming a package `easyeffects-USERNAME-presets` is reasonable.
+- The name of the package should be something descriptive e.g.
+`easyeffects-presets-LoudnessEqualizer`. If your package contains a group of
+presets without a particular "theme", naming a package
+`easyeffects-USERNAME-presets` is reasonable.
 
+<!--
 ### Flatpak
 
-Flatpak extension packages do not use `$XDG_DATA_DIRS`, and instead place and search for files under a different directory (detailed in examples below). Besides this detail, Flatpak and distribution packages should behave the same in regard to community presets.
+Flatpak extension packages do not use `$XDG_DATA_DIRS`, and instead place and
+search for files under a different directory (detailed in examples below).
+Besides this detail, Flatpak and distribution packages should behave the same in
+regard to community presets.
 
-In order to publish a Flatpak preset package on Flathub you do the following general steps:
+In order to publish a Flatpak preset package on Flathub you do the following
+general steps:
 
-1. Create AppStream MetaInfo file (should be stored in your preset repository as it is not Flatpak-specific).
+1. Create AppStream MetaInfo file (should be stored in your preset repository as
+it is not Flatpak-specific).
 2. Create Flatpak json manifest file
-3. Submit to Flathub, described following [Flathub's guide](https://docs.flathub.org/docs/for-app-authors/submission/).
+3. Submit to Flathub, described following
+[Flathub's guide](https://docs.flathub.org/docs/for-app-authors/submission/).
 
 #### Step by step instructions
 
-1. Decide on a name. It should be e.g. `io.github.wwmm.easyeffects.Presets.PRESET_PACKAGE_NAME`. For example `io.github.wwmm.easyeffects.Presets.LoudnessEqualizer` for a specific preset or `io.github.wwmm.easyeffects.Presets.wwmm` for a group of presets without a particular "theme". The name must be consistent across the files used for Flatpak otherwise the package will not build/work properly. 
+1. Decide on a name. It should be e.g.
+`io.github.wwmm.easyeffects.Presets.PRESET_PACKAGE_NAME`. For example
+`io.github.wwmm.easyeffects.Presets.LoudnessEqualizer` for a specific preset or
+`io.github.wwmm.easyeffects.Presets.wwmm` for a group of presets without a
+particular "theme". The name must be consistent across the files used for
+Flatpak otherwise the package will not build/work properly.
 
 > [!NOTE]  
-> Flatpak uses `io.github.wwmm.easyeffects.Presets` as the extension point name (which preset packages must use), while `com.github.wwmm.easyeffects` is the name of the Easy Effects package itself. This is necessary since `com.github.*` is only allowed for backwards compatibility reasons on Flathub, and newer packages must use `io.github.*`. 
+> Flatpak uses `io.github.wwmm.easyeffects.Presets` as the extension point name
+(which preset packages must use), while `com.github.wwmm.easyeffects` is the
+name of the Easy Effects package itself. This is necessary since `com.github.*`
+is only allowed for backwards compatibility reasons on Flathub, and newer
+packages must use `io.github.*`.
 
-2. Clone the Flathub repo for new submissions following [Flathub's guide](https://docs.flathub.org/docs/for-app-authors/submission/).
+2. Clone the Flathub repo for new submissions following
+[Flathub's guide](https://docs.flathub.org/docs/for-app-authors/submission/).
 
-3. Create the AppStream MetaInfo file, which should go in your preset repository, not the Flathub repository. Name it `io.github.wwmm.easyeffects.Presets.PRESET_PACKAGE_NAME.metainfo.xml`. Replace `PRESET_PACKAGE_NAME`, `PRESET_PACKAGE_NAME_PRETTY`, `DEVELOPER_NAME_ID`, `DEVELOPER_NAME`, and `REPO_URL`. You may optionally add more information to this file (which may help improve visibility of the package on Flathub/software stores) as described in the [appstream docs](https://www.freedesktop.org/software/appstream/docs/).
+3. Create the AppStream MetaInfo file, which should go in your preset
+repository, not the Flathub repository.
+Name it `io.github.wwmm.easyeffects.Presets.PRESET_PACKAGE_NAME.metainfo.xml`.
+Replace `PRESET_PACKAGE_NAME`, `PRESET_PACKAGE_NAME_PRETTY`,
+`DEVELOPER_NAME_ID`, `DEVELOPER_NAME`, and `REPO_URL`.
+You may optionally add more information to this file (which may help improve
+visibility of the package on Flathub/software stores) as described in the
+[appstream docs](https://www.freedesktop.org/software/appstream/docs/).
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -88,7 +115,17 @@ In order to publish a Flatpak preset package on Flathub you do the following gen
 </component>
 ```
 
-4. Create the Flatpak manifest file named `io.github.wwmm.easyeffects.Presets.PRESET_PACKAGE_NAME.json`, this should go in your Flathub repository. Replace `PRESET_PACKAGE_NAME`, `PRESET_FILE_NAME`, `REPO_NAME`, `REPO_URL`, and `LATEST_COMMIT`. An example of `REPO_NAME` is `wwmm/easyeffects` and `REPO_URL` could be `https://github.com/wwmm/easyeffects.git` You can add more `install` commands in `build-commands` if you want to install multiple presets. Make sure you carefully install to the correct directory for each type of preset, with the options of `input`, `output`, `irs`, and `rnnoise`. If the preset repo is not on GitHub remove or replace the `x-checker-data` section.
+4. Create the Flatpak manifest file named
+`io.github.wwmm.easyeffects.Presets.PRESET_PACKAGE_NAME.json`, this should go in
+your Flathub repository. Replace `PRESET_PACKAGE_NAME`, `PRESET_FILE_NAME`,
+`REPO_NAME`, `REPO_URL`, and `LATEST_COMMIT`.
+An example of `REPO_NAME` is `wwmm/easyeffects` and `REPO_URL` could be
+`https://github.com/wwmm/easyeffects.git`.
+You can add more `install` commands in `build-commands` if you want to install
+multiple presets. Make sure you carefully install to the correct directory for
+each type of preset, with the options of `input`, `output`, `irs`, and
+`rnnoise`. If the preset repo is not on GitHub remove or replace the
+`x-checker-data` section.
 
 ```json
 {
@@ -130,7 +167,12 @@ In order to publish a Flatpak preset package on Flathub you do the following gen
 
 ```
 
-5. It is also necessary to add the following file called `flathub.json` in the Flathub repo. The skip icons check is stricly necessary, since unlike a normal app we are not providing icons. We also recommend enabling a Flathub bot to automatically merge PRs with updates from the upstream repo. Given these are only preset files, this should not be a very risky thing to do and avoids manual maintenance hassle.
+5. It is also necessary to add the following file called `flathub.json` in the
+Flathub repo. The skip icons check is stricly necessary, since unlike a normal
+app we are not providing icons.
+We also recommend enabling a Flathub bot to automatically merge PRs with updates
+from the upstream repo. Given these are only preset files, this should not be a
+very risky thing to do and avoids manual maintenance hassle.
 
 ```json
 {
@@ -140,8 +182,9 @@ In order to publish a Flatpak preset package on Flathub you do the following gen
 
 ```
 
-6. Now you can submit this to Flathub via a PR, following [Flathub's instructions](https://docs.flathub.org/docs/for-app-authors/submission/).
-
+6. Now you can submit this to Flathub via a PR, following
+[Flathub's instructions](https://docs.flathub.org/docs/for-app-authors/submission/).
+-->
 
 ## Guidelines for package directories structure
 
@@ -199,9 +242,11 @@ package. But, more importantly, **make sure to build/save the preset with a
 version >=`7.2.0`**.
 
 More in detail, Easy Effects presets does not save the path anymore, but only
-the name of the additional files (without extension). 
-Previously, the path was stored in the preset JSON file as `kernel-path`, and now the replacement key which only stores the name is `kernel-name`. 
-So if you see `kernel-path` in a preset JSON file it probably needs to be updated by saving the preset with a version >=`7.2.0`.
+the name of the additional files (without extension).
+Previously, the path was stored in the preset JSON file as `kernel-path`, and
+now the replacement key which only stores the name is `kernel-name`.
+So if you see `kernel-path` in a preset JSON file it probably needs to be
+updated by saving the preset with a version >=`7.2.0`.
 
 When a preset is loaded,
 the application searches the specified file, first in the local directory,

--- a/data/ui/presets_menu.ui
+++ b/data/ui/presets_menu.ui
@@ -284,7 +284,7 @@
                                                 <property name="hexpand">1</property>
                                                 <property name="vexpand">1</property>
                                                 <property name="title" translatable="yes">No Community Presets Installed</property>
-                                                <property name="description" translatable="yes">Community Presets packages can be installed from Flatpak or the repository of your favorite distribution.</property>
+                                                <property name="description" translatable="yes">Community Presets packages can be installed from the repository of your favorite distribution.</property>
                                                 <style>
                                                     <class name="compact" />
                                                 </style>

--- a/include/crystalizer.hpp
+++ b/include/crystalizer.hpp
@@ -153,7 +153,7 @@ class Crystalizer : public PluginBase {
           const float L = band_data_L.at(n)[m];
           const float R = band_data_R.at(n)[m];
 
-          if (m > 0 && m < blocksize - 1) {
+          if (m > 0U && m < blocksize - 1U) {
             const float& L_lower = band_data_L.at(n)[m - 1U];
             const float& R_lower = band_data_R.at(n)[m - 1U];
             const float& L_upper = band_data_L.at(n)[m + 1U];
@@ -164,12 +164,12 @@ class Crystalizer : public PluginBase {
           } else if (m == 0U) {
             const float& L_lower = band_last_L.at(n);
             const float& R_lower = band_last_R.at(n);
-            const float& L_upper = band_data_L.at(n)[m + 1];
-            const float& R_upper = band_data_R.at(n)[m + 1];
+            const float& L_upper = band_data_L.at(n)[m + 1U];
+            const float& R_upper = band_data_R.at(n)[m + 1U];
 
             band_second_derivative_L.at(n)[m] = L_upper - 2.0F * L + L_lower;
             band_second_derivative_R.at(n)[m] = R_upper - 2.0F * R + R_lower;
-          } else if (m == blocksize - 1) {
+          } else if (m == blocksize - 1U) {
             const float& L_upper = band_next_L.at(n);
             const float& R_upper = band_next_R.at(n);
             const float& L_lower = band_data_L.at(n)[m - 1U];
@@ -197,8 +197,8 @@ class Crystalizer : public PluginBase {
           }
         }
       } else {
-        band_last_L.at(n) = band_data_L.at(n)[blocksize - 1];
-        band_last_R.at(n) = band_data_R.at(n)[blocksize - 1];
+        band_last_L.at(n) = band_data_L.at(n)[blocksize - 1U];
+        band_last_R.at(n) = band_data_R.at(n)[blocksize - 1U];
       }
     }
 

--- a/include/tags_resources.hpp
+++ b/include/tags_resources.hpp
@@ -29,6 +29,10 @@ inline constexpr auto icons = "/com/github/wwmm/easyeffects/icons";
 
 inline constexpr auto css = "/com/github/wwmm/easyeffects/ui/custom.css";
 
+// Flatpak info file
+
+inline constexpr auto flatpak_info_file = "/.flatpak-info";
+
 // Path to the widgets xml files
 
 inline constexpr auto app_info_ui = "/com/github/wwmm/easyeffects/ui/app_info.ui";

--- a/src/autogain.cpp
+++ b/src/autogain.cpp
@@ -130,7 +130,7 @@ AutoGain::~AutoGain() {
 }
 
 auto AutoGain::init_ebur128() -> bool {
-  if (n_samples == 0 || rate == 0) {
+  if (n_samples == 0U || rate == 0U) {
     return false;
   }
 

--- a/src/convolver.cpp
+++ b/src/convolver.cpp
@@ -37,6 +37,7 @@
 #include "plugin_base.hpp"
 #include "resampler.hpp"
 #include "tags_plugin_name.hpp"
+#include "tags_resources.hpp"
 #include "util.hpp"
 
 namespace {
@@ -65,7 +66,7 @@ Convolver::Convolver(const std::string& tag,
   local_dir_irs = std::string{g_get_user_config_dir()} + "/easyeffects/irs";
 
   // Flatpak specific path (.flatpak-info always present for apps running in the flatpak sandbox)
-  if (std::filesystem::is_regular_file("/.flatpak-info")) {
+  if (std::filesystem::is_regular_file(tags::resources::flatpak_info_file)) {
     system_data_dir_irs.push_back("/app/extensions/Presets/irs");
   }
 

--- a/src/crystalizer.cpp
+++ b/src/crystalizer.cpp
@@ -113,10 +113,10 @@ void Crystalizer::setup() {
 
     blocksize = n_samples;
 
-    n_samples_is_power_of_2 = (n_samples & (n_samples - 1)) == 0 && n_samples != 0;
+    n_samples_is_power_of_2 = (n_samples & (n_samples - 1U)) == 0 && n_samples != 0;
 
     if (!n_samples_is_power_of_2) {
-      while ((blocksize & (blocksize - 1)) != 0 && blocksize > 2) {
+      while ((blocksize & (blocksize - 1U)) != 0 && blocksize > 2U) {
         blocksize--;
       }
     }

--- a/src/crystalizer.cpp
+++ b/src/crystalizer.cpp
@@ -113,7 +113,7 @@ void Crystalizer::setup() {
 
     blocksize = n_samples;
 
-    n_samples_is_power_of_2 = (n_samples & (n_samples - 1U)) == 0 && n_samples != 0;
+    n_samples_is_power_of_2 = (n_samples & (n_samples - 1U)) == 0 && n_samples != 0U;
 
     if (!n_samples_is_power_of_2) {
       while ((blocksize & (blocksize - 1U)) != 0 && blocksize > 2U) {

--- a/src/fir_filter_base.cpp
+++ b/src/fir_filter_base.cpp
@@ -78,7 +78,7 @@ auto FirFilterBase::create_lowpass_kernel(const float& cutoff, const float& tran
     -> std::vector<float> {
   std::vector<float> output;
 
-  if (rate == 0) {
+  if (rate == 0U) {
     return output;
   }
 

--- a/src/level_meter.cpp
+++ b/src/level_meter.cpp
@@ -63,7 +63,7 @@ LevelMeter::~LevelMeter() {
 }
 
 auto LevelMeter::init_ebur128() -> bool {
-  if (n_samples == 0 || rate == 0) {
+  if (n_samples == 0U || rate == 0U) {
     return false;
   }
 

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -68,6 +68,7 @@
 #include "stereo_tools_preset.hpp"
 #include "tags_app.hpp"
 #include "tags_plugin_name.hpp"
+#include "tags_resources.hpp"
 #include "tags_schema.hpp"
 #include "util.hpp"
 
@@ -84,7 +85,7 @@ PresetsManager::PresetsManager()
       sie_settings(g_settings_new(tags::schema::id_input)) {
   // Initialize input and output directories for community presets.
   // Flatpak specific path (.flatpak-info always present for apps running in the flatpak sandbox).
-  if (std::filesystem::is_regular_file("/.flatpak-info")) {
+  if (std::filesystem::is_regular_file(tags::resources::flatpak_info_file)) {
     system_data_dir_input.push_back("/app/extensions/Presets/input");
     system_data_dir_output.push_back("/app/extensions/Presets/output");
     system_data_dir_irs.push_back("/app/extensions/Presets/irs");

--- a/src/rnnoise.cpp
+++ b/src/rnnoise.cpp
@@ -36,6 +36,7 @@
 #include "plugin_base.hpp"
 #include "resampler.hpp"
 #include "tags_plugin_name.hpp"
+#include "tags_resources.hpp"
 #include "util.hpp"
 
 RNNoise::RNNoise(const std::string& tag,
@@ -62,7 +63,7 @@ RNNoise::RNNoise(const std::string& tag,
   local_dir_rnnoise = std::string{g_get_user_config_dir()} + "/easyeffects/rnnoise";
 
   // Flatpak specific path (.flatpak-info always present for apps running in the flatpak sandbox)
-  if (std::filesystem::is_regular_file("/.flatpak-info")) {
+  if (std::filesystem::is_regular_file(tags::resources::flatpak_info_file)) {
     system_data_dir_rnnoise.push_back("/app/extensions/Presets/rnnoise");
   }
 

--- a/util/NEWS.yaml
+++ b/util/NEWS.yaml
@@ -4,7 +4,7 @@ Date: UNRELEASED_DATE
 
 Description:
 - Features∶
-- Community Presets have been implemented. Users can install packages containing multiple Easy Effects presets to be imported and applied inside the application. These packages will be maintained and shipped by volunteers. You can search them on Flathub or the repositories of your favorite distribution.
+- Community Presets have been implemented. Users can install packages containing multiple Easy Effects presets to be imported and applied inside the application. These packages will be maintained and shipped by volunteers. You can search them on the repositories of your favorite distribution.
 - Added the ability of collapsing the sidebar to hide the effects list and expand the area of the effects user interface.
 
 - Bug fixes∶


### PR DESCRIPTION
 Related to https://github.com/wwmm/easyeffects/issues/2445#issuecomment-2104171861.

@vchernin The Flatpak section in guidelines is only commented. If Flathub will accept EE extensions, it will be easy to revert the visibility removing HTML comment tags. But, realistically, it would be better to change it targeting Flatpak custom remotes. 

@wwmm I got the following warning. It should be related to the new gcc v14.

<details>
<summary> Compile warning </summary>

```bash
[82/196] Compiling C++ object src/easyeffects.p/convolver_menu_combine.cpp.o
In file included from /usr/include/c++/14.1.1/x86_64-pc-linux-gnu/bits/c++config.h:887,
                 from /usr/include/c++/14.1.1/type_traits:38,
                 from /usr/include/glib-2.0/glib/glib-typeof.h:43,
                 from /usr/include/glib-2.0/glib/gatomic.h:30,
                 from /usr/include/glib-2.0/glib/gthread.h:34,
                 from /usr/include/glib-2.0/glib/gasyncqueue.h:34,
                 from /usr/include/glib-2.0/glib.h:34,
                 from /usr/include/glib-2.0/gobject/gbinding.h:30,
                 from /usr/include/glib-2.0/glib-object.h:24,
                 from ../include/convolver_menu_combine.hpp:22,
                 from ../src/convolver_menu_combine.cpp:20:
/usr/include/c++/14.1.1/pstl/algorithm_impl.h: In function ‘_RandomAccessIterator __pstl::__internal::__brick_unique(_RandomAccessIterator, _RandomAccessIterator, _BinaryPredicate, std::true_type)’:
/usr/include/c++/14.1.1/pstl/algorithm_impl.h:1219:5: note: ‘#pragma message:  [Parallel STL message]: "Vectorized algorithm unimplemented, redirected to serial"’
 1219 |     _PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
      |     ^~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14.1.1/pstl/algorithm_impl.h: In function ‘_RandomAccessIterator __pstl::__internal::__brick_partition(_RandomAccessIterator, _RandomAccessIterator, _UnaryPredicate, std::true_type)’:
/usr/include/c++/14.1.1/pstl/algorithm_impl.h:1929:5: note: ‘#pragma message:  [Parallel STL message]: "Vectorized algorithm unimplemented, redirected to serial"’
 1929 |     _PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
      |     ^~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14.1.1/pstl/algorithm_impl.h: In function ‘_RandomAccessIterator __pstl::__internal::__brick_stable_partition(_RandomAccessIterator, _RandomAccessIterator, _UnaryPredicate, std::true_type)’:
/usr/include/c++/14.1.1/pstl/algorithm_impl.h:2029:5: note: ‘#pragma message:  [Parallel STL message]: "Vectorized algorithm unimplemented, redirected to serial"’
 2029 |     _PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
      |     ^~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14.1.1/pstl/algorithm_impl.h: In function ‘_RandomAccessIterator3 __pstl::__internal::__brick_merge(_RandomAccessIterator1, _RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator2, _RandomAccessIterator3, _Compare, std::true_type)’:
/usr/include/c++/14.1.1/pstl/algorithm_impl.h:2715:5: note: ‘#pragma message:  [Parallel STL message]: "Vectorized algorithm unimplemented, redirected to serial"’
 2715 |     _PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
      |     ^~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14.1.1/pstl/algorithm_impl.h: In function ‘void __pstl::__internal::__brick_inplace_merge(_RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator, _Compare, std::true_type)’:
/usr/include/c++/14.1.1/pstl/algorithm_impl.h:2764:5: note: ‘#pragma message:  [Parallel STL message]: "Vectorized algorithm unimplemented, redirected to serial"’
 2764 |     _PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial")
      |     ^~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14.1.1/pstl/algorithm_impl.h: In function ‘_OutputIterator __pstl::__internal::__brick_set_union(_RandomAccessIterator1, _RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator2, _OutputIterator, _Compare, std::true_type)’:
/usr/include/c++/14.1.1/pstl/algorithm_impl.h:3141:5: note: ‘#pragma message:  [Parallel STL message]: "Vectorized algorithm unimplemented, redirected to serial"’
 3141 |     _PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
      |     ^~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14.1.1/pstl/algorithm_impl.h: In function ‘_RandomAccessIterator3 __pstl::__internal::__brick_set_intersection(_RandomAccessIterator1, _RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator2, _RandomAccessIterator3, _Compare, std::true_type)’:
/usr/include/c++/14.1.1/pstl/algorithm_impl.h:3202:5: note: ‘#pragma message:  [Parallel STL message]: "Vectorized algorithm unimplemented, redirected to serial"’
 3202 |     _PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
      |     ^~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14.1.1/pstl/algorithm_impl.h: In function ‘_RandomAccessIterator3 __pstl::__internal::__brick_set_difference(_RandomAccessIterator1, _RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator2, _RandomAccessIterator3, _Compare, std::true_type)’:
/usr/include/c++/14.1.1/pstl/algorithm_impl.h:3298:5: note: ‘#pragma message:  [Parallel STL message]: "Vectorized algorithm unimplemented, redirected to serial"’
 3298 |     _PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
      |     ^~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14.1.1/pstl/algorithm_impl.h: In function ‘_RandomAccessIterator3 __pstl::__internal::__brick_set_symmetric_difference(_RandomAccessIterator1, _RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator2, _RandomAccessIterator3, _Compare, std::true_type)’:
/usr/include/c++/14.1.1/pstl/algorithm_impl.h:3390:5: note: ‘#pragma message:  [Parallel STL message]: "Vectorized algorithm unimplemented, redirected to serial"’
 3390 |     _PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
      |     ^~~~~~~~~~~~~~~~~~~~

```
</details>