### PR TITLE
Plugin row: Expand dragable area

### DIFF
--- a/data/ui/plugin_row.ui
+++ b/data/ui/plugin_row.ui
@@ -59,12 +59,18 @@
                 </child>
 
                 <child>
-                    <object class="GtkImage" id="drag_handle">
+                    <object class="GtkBox" id="drag_handle">
                         <property name="tooltip-text" translatable="yes">Change the position of this effect</property>
+                        <property name="halign">end</property>
                         <property name="valign">center</property>
-                        <property name="margin-start">8</property>
                         <property name="opacity">0</property>
-                        <property name="icon-name">ee-drag-handle-symbolic</property>
+                        <child>
+                            <object class="GtkImage">
+                                <property name="margin-start">8</property>
+                                <property name="valign">center</property>
+                                <property name="icon-name">ee-drag-handle-symbolic</property>
+                            </object>
+                        </child>
                         <property name="cursor">
                             <object class="GdkCursor">
                                 <property name="name">grab</property>


### PR DESCRIPTION
This is a quick hack to expand the dragable area of plugin rows. A thought about this reading #2889.

The drag area was only the `drag-handle` image, so you couldn't drag from the padding/margin between the bypass button and the image. Since we can click adjacent buttons even on their margin, I suppose we can drag the row even clicking on the padding of the drag area. But that wasn't possible because the drag feature was bound only on the image.

So this hack adds a box and put inside the image with a margin, so the dragable area is expanded a little bit. It should be more straightforward to understand the drag-and-drop feature since the cursor style changes soon as you enter the drag area (before it was only on the image).

Actually the best way to achieve this behavior was making the whole widget a GtkButton like the remove button. I tried it, but unfortunately the `navigation-sidebar` style class adds a left margin on the entire listview, so an additional right margin was shown which is not pleasant to see. So the previous hack is the best, even if the right margin of the drag area could not be used to drag (because it's actually the margin of the listview).         