### PR TITLE
Improve APO/GraphicEQ import/export

### DIFF
--- a/data/ui/equalizer_band.ui
+++ b/data/ui/equalizer_band.ui
@@ -7,6 +7,18 @@
         <property name="margin-bottom">6</property>
         <property name="spacing">6</property>
         <property name="orientation">vertical</property>
+
+        <child>
+            <object class="GtkLabel" id="band_number_label">
+                <property name="width-chars">8</property>
+                <property name="label">N</property>
+
+                <style>
+                    <class name="dim-label" />
+                </style>
+            </object>
+        </child>
+
         <child>
             <object class="GtkMenuButton">
                 <property name="margin-bottom">6</property>

--- a/src/equalizer_band_box.cpp
+++ b/src/equalizer_band_box.cpp
@@ -34,6 +34,8 @@
 
 namespace ui::equalizer_band_box {
 
+using namespace tags::equalizer;
+
 struct Data {
  public:
   ~Data() { util::debug("data struct destroyed"); }
@@ -56,6 +58,8 @@ struct _EqualizerBandBox {
 
   GtkPopover* popover_menu;
 
+  GtkLabel* band_number_label;
+
   GSettings *settings, *app_settings;
 
   Data* data;
@@ -65,19 +69,19 @@ struct _EqualizerBandBox {
 G_DEFINE_TYPE(EqualizerBandBox, equalizer_band_box, GTK_TYPE_BOX)
 
 void on_reset_frequency(EqualizerBandBox* self, GtkButton* btn) {
-  g_settings_reset(self->settings, tags::equalizer::band_frequency[self->data->index].data());
+  g_settings_reset(self->settings, band_frequency[self->data->index].data());
 }
 
 void on_reset_gain(EqualizerBandBox* self, GtkButton* btn) {
-  g_settings_reset(self->settings, tags::equalizer::band_gain[self->data->index].data());
+  g_settings_reset(self->settings, band_gain[self->data->index].data());
 }
 
 void on_reset_quality(EqualizerBandBox* self, GtkButton* btn) {
-  g_settings_reset(self->settings, tags::equalizer::band_q[self->data->index].data());
+  g_settings_reset(self->settings, band_q[self->data->index].data());
 }
 
 void on_reset_width(EqualizerBandBox* self, GtkButton* btn) {
-  g_settings_reset(self->settings, tags::equalizer::band_width[self->data->index].data());
+  g_settings_reset(self->settings, band_width[self->data->index].data());
 }
 
 auto set_band_label(EqualizerBandBox* self, double value) -> const char* {
@@ -129,29 +133,29 @@ void setup(EqualizerBandBox* self, GSettings* settings) {
 void bind(EqualizerBandBox* self, int index) {
   self->data->index = index;
 
-  g_settings_bind(self->settings, tags::equalizer::band_gain[index].data(),
-                  gtk_range_get_adjustment(GTK_RANGE(self->band_scale)), "value", G_SETTINGS_BIND_DEFAULT);
+  gtk_label_set_text(self->band_number_label, util::to_string(index + 1).c_str());
 
-  g_settings_bind(self->settings, tags::equalizer::band_frequency[index].data(),
-                  gtk_spin_button_get_adjustment(self->band_frequency), "value", G_SETTINGS_BIND_DEFAULT);
+  g_settings_bind(self->settings, band_gain[index].data(), gtk_range_get_adjustment(GTK_RANGE(self->band_scale)),
+                  "value", G_SETTINGS_BIND_DEFAULT);
 
-  g_settings_bind(self->settings, tags::equalizer::band_q[index].data(),
-                  gtk_spin_button_get_adjustment(self->band_quality), "value", G_SETTINGS_BIND_DEFAULT);
+  g_settings_bind(self->settings, band_frequency[index].data(), gtk_spin_button_get_adjustment(self->band_frequency),
+                  "value", G_SETTINGS_BIND_DEFAULT);
 
-  g_settings_bind(self->settings, tags::equalizer::band_width[index].data(),
-                  gtk_spin_button_get_adjustment(self->band_width), "value", G_SETTINGS_BIND_DEFAULT);
-
-  g_settings_bind(self->settings, tags::equalizer::band_solo[index].data(), self->band_solo, "active",
+  g_settings_bind(self->settings, band_q[index].data(), gtk_spin_button_get_adjustment(self->band_quality), "value",
                   G_SETTINGS_BIND_DEFAULT);
 
-  g_settings_bind(self->settings, tags::equalizer::band_mute[index].data(), self->band_mute, "active",
+  g_settings_bind(self->settings, band_width[index].data(), gtk_spin_button_get_adjustment(self->band_width), "value",
                   G_SETTINGS_BIND_DEFAULT);
 
-  ui::gsettings_bind_enum_to_combo_widget(self->settings, tags::equalizer::band_type[index].data(), self->band_type);
+  g_settings_bind(self->settings, band_solo[index].data(), self->band_solo, "active", G_SETTINGS_BIND_DEFAULT);
 
-  ui::gsettings_bind_enum_to_combo_widget(self->settings, tags::equalizer::band_mode[index].data(), self->band_mode);
+  g_settings_bind(self->settings, band_mute[index].data(), self->band_mute, "active", G_SETTINGS_BIND_DEFAULT);
 
-  ui::gsettings_bind_enum_to_combo_widget(self->settings, tags::equalizer::band_slope[index].data(), self->band_slope);
+  ui::gsettings_bind_enum_to_combo_widget(self->settings, band_type[index].data(), self->band_type);
+
+  ui::gsettings_bind_enum_to_combo_widget(self->settings, band_mode[index].data(), self->band_mode);
+
+  ui::gsettings_bind_enum_to_combo_widget(self->settings, band_slope[index].data(), self->band_slope);
 }
 
 void dispose(GObject* object) {
@@ -196,6 +200,7 @@ void equalizer_band_box_class_init(EqualizerBandBoxClass* klass) {
   gtk_widget_class_bind_template_child(widget_class, EqualizerBandBox, band_quality);
   gtk_widget_class_bind_template_child(widget_class, EqualizerBandBox, band_width);
   gtk_widget_class_bind_template_child(widget_class, EqualizerBandBox, popover_menu);
+  gtk_widget_class_bind_template_child(widget_class, EqualizerBandBox, band_number_label);
 
   gtk_widget_class_bind_template_callback(widget_class, on_reset_frequency);
   gtk_widget_class_bind_template_callback(widget_class, on_reset_gain);


### PR DESCRIPTION

* Added gsettings key range check for double/float values inside APO/GEQ import. I don't like this, the functions are now very complex because of this implementation, but it's the only way to make a check on valid values. Besides I suspect native gsettings is only emitting a warning on out of bounds values, but on Flatpak it may crash directly because the settings engine is different. If this is the case, those key checks will fix a big issue on that platform.  

* Since `band_width` affect the spectrum of the selected band depending on the filter type chosen, I reset it at the default on APO/GEQ preset import. Maybe this value should be properly calculated on every filter, but we don't know how to do it. So at the moment the best thing to do is to reset it to the default, avoiding to change the result depending on which previous value the user set.
* Reset `band_width` also inside `on_calculate_frequencies`. This seems a good thing to do since `band_width` affects the band spectrum, but maybe I could be wrong here. @wwmm What do you think?

* Reset `input-gain` on GEQ import. APO import always sets the preamp (0 db if not specified). But if we import an APO preset with a specific preamp and then import a GEQ preset, we retain the previous input gain, which I think it's not what we expect. GEQ does not have a preamp control, so I assume it's always 0 db by default.

* Improved APO preset parsing. The best thing to do is to follow this algorithm: https://github.com/lsp-plugins/lsp-plugins-para-equalizer/blob/master/src/main/ui/para_equalizer.cpp#L1502 - Which sets a specific quality or frequency on certain filters, no matter which is the value inside the preset file.

* Added the Band-Pass filter in the APO preset parsing. This is not present in the LSP algorithm, but we may add it anyway. @wwmm Any suggestion here?

* `EasyEffectsToApoFilter` and `ApoToEasyEffectsFilter` converted to maps. There's no real reason to use them as unordered maps. Besides the EasyEffectsToApoFilter was specifying the same LSP EQ filter multiple times which is useless. It makes sense to traslate LSP filters only to APO filters that have center frequencies.

* In APO export, write the gain value only for filters that need it. See APO config documentation:  https://sourceforge.net/p/equalizerapo/wiki/Configuration%20reference/#filter - The gain is mandatory only for Peak, Low-Shelf and High-Shelf filters.

* Use `tags::equalizer` namespace on the entire files so we don't have to specify it multiple times.

* Added number label on top of each bands inside Equalizer UI. This may seem unnecessary, but I think it's very useful. When I was testing the import feature, comparing APO presets bands with the results in the UI was not so easy because sometimes I had to count the bands. Indeed if the user has a big number of bands, looking at one in the center it's not easy for them to know which is the number of the chosen band. With a label on top, it's more straightforward.

And at the last I'd like to point out that I'm a bit skeptical on the use of `band-mute` in APO import. At the moment the APO OFF value sets the `band-mute`, but is it really the same? OFF means the band is not processed, so we still hear it, right? Which is different from the muting which is just emitting silence, I guess? Maybe like band gain to `-infinite`. Maybe it should be better to set `band-type` on Off when APO OFF is specified. The problem seems that APO does not have a concept of "muting the band". @wwmm What do you think?  