### PR TITLE
APO import: Do not consider band mute to determine band type

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -49,7 +49,7 @@ auto prepare_debug_message(const std::string& message, source_location location)
 
   std::ostringstream msg_stream;
 
-  msg_stream << "\t" << file_path.filename().string() << ":" << location.line() << "\t" << message;
+  msg_stream << "\t" << file_path.filename().string() << ":" << to_string(location.line()) << "\t" << message;
 
   return msg_stream.str();
 }

--- a/util/NEWS.yaml
+++ b/util/NEWS.yaml
@@ -6,11 +6,13 @@ Description:
 - Features∶
 - Community Presets have been implemented. Users can install packages containing multiple Easy Effects presets to be imported and applied inside the application. These packages will be maintained and shipped by volunteers. You can search them on the repositories of your favorite distribution.
 - Added the ability of collapsing the sidebar to hide the effects list and expand the area of the effects user interface.
-- EasyEffects won't touch streams that define `PW_KEY_TARGET_OBJECT` to an output device that is different from the one EE is using.
+- EasyEffects won't touch streams that define `PW_KEY_TARGET_OBJECT` to an output device that is different from the one EasyEffects is using.
+- Equalizer APO import feature can now apply Band-Pass filters.
 
 - Bug fixes∶
 - A change in GTK 4.14.1 prevented to apply the values inserted into the text field of our SpinButton widgets. This issue is now resolved.
-- The latest maximizer plugin releases do not have the ceiling port anymore. So we removed it from our window. 
+- The latest Maximizer plugin releases do not have the ceiling control anymore. So we removed it from our user interface (you can use the plugin input gain to retrieve the same functionality).
+- Equalizer APO import feature does not crash anymore on Flatpak when invalid values are provided.
 
 - Other notes∶
 - In order for Community Presets to be correctly shipped, packagers are invited to read and follow the guidelines linked inside the README of EasyEffects master branch.
@@ -347,7 +349,7 @@ Description:
 - When no application is available for display in the `Players/Recorders` a message will be shown to the user
 - Many translation updates
 - Bug fixes∶
-- Fixed a bug where EasyEffeects crashed when the number of points displayed in the spectrum was changed while our pipeline was active and the spectrum widget was visible
+- Fixed a bug where EasyEffects crashed when the number of points displayed in the spectrum was changed while our pipeline was active and the spectrum widget was visible
 - The pipeline latency value displayed in our window could be wrong in some situations. This was fixed.
 
 ---


### PR DESCRIPTION
Since APO does not have the concept of `band_mute`, we do not mute the LSP EQ band when APO band state is OFF. In APO config, OFF means that the band is disabled, so we just import `band_type` = `Off`.

On APO export feature, we just skip `band_type` = `Off` because we cannot determine the APO filter type, but this is not a big issue since the band is disabled/not used.

With this one, I think we are ready for the release.