### PR TITLE
Optimise spectrum's realtime code

### DIFF
--- a/include/spectrum.hpp
+++ b/include/spectrum.hpp
@@ -66,4 +66,6 @@ class Spectrum : public PluginBase {
   uint n_bands = 8192U;
 
   std::deque<float> deque_in_mono;
+
+  std::vector<float> hann_window;
 };

--- a/include/spectrum.hpp
+++ b/include/spectrum.hpp
@@ -65,7 +65,7 @@ class Spectrum : public PluginBase {
 
   uint n_bands = 8192U;
 
-  std::deque<float> deque_in_mono;
+  std::vector<float> latest_samples_mono;
 
   std::vector<float> hann_window;
 };

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -46,6 +46,14 @@ Spectrum::Spectrum(const std::string& tag,
   real_input.resize(n_bands);
   output.resize(n_bands / 2U + 1U);
 
+  // Precompute the Hann window, which is an expensive operation.
+  // https://en.wikipedia.org/wiki/Hann_function
+  hann_window.resize(n_bands);
+  for (size_t n = 0; n < n_bands; n++) {
+    hann_window[n] = 0.5F * (1.0F - std::cos(2.0F * std::numbers::pi_v<float> *
+        static_cast<float>(n) / static_cast<float>(n_bands-1)));
+  }
+
   complex_output = fftwf_alloc_complex(n_bands);
 
   plan = fftwf_plan_dft_r2c_1d(static_cast<int>(n_bands), real_input.data(), complex_output, FFTW_ESTIMATE);
@@ -116,12 +124,7 @@ void Spectrum::process(std::span<float>& left_in,
   assert(deque_in_mono.size() >= n_bands);
 
   for (size_t n = 0; n < n_bands; n++) {
-    // https://en.wikipedia.org/wiki/Hann_function
-
-    const float w = 0.5F * (1.0F - std::cos(2.0F * std::numbers::pi_v<float> * static_cast<float>(n) /
-                                            static_cast<float>(n_bands - 1U)));
-
-    real_input[n] = deque_in_mono[n] * w;
+    real_input[n] = deque_in_mono[n] * hann_window[n];
   }
 
   size_t count = 0U;

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -46,6 +46,8 @@ Spectrum::Spectrum(const std::string& tag,
   real_input.resize(n_bands);
   output.resize(n_bands / 2U + 1U);
 
+  latest_samples_mono.resize(n_bands);
+
   // Precompute the Hann window, which is an expensive operation.
   // https://en.wikipedia.org/wiki/Hann_function
   hann_window.resize(n_bands);
@@ -87,21 +89,8 @@ Spectrum::~Spectrum() {
 }
 
 void Spectrum::setup() {
-  deque_in_mono.resize(0U);
-
   std::ranges::fill(real_input, 0.0F);
-
-  /*
-    real_input size is hardcoded to 8192. THe same maxium buffer size hardcoded in PipeWire
-    https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/master/src/pipewire/filter.c#L48. If we reevei a smaller
-    array we have to insert some zeros in the beginning.
-  */
-
-  if (n_samples < real_input.size()) {
-    while (deque_in_mono.size() != real_input.size() - n_samples) {
-      deque_in_mono.push_back(0.0F);
-    }
-  }
+  std::ranges::fill(latest_samples_mono, 0.0F);
 }
 
 void Spectrum::process(std::span<float>& left_in,
@@ -117,22 +106,23 @@ void Spectrum::process(std::span<float>& left_in,
     return;
   }
 
-  for (uint n = 0U; n < left_in.size(); n++) {
-    deque_in_mono.push_back(0.5F * (left_in[n] + right_in[n]));
-  }
+  if (n_samples < n_bands) {
+    // Drop the oldest quantum.
+    for (size_t n = 0; n < n_bands - n_samples; n++)
+      latest_samples_mono[n] = latest_samples_mono[n_samples + n];
 
-  assert(deque_in_mono.size() >= n_bands);
+    // Copy the new quantum.
+    for (size_t n = 0; n < n_samples; n++)
+      latest_samples_mono[n_bands - n_samples + n] = 0.5F * (left_in[n] + right_in[n]);
+  } else {
+    // Copy the latest n_bands samples.
+    for (size_t n = 0; n < n_bands; n++)
+      latest_samples_mono[n] = 0.5F * (left_in[n_samples - n_bands + n] +
+                                       right_in[n_samples - n_bands + n]);
+  }
 
   for (size_t n = 0; n < n_bands; n++) {
-    real_input[n] = deque_in_mono[n] * hann_window[n];
-  }
-
-  size_t count = 0U;
-
-  while (count < n_samples && !deque_in_mono.empty()) {
-    deque_in_mono.pop_front();
-
-    count++;
+    real_input[n] = latest_samples_mono[n] * hann_window[n];
   }
 
   if (send_notifications) {

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -24,6 +24,7 @@
 #include <glib.h>
 #include <sys/types.h>
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <mutex>
@@ -112,15 +113,15 @@ void Spectrum::process(std::span<float>& left_in,
     deque_in_mono.push_back(0.5F * (left_in[n] + right_in[n]));
   }
 
-  for (size_t n = 0; n < deque_in_mono.size(); n++) {
-    if (n < real_input.size()) {
-      // https :  // en.wikipedia.org/wiki/Hann_function
+  assert(deque_in_mono.size() >= n_bands);
 
-      const float w = 0.5F * (1.0F - std::cos(2.0F * std::numbers::pi_v<float> * static_cast<float>(n) /
-                                              static_cast<float>(real_input.size() - 1U)));
+  for (size_t n = 0; n < n_bands; n++) {
+    // https://en.wikipedia.org/wiki/Hann_function
 
-      real_input[n] = deque_in_mono[n] * w;
-    }
+    const float w = 0.5F * (1.0F - std::cos(2.0F * std::numbers::pi_v<float> * static_cast<float>(n) /
+                                            static_cast<float>(n_bands - 1U)));
+
+    real_input[n] = deque_in_mono[n] * w;
   }
 
   size_t count = 0U;


### PR DESCRIPTION
The goal of this pull request is to reduce the amount of work done by spectrum in the realtime thread, ie its `Spectrum::process()` function.

This is a good optimization target because it runs on all EE instances that have a window attached. It highlighted many xruns on a user's desktop, see #3224.

Commit messages provide information about what is being done.

---

@wwmm I've reworked the code filling the new `std::vector` to handle the `n_samples > n_bands` edge-case. I've tested it with 8192 and 16384 quantums. 8192 works fine but is standard code. 16384 is interesting (others don't work, my soundcard wants powers of two):
 - The sound source (tested `pw-play` and a PulseAudio client) is emitting glitched audio (about 70% periods of silence, rest is working). EE does follow along, showing frames when there is audio coming in.
 - EE ends up crashing by sefault inside `__memcpy_avx_unaligned_erms` that is generated by `std::copy()` at the start of `Spectrum::process()`. I'm not seeing any bug in EE code so I think the buffer pointer given by `pw_filter_get_dsp_buffer()` is corrupted. I've not digged deeper though.
 - Anyway, a spectrum updated 3 times per second would not be really useful.

Conclusion: >8192 quantums do not look supported by PW (v1.2.0) and we don't behave too badly.

---

With all three patches applied (only 2 and 3 give perf improvements), the performance delta is something like this on my machine.

```
         Before      After
avg (µs)    183.1       50.7
stdev        29.0       13.8
min          43         13
5th perc    131         30
25th perc   170         43
median      182         51
75th perc   200         58
95th perc   226         75
max         365        106
```

---

<details>

<summary>Getting benchmark data</summary>

To record data, I do the following (with [this `stats` script](https://git.sr.ht/~tleb/bin/tree/3c7d0281fb9057b595cec5cbcc26340f4ee13243/item/stats)):

```
⟩ # Record data, I usually wait for the "15 seconds" message
⟩ pw-profiler
Logging to profiler.log
Attaching to Profiler id:5
logging driver 50
logging follower 59 ("ee_soe_output_level")
logging follower 110 ("ee_soe_spectrum")
logging follower 94 ("easyeffects_sink")
logging follower 36 ("Firefox")
logging 1504 samples  15 seconds [CPU 0.092090 0.107868^C 0.108057]
dumping scripts for 4 followers
run 'sh generate_timings.sh' and load Timings.html in a browser

⟩ # Now find the interesting column, here column 18
⟩ grep spectrum Timing5.plot
plot "profiler.log" using 10 title "ee_soe_output_level/59" with lines,
"profiler.log" using 18 title "ee_soe_spectrum/110" with lines,
"profiler.log" using 26 title "easyeffects_sink/94" with lines,
"profiler.log" using 34 title "Firefox/36" with lines

⟩ # And compute statistics
⟩ cut -f18 profiler.log | stats
cnt        1539
avg          50.7
stdev        13.8

min          13.0
5th perc     30.0
25th perc    43.0
median       51.0
75th perc    58.0
95th perc    75.0
max         106.0
```

</details>