### PR TITLE
spectrum: use gtk tick callback to trigger spectrum redraws

### DIFF
--- a/include/plugin_base.hpp
+++ b/include/plugin_base.hpp
@@ -21,6 +21,7 @@
 
 #include <gio/gio.h>
 #include <glib.h>
+#include <atomic>
 #include <pipewire/filter.h>
 #include <sigc++/signal.h>
 #include <spa/utils/hook.h>
@@ -91,7 +92,8 @@ class PluginBase {
 
   bool package_installed = true;
 
-  bool bypass = false;
+  std::atomic<bool> bypass = {false};
+  static_assert(std::atomic<bool>::is_always_lock_free);
 
   bool connected_to_pw = false;
 

--- a/include/spectrum.hpp
+++ b/include/spectrum.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <fftw3.h>
 #include <sigc++/signal.h>
 #include <sys/types.h>
@@ -51,7 +52,7 @@ class Spectrum : public PluginBase {
 
   auto get_latency_seconds() -> float override;
 
-  sigc::signal<void(uint, uint, double*)> power;  // rate, nbands, magnitudes
+  std::tuple<uint, uint, double*> compute_magnitudes();  // rate, nbands, magnitudes
 
  private:
   std::atomic<bool> fftw_ready = false;
@@ -68,4 +69,14 @@ class Spectrum : public PluginBase {
   std::array<float, n_bands> latest_samples_mono;
 
   std::array<float, n_bands> hann_window;
+
+  enum {
+    DB_BIT_IDX = (1 << 0),      // To which db_buffers array process() should write.
+    DB_BIT_NEWDATA = (1 << 1),  // If new data has been written by process().
+    DB_BIT_BUSY = (1 << 2),     // If process() is currently writing data.
+  };
+
+  std::array<std::array<float, n_bands>, 2> db_buffers;
+  std::atomic<int> db_control = {0};
+  static_assert(std::atomic<int>::is_always_lock_free);
 };

--- a/include/spectrum.hpp
+++ b/include/spectrum.hpp
@@ -63,9 +63,9 @@ class Spectrum : public PluginBase {
   std::vector<float> real_input;
   std::vector<double> output;
 
-  uint n_bands = 8192U;
+  static constexpr uint n_bands = 8192U;
 
-  std::vector<float> latest_samples_mono;
+  std::array<float, n_bands> latest_samples_mono;
 
   std::vector<float> hann_window;
 };

--- a/include/spectrum.hpp
+++ b/include/spectrum.hpp
@@ -60,10 +60,10 @@ class Spectrum : public PluginBase {
 
   fftwf_complex* complex_output = nullptr;
 
-  std::vector<float> real_input;
-  std::vector<double> output;
-
   static constexpr uint n_bands = 8192U;
+
+  std::array<float, n_bands> real_input;
+  std::vector<double> output;
 
   std::array<float, n_bands> latest_samples_mono;
 

--- a/include/spectrum.hpp
+++ b/include/spectrum.hpp
@@ -51,7 +51,7 @@ class Spectrum : public PluginBase {
 
   auto get_latency_seconds() -> float override;
 
-  sigc::signal<void(uint, uint, std::vector<double>)> power;  // rate, nbands, magnitudes
+  sigc::signal<void(uint, uint, double*)> power;  // rate, nbands, magnitudes
 
  private:
   bool fftw_ready = false;
@@ -63,7 +63,7 @@ class Spectrum : public PluginBase {
   static constexpr uint n_bands = 8192U;
 
   std::array<float, n_bands> real_input;
-  std::vector<double> output;
+  std::array<double, n_bands / 2U + 1U> output;
 
   std::array<float, n_bands> latest_samples_mono;
 

--- a/include/spectrum.hpp
+++ b/include/spectrum.hpp
@@ -67,5 +67,5 @@ class Spectrum : public PluginBase {
 
   std::array<float, n_bands> latest_samples_mono;
 
-  std::vector<float> hann_window;
+  std::array<float, n_bands> hann_window;
 };

--- a/include/spectrum.hpp
+++ b/include/spectrum.hpp
@@ -54,7 +54,7 @@ class Spectrum : public PluginBase {
   sigc::signal<void(uint, uint, double*)> power;  // rate, nbands, magnitudes
 
  private:
-  bool fftw_ready = false;
+  std::atomic<bool> fftw_ready = false;
 
   fftwf_plan plan = nullptr;
 

--- a/src/effects_box.cpp
+++ b/src/effects_box.cpp
@@ -396,7 +396,7 @@ void setup(EffectsBox* self, app::Application* application, PipelineType pipelin
   // spectrum array
 
   self->data->connections.push_back(
-      self->data->effects_base->spectrum->power.connect([=](uint rate, uint n_bands, std::vector<double> magnitudes) {
+      self->data->effects_base->spectrum->power.connect([=](uint rate, uint n_bands, double *magnitudes) {
         if (self == nullptr) {
           return;
         }
@@ -419,7 +419,7 @@ void setup(EffectsBox* self, app::Application* application, PipelineType pipelin
         auto* acc = gsl_interp_accel_alloc();
         auto* spline = gsl_spline_alloc(gsl_interp_steffen, n_bands);
 
-        gsl_spline_init(spline, self->data->spectrum_freqs.data(), magnitudes.data(), n_bands);
+        gsl_spline_init(spline, self->data->spectrum_freqs.data(), magnitudes, n_bands);
 
         for (size_t n = 0; n < self->data->spectrum_x_axis.size(); n++) {
           self->data->spectrum_mag[n] =

--- a/src/effects_box.cpp
+++ b/src/effects_box.cpp
@@ -294,6 +294,58 @@ void on_listen_mic_toggled(EffectsBox* self, GtkToggleButton* button) {
   self->data->application->sie->set_listen_to_mic(gtk_toggle_button_get_active(button) != 0);
 }
 
+static gboolean
+spectrum_data_update(GtkWidget* widget, GdkFrameClock* frame_clock, EffectsBox* self) {
+  if (!ui::chart::get_is_visible(self->spectrum_chart)) {
+    return G_SOURCE_CONTINUE;
+  }
+
+  if (!schedule_signal_idle) {
+    return G_SOURCE_CONTINUE;
+  }
+
+  auto [rate, n_bands, magnitudes] = self->data->effects_base->spectrum->compute_magnitudes();
+
+  // No new data available, no redraw required.
+  if (rate == 0 || n_bands == 0) {
+    return G_SOURCE_CONTINUE;
+  }
+
+  if (self->data->spectrum_rate != rate || self->data->spectrum_n_bands != n_bands) {
+    self->data->spectrum_rate = rate;
+    self->data->spectrum_n_bands = n_bands;
+
+    init_spectrum_frequency_axis(self);
+  }
+
+  auto* acc = gsl_interp_accel_alloc();
+  auto* spline = gsl_spline_alloc(gsl_interp_steffen, n_bands);
+
+  gsl_spline_init(spline, self->data->spectrum_freqs.data(), magnitudes, n_bands);
+
+  for (size_t n = 0; n < self->data->spectrum_x_axis.size(); n++) {
+    self->data->spectrum_mag[n] =
+        static_cast<float>(gsl_spline_eval(spline, self->data->spectrum_x_axis[n], acc));
+  }
+
+  gsl_spline_free(spline);
+  gsl_interp_accel_free(acc);
+
+  std::ranges::for_each(self->data->spectrum_mag, [](auto& v) {
+    v = 10.0F * std::log10(v);
+
+    if (!std::isinf(v)) {
+      v = (v > util::minimum_db_level) ? v : util::minimum_db_level;
+    } else {
+      v = util::minimum_db_level;
+    }
+  });
+
+  ui::chart::set_y_data(self->spectrum_chart, self->data->spectrum_mag);
+
+  return G_SOURCE_CONTINUE;
+}
+
 void setup(EffectsBox* self, app::Application* application, PipelineType pipeline_type, GtkIconTheme* icon_theme) {
   self->data->application = application;
   self->data->pipeline_type = pipeline_type;
@@ -395,52 +447,8 @@ void setup(EffectsBox* self, app::Application* application, PipelineType pipelin
 
   // spectrum array
 
-  self->data->connections.push_back(
-      self->data->effects_base->spectrum->power.connect([=](uint rate, uint n_bands, double *magnitudes) {
-        if (self == nullptr) {
-          return;
-        }
-
-        if (!ui::chart::get_is_visible(self->spectrum_chart)) {
-          return;
-        }
-
-        if (!schedule_signal_idle) {
-          return;
-        }
-
-        if (self->data->spectrum_rate != rate || self->data->spectrum_n_bands != n_bands) {
-          self->data->spectrum_rate = rate;
-          self->data->spectrum_n_bands = n_bands;
-
-          init_spectrum_frequency_axis(self);
-        }
-
-        auto* acc = gsl_interp_accel_alloc();
-        auto* spline = gsl_spline_alloc(gsl_interp_steffen, n_bands);
-
-        gsl_spline_init(spline, self->data->spectrum_freqs.data(), magnitudes, n_bands);
-
-        for (size_t n = 0; n < self->data->spectrum_x_axis.size(); n++) {
-          self->data->spectrum_mag[n] =
-              static_cast<float>(gsl_spline_eval(spline, self->data->spectrum_x_axis[n], acc));
-        }
-
-        gsl_spline_free(spline);
-        gsl_interp_accel_free(acc);
-
-        std::ranges::for_each(self->data->spectrum_mag, [](auto& v) {
-          v = 10.0F * std::log10(v);
-
-          if (!std::isinf(v)) {
-            v = (v > util::minimum_db_level) ? v : util::minimum_db_level;
-          } else {
-            v = util::minimum_db_level;
-          }
-        });
-
-        ui::chart::set_y_data(self->spectrum_chart, self->data->spectrum_mag);
-      }));
+  gtk_widget_add_tick_callback(GTK_WIDGET(self->spectrum_chart), (GtkTickCallback)spectrum_data_update,
+                               self, NULL);
 
   // As we are showing the window we want the filters to send notifications about level meters, etc
 

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -43,8 +43,6 @@ Spectrum::Spectrum(const std::string& tag,
                    PipelineType pipe_type)
     : PluginBase(tag, "spectrum", tags::plugin_package::ee, schema, schema_path, pipe_manager, pipe_type),
       fftw_ready(true) {
-  output.resize(n_bands / 2U + 1U);
-
   // Precompute the Hann window, which is an expensive operation.
   // https://en.wikipedia.org/wiki/Hann_function
   for (size_t n = 0; n < n_bands; n++) {
@@ -137,7 +135,7 @@ void Spectrum::process(std::span<float>& left_in,
         output[i] = static_cast<double>(sqr);
       }
 
-      power.emit(rate, output.size(), output);
+      power.emit(rate, output.size(), output.data());
     });
   }
 }

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -27,6 +27,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstddef>
+#include <cstring>
 #include <mutex>
 #include <numbers>
 #include <span>
@@ -96,8 +97,8 @@ void Spectrum::process(std::span<float>& left_in,
 
   if (n_samples < n_bands) {
     // Drop the oldest quantum.
-    for (size_t n = 0; n < n_bands - n_samples; n++)
-      latest_samples_mono[n] = latest_samples_mono[n_samples + n];
+    std::memmove(&latest_samples_mono[0], &latest_samples_mono[n_samples],
+        (n_bands - n_samples) * sizeof(float));
 
     // Copy the new quantum.
     for (size_t n = 0; n < n_samples; n++)

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -57,8 +57,6 @@ Spectrum::Spectrum(const std::string& tag,
   g_signal_connect(settings, "changed::show", G_CALLBACK(+[](GSettings* settings, char* key, gpointer user_data) {
                      auto* self = static_cast<Spectrum*>(user_data);
 
-                     std::scoped_lock<std::mutex> lock(self->data_mutex);
-
                      self->bypass = g_settings_get_boolean(settings, key) == 0;
                    }),
                    this);
@@ -68,8 +66,6 @@ Spectrum::~Spectrum() {
   if (connected_to_pw) {
     disconnect_from_pw();
   }
-
-  std::scoped_lock<std::mutex> lock(data_mutex);
 
   fftw_ready = false;
 
@@ -91,8 +87,6 @@ void Spectrum::process(std::span<float>& left_in,
                        std::span<float>& right_in,
                        std::span<float>& left_out,
                        std::span<float>& right_out) {
-  std::scoped_lock<std::mutex> lock(data_mutex);
-
   std::copy(left_in.begin(), left_in.end(), left_out.begin());
   std::copy(right_in.begin(), right_in.end(), right_out.begin());
 

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -43,7 +43,6 @@ Spectrum::Spectrum(const std::string& tag,
                    PipelineType pipe_type)
     : PluginBase(tag, "spectrum", tags::plugin_package::ee, schema, schema_path, pipe_manager, pipe_type),
       fftw_ready(true) {
-  real_input.resize(n_bands);
   output.resize(n_bands / 2U + 1U);
 
   // Precompute the Hann window, which is an expensive operation.

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -46,8 +46,6 @@ Spectrum::Spectrum(const std::string& tag,
   real_input.resize(n_bands);
   output.resize(n_bands / 2U + 1U);
 
-  latest_samples_mono.resize(n_bands);
-
   // Precompute the Hann window, which is an expensive operation.
   // https://en.wikipedia.org/wiki/Hann_function
   hann_window.resize(n_bands);

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -110,29 +110,51 @@ void Spectrum::process(std::span<float>& left_in,
                                        right_in[n_samples - n_bands + n]);
   }
 
+  // Grab the current index AND mark as busy at the same time.
+  int index = db_control.fetch_or(DB_BIT_BUSY) & DB_BIT_IDX;
+
+  // Fill the buffer.
+  db_buffers[index] = latest_samples_mono;
+
+  // Mark new data available AND mark as not busy anymore.
+  db_control.store(index | DB_BIT_NEWDATA);
+}
+
+std::tuple<uint, uint, double*> Spectrum::compute_magnitudes() {
+  // Early return if no new data is available, ie if process() has not been
+  // called since our last compute_magnitudes() call.
+  int curr_control = db_control.load();
+  if (!(curr_control & DB_BIT_NEWDATA)) {
+    return std::tuple<uint, uint, double*>(0, 0, nullptr);
+  }
+
+  // CAS loop to toggle the buffer used and remove NEWDATA flag, waiting for !BUSY.
+  int next_control;
+  do {
+    curr_control &= ~DB_BIT_BUSY;
+    next_control = (curr_control ^ DB_BIT_IDX) & DB_BIT_IDX;
+  } while (!db_control.compare_exchange_weak(curr_control, next_control));
+
+  // Buffer with data is at the index which was found inside db_control.
+  int index = curr_control & DB_BIT_IDX;
+  float *buf = db_buffers[index].data();
+
+  // https://en.wikipedia.org/wiki/Hann_function
   for (size_t n = 0; n < n_bands; n++) {
-    real_input[n] = latest_samples_mono[n] * hann_window[n];
+    real_input[n] = buf[n] * hann_window[n];
   }
 
-  if (send_notifications) {
-    util::idle_add([this]() {
-      if (bypass) {
-        return;
-      }
+  fftwf_execute(plan);
 
-      fftwf_execute(plan);
+  for (uint i = 0U; i < output.size(); i++) {
+    float sqr = complex_output[i][0] * complex_output[i][0] + complex_output[i][1] * complex_output[i][1];
 
-      for (uint i = 0U; i < output.size(); i++) {
-        float sqr = complex_output[i][0] * complex_output[i][0] + complex_output[i][1] * complex_output[i][1];
+    sqr /= static_cast<float>(output.size() * output.size());
 
-        sqr /= static_cast<float>(output.size() * output.size());
-
-        output[i] = static_cast<double>(sqr);
-      }
-
-      power.emit(rate, output.size(), output.data());
-    });
+    output[i] = static_cast<double>(sqr);
   }
+
+  return std::tuple<uint, uint, double*>(rate, output.size(), output.data());
 }
 
 auto Spectrum::get_latency_seconds() -> float {

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -48,7 +48,6 @@ Spectrum::Spectrum(const std::string& tag,
 
   // Precompute the Hann window, which is an expensive operation.
   // https://en.wikipedia.org/wiki/Hann_function
-  hann_window.resize(n_bands);
   for (size_t n = 0; n < n_bands; n++) {
     hann_window[n] = 0.5F * (1.0F - std::cos(2.0F * std::numbers::pi_v<float> *
         static_cast<float>(n) / static_cast<float>(n_bands-1)));


### PR DESCRIPTION
Related issue: #3224. Related previous PR: #3231.

I have written all informations inside commit messages. The last one is the bulk of the series.

 - We start by some cleanup: we switch all `std::vector` in Spectrum to being arrays. This avoids `.resize()` calls inside the constructor. The goal is simpler code, it is not an optimization.
 - We then switch `PluginBase::bypass` to become atomic. This allows removing the `data_mutex` locking in `Spectrum`.
 - We switch `fftw_ready` to become atomic as well.
 - We use `std::memmove()` to shift previous samples. This improves the average time spent inside `process()`.
 - We finish by switching the main patch. It changes the way spectrum chart redraw is being scheduled.

After this patch series, `Spectrum::process()` does not appear anymore in a `perf` recording, and we get a 60FPS (or more depending on display) spectrum chart.

---

Some stats on my workstation. 256 quantum, 48kHz sample rate, ran 45 seconds, no other load.

```
           before      after
calls        8912       8923
avg (µs)       65.0       34.2
stdev          16.9        7.6
min             0.0        7.0
5th perc       39.0       20.0
25th perc      54.0       29.0
median         69.0       35.0
75th perc      74.0       40.0
95th perc      82.0       43.0
max           151.0      127.0
```

---

I use this small patch to dump chart redraw interval timings:

<details>
```diff
diff --git a/src/chart.cpp b/src/chart.cpp
index 8e9d53b13..91f609905 100644
--- a/src/chart.cpp
+++ b/src/chart.cpp
@@ -249,6 +249,8 @@ void set_x_data(Chart* self, const std::vector<double>& x) {
   });
 }

+static gint64 time_since_last_drawing;
+
 void set_y_data(Chart* self, const std::vector<double>& y) {
   if (!GTK_IS_WIDGET(self) || y.empty()) {
     return;
@@ -280,6 +282,10 @@ void set_y_data(Chart* self, const std::vector<double>& y) {
   }

   gtk_widget_queue_draw(GTK_WIDGET(self));
+
+  gint64 time = g_get_monotonic_time();
+  printf("%.0f ms\n", (double)(time - time_since_last_drawing) / (1e3));
+  time_since_last_drawing = time;
 }

 void on_pointer_motion(GtkEventControllerMotion* controller, double xpos, double ypos, Chart* self) {
```
</details>