### PR TITLE
LV2 wrapper performance improvements

### DIFF
--- a/include/lv2_wrapper.hpp
+++ b/include/lv2_wrapper.hpp
@@ -280,6 +280,12 @@ class Lv2Wrapper {
 
   std::vector<Port> ports;
 
+  struct {
+    struct { uint left, right; } in;
+    struct { uint left, right; } probe;
+    struct { uint left, right; } out;
+  } data_ports;
+
   std::vector<std::function<void()>> gsettings_sync_funcs;
 
   std::unordered_map<std::string, LV2_URID> map_uri_to_urid;

--- a/include/lv2_wrapper.hpp
+++ b/include/lv2_wrapper.hpp
@@ -280,6 +280,9 @@ class Lv2Wrapper {
 
   std::vector<Port> ports;
 
+  // Multiband compressor/gate use 1+8*7=57 control ports. Round up to 64.
+  std::array<std::pair<size_t, uint>, 64> control_ports_cache;
+
   struct {
     struct { uint left, right; } in;
     struct { uint left, right; } probe;


### PR DESCRIPTION
Hi, two small improvements for the LV2 wrapper used by a lot of plugins.

When using perf, I noticed LV2 port related functions were appearing at the top (for the realtime thread, ignoring library code). This is odd because they do no sample processing. The bulk is that LV2 exposes many ports (735 for equalizer for example), and we iterate over them at each `process()`.

For data ports, there is a small number so we store indexes into class fields.

For control, there could be two solutions (or more?):
 - Have each `Lv2Wrapper` user store a field of the index for each port. That would require to update each plugin using `Lv2Wrapper` in three ways: (1) add field(s) in class, (2) add code in the probe to grab the index(es) and (3) update calls to a new overload function like `float Lv2Wrapper::get_control_port_value(uint index)`.
 - Or we could modify `Lv2Wrapper::get_control_port_value()` to minimise work. Approach taken is to store a cache of port indexes based on symbol (string) hash. We never update the cache, the first 64 unique calls define what is stored inside of it. This is fine as all calls are done using a fixed number of strings. Most are with compile-time known. Some (multiband compressor/gate) iterate with `0 <= n < 8` and lookup 7 control ports per band. We could add a warning as the cache should never be full; is there a `printf_ratelimited()` or something?

We don't need to do the same thing for `LadspaWrapper` because its only user (`DeepFilterNet`) uses a plugin with only 30 ports. Iterating over 30 entries is fine (1/6th the time of `PluginBase::get_peaks`).