### PR TITLE
spectrum compensating delay (av sync)

### DIFF
--- a/include/spectrum.hpp
+++ b/include/spectrum.hpp
@@ -70,6 +70,7 @@ class Spectrum : public PluginBase {
   std::array<float, n_bands> right_delay_input_array;
   std::span<float> left_delay_input;
   std::span<float> right_delay_input;
+  
   std::array<float, n_bands> left_delayed_array;
   std::array<float, n_bands> right_delayed_array;
   std::span<float> left_delayed;

--- a/include/spectrum.hpp
+++ b/include/spectrum.hpp
@@ -66,8 +66,10 @@ class Spectrum : public PluginBase {
   std::array<float, n_bands> real_input;
   std::array<double, n_bands / 2U + 1U> output;
 
-  std::array<float, n_bands> left_delayed;
-  std::array<float, n_bands> right_delayed;
+  std::array<float, n_bands> left_delayed_array;
+  std::array<float, n_bands> right_delayed_array;
+  std::span<float> left_delayed;
+  std::span<float> right_delayed;
 
   std::array<float, n_bands> latest_samples_mono;
 

--- a/include/spectrum.hpp
+++ b/include/spectrum.hpp
@@ -66,6 +66,10 @@ class Spectrum : public PluginBase {
   std::array<float, n_bands> real_input;
   std::array<double, n_bands / 2U + 1U> output;
 
+  std::array<float, n_bands> left_delay_input_array;
+  std::array<float, n_bands> right_delay_input_array;
+  std::span<float> left_delay_input;
+  std::span<float> right_delay_input;
   std::array<float, n_bands> left_delayed_array;
   std::array<float, n_bands> right_delayed_array;
   std::span<float> left_delayed;

--- a/include/spectrum.hpp
+++ b/include/spectrum.hpp
@@ -66,10 +66,8 @@ class Spectrum : public PluginBase {
   std::array<float, n_bands> real_input;
   std::array<double, n_bands / 2U + 1U> output;
 
-  std::array<float, n_bands> left_delayed_array;
-  std::array<float, n_bands> right_delayed_array;
-  std::span<float> left_delayed(left_delayed_array);
-  std::span<float> right_delayed(right_delayed_array);
+  std::array<float, n_bands> left_delayed;
+  std::array<float, n_bands> right_delayed;
 
   std::array<float, n_bands> latest_samples_mono;
 

--- a/include/spectrum.hpp
+++ b/include/spectrum.hpp
@@ -66,6 +66,11 @@ class Spectrum : public PluginBase {
   std::array<float, n_bands> real_input;
   std::array<double, n_bands / 2U + 1U> output;
 
+  std::array<float, n_bands> left_delayed_array;
+  std::array<float, n_bands> right_delayed_array;
+  std::span<float> left_delayed(left_delayed_array);
+  std::span<float> right_delayed(right_delayed_array);
+
   std::array<float, n_bands> latest_samples_mono;
 
   std::array<float, n_bands> hann_window;

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -143,19 +143,19 @@ void Spectrum::process(std::span<float>& left_in,
 
   if ( n_samples < n_bands) {
     // Drop the oldest quantum.
-    std::memmove(left_delay_input[0], left_delay_input[n_samples], (n_bands - n_samples) * sizeof(float));
-    std::memmove(right_delay_input[0], right_delay_input[n_samples], (n_bands - n_samples) * sizeof(float));
+    std::memmove(&left_delay_input_array[0], left_delay_input_array[n_samples], (n_bands - n_samples) * sizeof(float));
+    std::memmove(&right_delay_input_array[0], right_delay_input_array[n_samples], (n_bands - n_samples) * sizeof(float));
 
     // Copy the new quantum.
     for (size_t n = 0; n < n_samples; n++) {
-      left_delay_input[n_bands - n_samples + n] = left_in[n];
-      right_delay_input[n_bands - n_samples + n] = right_in[n];
+      left_delay_input_array[n_bands - n_samples + n] = left_in[n];
+      right_delay_input_array[n_bands - n_samples + n] = right_in[n];
     }
   } else {
     // Copy the latest n_bands samples.
     for (size_t n = 0; n < n_bands; n++) {
-      left_delay_input[n] = left_in[n_samples - n_bands + n];
-      right_delay_input[n] = right_in[n_samples - n_bands + n];
+      left_delay_input_array[n] = left_in[n_samples - n_bands + n];
+      right_delay_input_array[n] = right_in[n_samples - n_bands + n];
     }
   }
 
@@ -166,13 +166,13 @@ void Spectrum::process(std::span<float>& left_in,
     lv2_wrapper->connect_data_ports(left_delay_input, right_delay_input, left_delayed, right_delayed);
     lv2_wrapper->run();
 
-    // Copy the latest n_bands samples from the delayed signal.
+    // Downmix the latest n_bands samples from the delayed signal.
     for (size_t n = 0; n < n_bands; n++) {
       latest_samples_mono[n] = 0.5F * (left_delayed[n_samples - n_bands + n] +
                                         right_delayed[n_samples - n_bands + n]);
     }
   } else {
-    // Copy the latest n_bands samples from the non-delayed signal.
+    // Downmix the latest n_bands samples from the non-delayed signal.
     for (size_t n = 0; n < n_bands; n++) {
       latest_samples_mono[n] = 0.5F * (left_delay_input[n_samples - n_bands + n] +
                                         right_delay_input[n_samples - n_bands + n]);

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -75,8 +75,8 @@ Spectrum::Spectrum(const std::string& tag,
   lv2_wrapper->set_control_port_value("wet_r", static_cast<float>(util::db_to_linear(0.0F)));
 
   // TODO: configurable delay
-  lv2_wrapper->set_control_port_value("time_l", 1000F);
-  lv2_wrapper->set_control_port_value("time_r", 1000F);
+  lv2_wrapper->set_control_port_value("time_l", 1000.0F);
+  lv2_wrapper->set_control_port_value("time_r", 1000.0F);
 
 
 
@@ -108,8 +108,11 @@ void Spectrum::setup() {
   std::ranges::fill(real_input, 0.0F);
   std::ranges::fill(latest_samples_mono, 0.0F);
 
-  std::ranges::fill(left_delayed, 0.0F);
-  std::ranges::fill(right_delayed, 0.0F);
+  std::ranges::fill(left_delayed_array, 0.0F);
+  std::ranges::fill(right_delayed_array, 0.0F);
+
+  left_delayed = std::span<float>(left_delayed_array);
+  right_delayed = std::span<float>(right_delayed_array);
 
   lv2_wrapper->set_n_samples(n_bands);
 

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -143,8 +143,8 @@ void Spectrum::process(std::span<float>& left_in,
 
   if ( n_samples < n_bands) {
     // Drop the oldest quantum.
-    std::memmove(&left_delay_input_array[0], left_delay_input_array[n_samples], (n_bands - n_samples) * sizeof(float));
-    std::memmove(&right_delay_input_array[0], right_delay_input_array[n_samples], (n_bands - n_samples) * sizeof(float));
+    std::memmove(&left_delay_input_array[0], &left_delay_input_array[n_samples], (n_bands - n_samples) * sizeof(float));
+    std::memmove(&right_delay_input_array[0], &right_delay_input_array[n_samples], (n_bands - n_samples) * sizeof(float));
 
     // Copy the new quantum.
     for (size_t n = 0; n < n_samples; n++) {

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -118,10 +118,11 @@ void Spectrum::setup() {
   left_delayed = std::span<float>(left_delayed_array);
   right_delayed = std::span<float>(right_delayed_array);
 
-  // n_bands instead of n_samples, because we the output
+  // n_bands instead of n_samples, because the output
   // array is of size n_bands for the fft. This is necessary
   // because n_samples has a dynamic size, but recomputing
   // the number of bands for the fft is extremely expensive.
+  // So we use a static number, n_bands, for the fft and related code.
   lv2_wrapper->set_n_samples(n_bands);
 
   if (lv2_wrapper->get_rate() != rate) {

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -108,8 +108,8 @@ void Spectrum::setup() {
   std::ranges::fill(real_input, 0.0F);
   std::ranges::fill(latest_samples_mono, 0.0F);
 
-  std::ranges::fill(left_delayed_array, 0.0F);
-  std::ranges::fill(right_delayed_array, 0.0F);
+  std::ranges::fill(left_delayed, 0.0F);
+  std::ranges::fill(right_delayed, 0.0F);
 
   lv2_wrapper->set_n_samples(n_bands);
 

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -137,7 +137,7 @@ void Spectrum::process(std::span<float>& left_in,
   // with the audio as experienced by the user
   if ( !lv2_wrapper->found_plugin || !lv2_wrapper->has_instance() ) {
     lv2_wrapper->connect_data_ports(left_in, right_in, left_delayed, right_delayed);
-    lv2_wrapper->runt();
+    lv2_wrapper->run();
   } else {
     std::copy(left_in.begin(), left_in.end(), left_delayed.begin());
     std::copy(right_in.begin(), right_in.end(), right_delayed.begin());

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -168,14 +168,14 @@ void Spectrum::process(std::span<float>& left_in,
 
     // Downmix the latest n_bands samples from the delayed signal.
     for (size_t n = 0; n < n_bands; n++) {
-      latest_samples_mono[n] = 0.5F * (left_delayed[n_samples - n_bands + n] +
-                                        right_delayed[n_samples - n_bands + n]);
+      latest_samples_mono[n] = 0.5F * (left_delayed[n] +
+                                        right_delayed[n]);
     }
   } else {
     // Downmix the latest n_bands samples from the non-delayed signal.
     for (size_t n = 0; n < n_bands; n++) {
-      latest_samples_mono[n] = 0.5F * (left_delay_input[n_samples - n_bands + n] +
-                                        right_delay_input[n_samples - n_bands + n]);
+      latest_samples_mono[n] = 0.5F * (left_delay_input[n] +
+                                        right_delay_input[n]);
     }
   }
 

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -108,15 +108,24 @@ void Spectrum::setup() {
   std::ranges::fill(real_input, 0.0F);
   std::ranges::fill(latest_samples_mono, 0.0F);
 
+  std::ranges::fill(left_delay_input_array, 0.0F);
+  std::ranges::fill(right_delay_input_array, 0.0F);
+  left_delay_input = std::span<float>(left_delay_input_array);
+  right_delay_input = std::span<float>(right_delay_input_array);
+
   std::ranges::fill(left_delayed_array, 0.0F);
   std::ranges::fill(right_delayed_array, 0.0F);
-
   left_delayed = std::span<float>(left_delayed_array);
   right_delayed = std::span<float>(right_delayed_array);
 
+  // n_bands instead of n_samples, because we the output
+  // array is of size n_bands for the fft. This is necessary
+  // because n_samples has a dynamic size, but recomputing
+  // the number of bands for the fft is extremely expensive.
   lv2_wrapper->set_n_samples(n_bands);
 
   if (lv2_wrapper->get_rate() != rate) {
+    util::debug(log_tag + " creating instance of comp delay x2 stereo for spectrum A/V sync");
     lv2_wrapper->create_instance(rate);
   }
 }
@@ -132,30 +141,42 @@ void Spectrum::process(std::span<float>& left_in,
     return;
   }
 
-  // delay the visualization of the spectrum by the reported latency
-  // of the output device, so that the spectrum is visually in sync
-  // with the audio as experienced by the user
-  if ( !lv2_wrapper->found_plugin || !lv2_wrapper->has_instance() ) {
-    lv2_wrapper->connect_data_ports(left_in, right_in, left_delayed, right_delayed);
-    lv2_wrapper->run();
-  } else {
-    std::copy(left_in.begin(), left_in.end(), left_delayed.begin());
-    std::copy(right_in.begin(), right_in.end(), right_delayed.begin());
-  }
-
-  if (n_samples < n_bands) {
+  if ( n_samples < n_bands) {
     // Drop the oldest quantum.
-    std::memmove(&latest_samples_mono[0], &latest_samples_mono[n_samples],
-        (n_bands - n_samples) * sizeof(float));
+    std::memmove(left_delay_input[0], left_delay_input[n_samples], (n_bands - n_samples) * sizeof(float));
+    std::memmove(right_delay_input[0], right_delay_input[n_samples], (n_bands - n_samples) * sizeof(float));
 
     // Copy the new quantum.
-    for (size_t n = 0; n < n_samples; n++)
-      latest_samples_mono[n_bands - n_samples + n] = 0.5F * (left_delayed[n] + right_delayed[n]);
+    for (size_t n = 0; n < n_samples; n++) {
+      left_delay_input[n_bands - n_samples + n] = left_in[n];
+      right_delay_input[n_bands - n_samples + n] = right_in[n];
+    }
   } else {
     // Copy the latest n_bands samples.
-    for (size_t n = 0; n < n_bands; n++)
+    for (size_t n = 0; n < n_bands; n++) {
+      left_delay_input[n] = left_in[n_samples - n_bands + n];
+      right_delay_input[n] = right_in[n_samples - n_bands + n];
+    }
+  }
+
+  // delay the visualization of the spectrum by the reported latency
+  // of the output device, so that the spectrum is visually in sync
+  // with the audio as experienced by the user. (A/V sync)
+  if ( lv2_wrapper->found_plugin && lv2_wrapper->has_instance() ) {
+    lv2_wrapper->connect_data_ports(left_delay_input, right_delay_input, left_delayed, right_delayed);
+    lv2_wrapper->run();
+
+    // Copy the latest n_bands samples from the delayed signal.
+    for (size_t n = 0; n < n_bands; n++) {
       latest_samples_mono[n] = 0.5F * (left_delayed[n_samples - n_bands + n] +
-                                       right_delayed[n_samples - n_bands + n]);
+                                        right_delayed[n_samples - n_bands + n]);
+    }
+  } else {
+    // Copy the latest n_bands samples from the non-delayed signal.
+    for (size_t n = 0; n < n_bands; n++) {
+      latest_samples_mono[n] = 0.5F * (left_delay_input[n_samples - n_bands + n] +
+                                        right_delay_input[n_samples - n_bands + n]);
+    }
   }
 
   /*


### PR DESCRIPTION
Adds ability to delay the data going to the spectrum display, so that in case of an audio device with long latency, the visual feedback can remain synchronized with what is audible.