### PR TITLE
QML: prefer identity over equality

### DIFF
--- a/src/contents/ui/EeSpinBox.qml
+++ b/src/contents/ui/EeSpinBox.qml
@@ -47,7 +47,7 @@ FormCard.AbstractFormDelegate {
     focusPolicy: Kirigami.Settings.isMobile ? Qt.StrongFocus : Qt.NoFocus
     onClicked: spinbox.forceActiveFocus()
     Keys.onPressed: (event) => {
-        if (event.key == Qt.Key_PageUp) {
+        if (event.key === Qt.Key_PageUp) {
             control.valueModified(control.value + pageSteps * stepSize);
             event.accepted = true;
         } else if (event.key === Qt.Key_PageDown) {

--- a/src/contents/ui/MenuAddPlugins.qml
+++ b/src/contents/ui/MenuAddPlugins.qml
@@ -74,7 +74,7 @@ Kirigami.OverlaySheet {
                         for (let n = 0; n < plugins.length; n++) {
                             if (plugins[n].startsWith(name)) {
                                 const m = plugins[n].match(/#(\d+)$/);
-                                if (m.length == 2)
+                                if (m.length === 2)
                                     index_list.push(m[1]);
 
                             }

--- a/src/contents/ui/PageStreamsEffects.qml
+++ b/src/contents/ui/PageStreamsEffects.qml
@@ -188,7 +188,7 @@ Kirigami.Page {
 
                     pluginsListModel.clear();
                     populatePluginsListModel(newList);
-                    if (newList.length == 1 && pluginsListView.currentIndex == -1)
+                    if (newList.length === 1 && pluginsListView.currentIndex === -1)
                         pluginsListView.currentIndex = 0;
 
                 }


### PR DESCRIPTION
@wwmm You used equality on `Qt.Key_PageUp`, but not on `Qt.Key_PageDown`. I suppose you wanted to do identity for both (I tested both keys). Besides it's quite safe to use identity on array lenghts and indexes. 