### PR TITLE
Optimize sed regex

### DIFF
--- a/util/convert_schema_to_kcfg.sh
+++ b/util/convert_schema_to_kcfg.sh
@@ -13,7 +13,7 @@ cd "$UTIL_DIR"
 
 # s/regexp/replacement/
 cat $SCHEMA |
-    sed -r 's/(<key.*)-(.)/\1\u\2/g' | # removing "-" and putting the next character in upper case
+    sed -r 's/(<key\sname="[a-z]*)-([a-z])/\1\u\2/g' | # removing "-" and putting the next character in upper case
     sed -r 's/key/entry/' | 
     sed -r 's/type="b"/type="Bool"/' |
     sed -r 's/type="i"/type="Int"/' |
@@ -30,6 +30,6 @@ cat $SCHEMA |
     xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0 http://www.kde.org/standards/kcfg/1.0/kcfg.xsd"> \
     <kcfgfile name="easyeffectsrc" /> \
     <group name="imported">' |
-    sed -r 's/(<entry.*>)/\1\n\t\t\t\t<label><\/label>/g' |
-    sed -r 's/<range min="(.*)" max="(.*)".*\/>/\t<min>\1<\/min>\n\t\t\t\t<max>\2<\/max>/g' |
-    sed -r 's/(<default.*>)/\t\1/g' > $OUTPUT_FILE
+    sed -r 's/(<entry[^>]*>)/\1\n\t\t\t\t<label><\/label>/g' |
+    sed -r 's/<range min="([0-9.]*)" max="([0-9.]*)"\s*\/>/\t<min>\1<\/min>\n\t\t\t\t<max>\2<\/max>/g' |
+    sed -r 's/(<default[^>]*>)/\t\1/g' > $OUTPUT_FILE


### PR DESCRIPTION
I tested them on https://sed.js.org/

I couldn't test them on the schema files, please do it @wwmm, but I don't think there will be issues.

Basically it's always better to avoid `.*` because it consumes all the line (or worse, the entire string file) and then the engine has to go back (backtracking) to check the possible matches.

I don't know if sed supports possessive quantifiers (.*+) that avoid backtracking, but the new regexes should reduce it and improve performance anyway.