### PR TITLE
Optimize sed regex for schema converter

### DIFF
--- a/util/convert_schema_to_kcfg.sh
+++ b/util/convert_schema_to_kcfg.sh
@@ -13,15 +13,20 @@ cd "$UTIL_DIR"
 
 # s/regexp/replacement/
 cat $SCHEMA |
-    sed -r 's/(<key\s+name="[a-z]*)-([a-z])/\1\u\2/g' | # removing "-" and putting the next character in upper case
-    sed -r 's/key/entry/' | 
+    sed -r 's/(<key\s+name="[a-z0-9]*)-([a-z])/\1\u\2/g' | # removing "-" and putting the next character in upper case
+    sed -r 's/key/entry/' |
     sed -r 's/type="b"/type="Bool"/' |
     sed -r 's/type="i"/type="Int"/' |
     sed -r 's/type="d"/type="Double"/' |
     sed -r 's/type="s"/type="String"/' |
-    sed '1d;2d;3d;$d;' | # removing lines
-    sed '$d' |
-    sed '$ a \\t</group>' |
+    # replacing schema enums, but they should be moved in the entries list after the script execution,
+    # then empty choice and name properties should be filled with new values
+    sed -r 's/<enum[^>]+>/\t<entry name="" type="Enum">\n\t\t\t<choices>/g' |
+    sed -r 's/<value\s+nick="/\t\t<choice name="">\n\t\t\t\t\t<label>/g' |
+    sed -r 's/"\s+value="[^"]+"\s*\/>/<\/label>\n\t\t\t\t<\/choice>/g' |
+    sed -r 's/<\/enum>/\t\t<\/choices>\n\t\t<default><\/default>\n\t\t<\/entry>/g' |
+    sed -E '/<([?]xml|[/]?schema(list)?)[^>]*>/d' | # removing lines with unneeded tags
+    sed '$ a \\t</group>' | # append closing tags
     sed '$ a </kcfg>' |
     sed '1 i \
 <?xml version="1.0" encoding="UTF-8"?> \


### PR DESCRIPTION
This latest version should be much better.

I thought the enum choices were outside the `group` tag, but afterwards I realized that they are already inside because I added a new regex to remove the gsettings `schema` tags (along with `?xml` and `schemalist`). So after the script execution, you have all the enum choices in the `group`, but al the top.

I suppose you still want to move them in other places to reorder the settings and you still have to fill choice and name properties.

At the end, when everything has been filled, it's always better to make a format from the editor.     