### PR TITLE
Fix plugin credit and check level minimums 

### DIFF
--- a/src/contents/ui/Autogain.qml
+++ b/src/contents/ui/Autogain.qml
@@ -287,7 +287,7 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using") + EEtagsPluginPackage.ebur128
+            text: i18n("Using %1", EEtagsPluginPackage.ebur128)
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/BassEnhancer.qml
+++ b/src/contents/ui/BassEnhancer.qml
@@ -190,7 +190,7 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using") + EEtagsPluginPackage.calf
+            text: i18n("Using %1", EEtagsPluginPackage.calf)
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/Compressor.qml
+++ b/src/contents/ui/Compressor.qml
@@ -815,7 +815,7 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using") + EEtagsPluginPackage.lsp
+            text: i18n("Using %1", EEtagsPluginPackage.lsp)
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/Crystalizer.qml
+++ b/src/contents/ui/Crystalizer.qml
@@ -71,7 +71,7 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using") + EEtagsPluginPackage.zita
+            text: i18n("Using %1", EEtagsPluginPackage.zita)
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/Exciter.qml
+++ b/src/contents/ui/Exciter.qml
@@ -190,7 +190,7 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using") + EEtagsPluginPackage.calf
+            text: i18n("Using %1", EEtagsPluginPackage.calf)
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/Gate.qml
+++ b/src/contents/ui/Gate.qml
@@ -911,7 +911,7 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using") + EEtagsPluginPackage.lsp
+            text: i18n("Using %1", EEtagsPluginPackage.lsp)
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/Limiter.qml
+++ b/src/contents/ui/Limiter.qml
@@ -493,7 +493,7 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using") + EEtagsPluginPackage.lsp
+            text: i18n("Using %1", EEtagsPluginPackage.lsp)
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/Maximizer.qml
+++ b/src/contents/ui/Maximizer.qml
@@ -102,7 +102,7 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using") + EEtagsPluginPackage.zam
+            text: i18n("Using %1", EEtagsPluginPackage.zam)
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/PageStreamsEffects.qml
+++ b/src/contents/ui/PageStreamsEffects.qml
@@ -18,6 +18,8 @@ Kirigami.Page {
     required property var pluginsDB
     required property var pipelineInstance
     property string logTag: "PageStreamsEffects"
+    property int minLeftLevel: -99
+    property int minRightLevel: -99
 
     padding: 0
     Component.onCompleted: {
@@ -407,11 +409,19 @@ Kirigami.Page {
                     id: footerFrameAnimation
 
                     onTriggered: {
-                        let left = Number(pipelineInstance.getOutputLevelLeft()).toLocaleString(Qt.locale(), 'f', 0);
-                        let right = Number(pipelineInstance.getOutputLevelRight()).toLocaleString(Qt.locale(), 'f', 0);
-                        let latency = Number(pipelineInstance.getPipeLineLatency()).toLocaleString(Qt.locale(), 'f', 1);
-                        let rate = Number(pipelineInstance.getPipeLineRate()).toLocaleString(Qt.locale(), 'f', 1);
-                        actionLevelValue.text = `${left} ${right} dB`;
+                        let left = Number(pipelineInstance.getOutputLevelLeft());
+                        let right = Number(pipelineInstance.getOutputLevelRight());
+                        if (isNaN(left) || left < minLeftLevel)
+                            left = minLeftLevel;
+
+                        if (isNaN(right) || right < minRightLevel)
+                            right = minRightLevel;
+
+                        const localeLeft = left.toLocaleString(Qt.locale(), 'f', 0);
+                        const localeRight = right.toLocaleString(Qt.locale(), 'f', 0);
+                        const latency = Number(pipelineInstance.getPipeLineLatency()).toLocaleString(Qt.locale(), 'f', 1);
+                        const rate = Number(pipelineInstance.getPipeLineRate()).toLocaleString(Qt.locale(), 'f', 1);
+                        actionLevelValue.text = `${localeLeft} ${localeRight} dB`;
                         actionLatencyValue.text = `${latency} ms`;
                         actionRateValue.text = `${rate} kHz`;
                     }

--- a/src/plugin_base.hpp
+++ b/src/plugin_base.hpp
@@ -100,8 +100,11 @@ class PluginBase : public QObject {
 
   float latency_value = 0.0F;  // seconds
 
-  float input_peak_left = util::minimum_linear_level, input_peak_right = util::minimum_linear_level;
-  float output_peak_left = util::minimum_linear_level, output_peak_right = util::minimum_linear_level;
+  // Even if it would be reasonable to initialize the peaks to `util::minimum_db_level`,
+  // we want the plugins UI and the output level to report 0 db in the initial stage
+  // (when nothing is playing), so 0.0F is more suitable for this purpose.
+  float input_peak_left = 0.0F, input_peak_right = 0.0F;
+  float output_peak_left = 0.0F, output_peak_right = 0.0F;
 
   std::chrono::time_point<std::chrono::system_clock> clock_start;
 

--- a/src/tags_plugin_name.cpp
+++ b/src/tags_plugin_name.cpp
@@ -113,11 +113,7 @@ QList<QString> Model::getBaseNames() {
 auto get_id(const QString& name) -> QString {
   QRegularExpressionMatch match = id_regex.match(name);
 
-  if (match.hasMatch()) {
-    return match.captured(1);
-  }
-
-  return "";
+  return match.hasMatch() ? match.captured(1) : "";
 }
 
 }  // namespace tags::plugin_name

--- a/src/tags_plugin_name.hpp
+++ b/src/tags_plugin_name.hpp
@@ -43,18 +43,18 @@ class Package : public QObject {
   Q_OBJECT
 
  public:
-  CREATE_PROPERTY(QString, bs2b, QStringLiteral(" bs2b"));
-  CREATE_PROPERTY(QString, calf, QStringLiteral(" Calf Studio Gear"));
-  CREATE_PROPERTY(QString, deepfilternet, QStringLiteral(" DeepFilterNet"));
-  CREATE_PROPERTY(QString, ebur128, QStringLiteral(" libebur128"));
-  CREATE_PROPERTY(QString, ee, QStringLiteral(" Easy Effects"));
-  CREATE_PROPERTY(QString, lsp, QStringLiteral(" Linux Studio Plugins"));
-  CREATE_PROPERTY(QString, mda, QStringLiteral(" MDA"));
-  CREATE_PROPERTY(QString, rnnoise, QStringLiteral(" RNNoise"));
-  CREATE_PROPERTY(QString, soundTouch, QStringLiteral(" SoundTouch"));
-  CREATE_PROPERTY(QString, speex, QStringLiteral(" SpeexDSP"));
-  CREATE_PROPERTY(QString, zam, QStringLiteral(" ZamAudio"));
-  CREATE_PROPERTY(QString, zita, QStringLiteral(" Zita"));
+  CREATE_PROPERTY(QString, bs2b, QStringLiteral("bs2b"));
+  CREATE_PROPERTY(QString, calf, QStringLiteral("Calf Studio Gear"));
+  CREATE_PROPERTY(QString, deepfilternet, QStringLiteral("DeepFilterNet"));
+  CREATE_PROPERTY(QString, ebur128, QStringLiteral("libebur128"));
+  CREATE_PROPERTY(QString, ee, QStringLiteral("Easy Effects"));
+  CREATE_PROPERTY(QString, lsp, QStringLiteral("Linux Studio Plugins"));
+  CREATE_PROPERTY(QString, mda, QStringLiteral("MDA"));
+  CREATE_PROPERTY(QString, rnnoise, QStringLiteral("RNNoise"));
+  CREATE_PROPERTY(QString, soundTouch, QStringLiteral("SoundTouch"));
+  CREATE_PROPERTY(QString, speex, QStringLiteral("SpeexDSP"));
+  CREATE_PROPERTY(QString, zam, QStringLiteral("ZamAudio"));
+  CREATE_PROPERTY(QString, zita, QStringLiteral("Zita"));
 };
 
 }  // namespace tags::plugin_package


### PR DESCRIPTION
I tried to implement ftm::format to fix plugin credits translations, then discovered QString can make formatting with `arg()` method. Passing the result of `i18n` I got a `i18n_argument_missing`.

Later I made a search and went to this:
- https://bugs.kde.org/show_bug.cgi?id=425159
- https://invent.kde.org/plasma/discover/-/commit/c5893d35c5531eeb86db67f4b1729571cfde072a

In which I discovered that we can do the same in QML. So it was more easy than we though, but it's weird there's no documentation on that system and I had to find this solution on a bugtracker.

Besides I saw you initialized plugin peak levels to the minimum linear value, but this was weird to me because those class properties are in dB units (we pass them to QML to show levels). So I changed them to the minimum db level (defined in util.hpp), but this led to show -100 on all levels when the app is started (which is reasonable since nothing is playing, but maybe this was not your purpose).

So in order to show 0 at the start when nothing is playing (the same happens on libadwaita), I initialized them to `0.0F`.

At last, I added a check for -99 db like we did in libadwaita for the output levels. 

Update. I forgot to mention the following: Is there a way to translate new QML strings? I'd like to test those plugin credits in my local language. I suppose I won't find them in weblate.
