### PR TITLE
Improve user input cleaning and fix translations

### DIFF
--- a/src/contents/ui/Autogain.qml
+++ b/src/contents/ui/Autogain.qml
@@ -156,7 +156,7 @@ Kirigami.ScrollablePage {
                         id: momentary
 
                         label: i18n("Momentary")
-                        unit: i18n("LUFS")
+                        unit: "LUFS"
                         from: Common.minimumDecibelLevel
                         to: 10
                         value: 0
@@ -173,7 +173,7 @@ Kirigami.ScrollablePage {
                         id: shortterm
 
                         label: i18n("Short-Term")
-                        unit: i18n("LUFS")
+                        unit: "LUFS"
                         from: Common.minimumDecibelLevel
                         to: 10
                         value: 0
@@ -190,7 +190,7 @@ Kirigami.ScrollablePage {
                         id: integrated
 
                         label: i18n("Integrated")
-                        unit: i18n("LUFS")
+                        unit: "LUFS"
                         from: Common.minimumDecibelLevel
                         to: 10
                         value: 0
@@ -207,7 +207,7 @@ Kirigami.ScrollablePage {
                         id: relative
 
                         label: i18n("Relative")
-                        unit: i18n("LUFS")
+                        unit: "LUFS"
                         from: Common.minimumDecibelLevel
                         to: 10
                         value: 0
@@ -224,7 +224,7 @@ Kirigami.ScrollablePage {
                         id: range
 
                         label: i18n("Range")
-                        unit: i18n("LU")
+                        unit: "LU"
                         from: 0
                         to: 50
                         value: 0
@@ -241,7 +241,7 @@ Kirigami.ScrollablePage {
                         id: loudness
 
                         label: i18n("Loudness")
-                        unit: i18n("LUFS")
+                        unit: "LUFS"
                         from: Common.minimumDecibelLevel
                         to: 10
                         value: 0
@@ -258,7 +258,7 @@ Kirigami.ScrollablePage {
                         id: outputGain
 
                         label: i18n("Output Gain")
-                        unit: i18n("dB")
+                        unit: "dB"
                         from: Common.minimumDecibelLevel
                         to: 20
                         value: 0

--- a/src/contents/ui/BlocklistSheet.qml
+++ b/src/contents/ui/BlocklistSheet.qml
@@ -48,7 +48,8 @@ Kirigami.OverlaySheet {
                     icon.name: "list-add-symbolic"
                     onTriggered: {
                         const name = newBlockedApp.text;
-                        if (!Common.isEmpty(name)) {
+                        // trim to exclude names containing only multiple spaces
+                        if (!Common.isEmpty(name.trim())) {
                             if (!streamDB.blocklist.includes(name)) {
                                 streamDB.blocklist.push(name);
                                 newBlockedApp.text = "";
@@ -73,7 +74,7 @@ Kirigami.OverlaySheet {
             }
 
             validator: RegularExpressionValidator {
-                regularExpression: /[^\\/]{100}$/ //less than 100 characters and no / or \
+                regularExpression: /^[^\\/]{1,100}$/ //strings without `/` or `\` (max 100 chars)
             }
 
         }
@@ -118,7 +119,7 @@ Kirigami.OverlaySheet {
                         alignment: Qt.AlignRight
                         actions: [
                             Kirigami.Action {
-                                text: i18n("Delete this Preset")
+                                text: i18n("Delete this App")
                                 icon.name: "delete"
                                 displayHint: Kirigami.DisplayHint.AlwaysHide
                                 onTriggered: {

--- a/src/contents/ui/Maximizer.qml
+++ b/src/contents/ui/Maximizer.qml
@@ -79,7 +79,7 @@ Kirigami.ScrollablePage {
                         id: reductionLevel
 
                         label: i18n("Reduction")
-                        unit: i18n("dB")
+                        unit: "dB"
                         from: 0
                         to: 40
                         value: 0

--- a/src/contents/ui/MenuAddPlugins.qml
+++ b/src/contents/ui/MenuAddPlugins.qml
@@ -129,7 +129,7 @@ Kirigami.OverlaySheet {
                             plugins.push(new_name);
                         }
                         streamDB.plugins = plugins;
-                        showMenuStatus(i18n("Added Plugin: " + translatedName));
+                        showMenuStatus(i18n("Added Plugin") + ": " + translatedName);
                     }
                 }
 

--- a/src/contents/ui/PresetsCommunityPage.qml
+++ b/src/contents/ui/PresetsCommunityPage.qml
@@ -85,7 +85,7 @@ ColumnLayout {
             width: listView.width
             onClicked: {
                 if (Presets.Manager.loadCommunityPresetFile(pipeline, path, presetPackage) === false)
-                    showPresetsMenuStatus(i18n("The Preset " + name + "failed to load"));
+                    showPresetsMenuStatus(i18n("The Preset %1 failed to load", name));
 
             }
 
@@ -109,9 +109,9 @@ ColumnLayout {
                             displayHint: Kirigami.DisplayHint.AlwaysHide
                             onTriggered: {
                                 if (Presets.Manager.importFromCommunityPackage(pipeline, path, presetPackage) === true)
-                                    showPresetsMenuStatus(i18n("Imported the Community Preset: " + name));
+                                    showPresetsMenuStatus(i18n("Imported the Community Preset") + ": " + name);
                                 else
-                                    showPresetsMenuStatus(i18n("Failed to Import the Community Preset: " + name));
+                                    showPresetsMenuStatus(i18n("Failed to Import the Community Preset") + ": " + name);
                             }
                         }
                     ]

--- a/src/contents/ui/PresetsLocalPage.qml
+++ b/src/contents/ui/PresetsLocalPage.qml
@@ -69,13 +69,16 @@ ColumnLayout {
                 text: i18n("Create Preset")
                 icon.name: "list-add-symbolic"
                 onTriggered: {
-                    if (!Common.isEmpty(newPresetName.text)) {
-                        if (Presets.Manager.add(pipeline, newPresetName.text) === true) {
+                    // remove the final preset extension if specified
+                    const newName = newPresetName.text.replace(/\.json$/, "");
+                    // trim to exclude names containing only multiple spaces
+                    if (!Common.isEmpty(newName.trim())) {
+                        if (Presets.Manager.add(pipeline, newName) === true) {
                             newPresetName.accepted();
-                            showPresetsMenuStatus(i18n("New Preset Created: " + newPresetName.text));
+                            showPresetsMenuStatus(i18n("New Preset Created: " + newName));
                             newPresetName.text = "";
                         } else {
-                            showPresetsMenuStatus(i18n("Failed to Create Preset: " + newPresetName.text));
+                            showPresetsMenuStatus(i18n("Failed to Create Preset: " + newName));
                         }
                     }
                 }
@@ -97,7 +100,7 @@ ColumnLayout {
         }
 
         validator: RegularExpressionValidator {
-            regularExpression: /[^\\/]{100}$/ //less than 100 characters and no / or \
+            regularExpression: /^[^\\/]{1,100}$/ //strings without `/` or `\` (max 100 chars)
         }
 
     }

--- a/src/contents/ui/PresetsLocalPage.qml
+++ b/src/contents/ui/PresetsLocalPage.qml
@@ -75,10 +75,10 @@ ColumnLayout {
                     if (!Common.isEmpty(newName.trim())) {
                         if (Presets.Manager.add(pipeline, newName) === true) {
                             newPresetName.accepted();
-                            showPresetsMenuStatus(i18n("New Preset Created: " + newName));
+                            showPresetsMenuStatus(i18n("New Preset Created") + ": " + newName);
                             newPresetName.text = "";
                         } else {
-                            showPresetsMenuStatus(i18n("Failed to Create Preset: " + newName));
+                            showPresetsMenuStatus(i18n("Failed to Create Preset") + ": " + newName);
                         }
                     }
                 }
@@ -147,7 +147,7 @@ ColumnLayout {
             width: listView.width
             onClicked: {
                 if (Presets.Manager.loadLocalPresetFile(pipeline, name) === false)
-                    showPresetsMenuStatus(i18n("The Preset " + name + "failed to load"));
+                    showPresetsMenuStatus(i18n("The Preset %1 failed to load", name));
 
             }
 
@@ -165,9 +165,9 @@ ColumnLayout {
                             displayHint: Kirigami.DisplayHint.AlwaysHide
                             onTriggered: {
                                 if (Presets.Manager.savePresetFile(pipeline, name) === true)
-                                    showPresetsMenuStatus(i18n("Settings Saved to: " + name));
+                                    showPresetsMenuStatus(i18n("Settings Saved to: %1", name));
                                 else
-                                    showPresetsMenuStatus(i18n("Failed to Save Settings to: " + name));
+                                    showPresetsMenuStatus(i18n("Failed to Save Settings to: %1", name));
                             }
                         },
                         Kirigami.Action {
@@ -176,9 +176,9 @@ ColumnLayout {
                             displayHint: Kirigami.DisplayHint.AlwaysHide
                             onTriggered: {
                                 if (Presets.Manager.remove(pipeline, name) === true)
-                                    showPresetsMenuStatus(i18n("The Preset " + name + " Has Been Removed"));
+                                    showPresetsMenuStatus(i18n("The Preset %1 Has Been Removed", name));
                                 else
-                                    showPresetsMenuStatus(i18n("The Preset " + name + " Coult Not Be Removed"));
+                                    showPresetsMenuStatus(i18n("The Preset %1 Could Not Be Removed", name));
                             }
                         }
                     ]

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -134,7 +134,7 @@ Kirigami.ApplicationWindow {
             visible: false
 
             MenuItem {
-                // text: i18n("Preset: " + DB.Manager.main.lastUsedPreset)
+                // text: i18n("Preset") + ": " + DB.Manager.main.lastUsedPreset
                 enabled: false
             }
 


### PR DESCRIPTION
Qml has it's own regex syntax, but maybe it's better if we stick to the js one which is more intuitive. In both perl and js regex engine, `${100}` means "match exactly 100 times", but we want between 1 and 100. Using `{1,100}` is not confusing, even if `{100}` works the same way in Qml.

Besides I wanted to exclude strings with whitespaces only, but it's not possible with the single regex validator in Qml. Asking ChatGTP I got the following which works in js: https://regex101.com/r/ohg7BD/1

Using it in Qml instead, the user can still add a string with only multiple whitespaces (i.e `              `). So I modified the check on the trimmed version of the string.

Made the same for the preset manager, plus an additional replace string method to remove the preset `.json` final extension, if specified (since we automatically add it, it's not wanted because we end up writing a file with double extension).

There are also other issues, but I will list them in #2960
