### PR TITLE
Escape Js/Qml regex

### DIFF
--- a/src/contents/ui/Common.js
+++ b/src/contents/ui/Common.js
@@ -1,8 +1,15 @@
 var minimumLinearLevel = 0.00001;
 var minimumDecibelLevel = -100.0;
 
-function isEmpty(str) {
-    return (!str || str.length === 0);
+function isEmpty(v) {
+    switch (typeof v) {
+        case "string":
+            return v.length === 0;
+        case "number":
+            return isNaN(v);
+        default:
+            return false;
+  }
 }
 
 function equalArrays(a, b) {

--- a/src/contents/ui/Common.js
+++ b/src/contents/ui/Common.js
@@ -11,7 +11,7 @@ function equalArrays(a, b) {
     }
 
     for (let n = 0; n < a.length; n++) {
-        // We use this function in a situation where the order of the elements matter. So if the same value is on 
+        // We use this function in a situation where the order of the elements matter. So if the same value is on
         // another position the arrays are different
 
         if (a[n] !== b[n]) {
@@ -23,6 +23,10 @@ function equalArrays(a, b) {
 }
 
 function clamp(num, min, max) { return Math.min(Math.max(num, min), max); }
+
+function regExpEscape(str) {
+    return str.replace(/[\\/^$*+?.()|[\]{}\-]/g, '\\$&');
+}
 
 function printObjectProperties(obj) {
     for (var prop in obj) {

--- a/src/contents/ui/MenuAddPlugins.qml
+++ b/src/contents/ui/MenuAddPlugins.qml
@@ -146,7 +146,8 @@ Kirigami.OverlaySheet {
             Layout.fillWidth: true
             placeholderText: i18n("Search")
             onAccepted: {
-                TagsPluginName.SortedNameModel.filterRegularExpression = RegExp(search.text, "i");
+                const re = Common.regExpEscape(search.text);
+                TagsPluginName.SortedNameModel.filterRegularExpression = RegExp(re, "i");
             }
         }
 

--- a/src/contents/ui/PresetsCommunityPage.qml
+++ b/src/contents/ui/PresetsCommunityPage.qml
@@ -49,7 +49,8 @@ ColumnLayout {
         Layout.fillWidth: true
         placeholderText: i18n("Search")
         onAccepted: {
-            sortedListModel.filterRegularExpression = RegExp(search.text, "i");
+            const re = Common.regExpEscape(search.text);
+            sortedListModel.filterRegularExpression = RegExp(re, "i");
         }
     }
 

--- a/src/contents/ui/PresetsLocalPage.qml
+++ b/src/contents/ui/PresetsLocalPage.qml
@@ -70,7 +70,7 @@ ColumnLayout {
                 icon.name: "list-add-symbolic"
                 onTriggered: {
                     // remove the final preset extension if specified
-                    const newName = newPresetName.text.replace(/\.json$/, "");
+                    const newName = newPresetName.text.replace(/(?:\.json)+$/, "");
                     // trim to exclude names containing only multiple spaces
                     if (!Common.isEmpty(newName.trim())) {
                         if (Presets.Manager.add(pipeline, newName) === true) {

--- a/src/contents/ui/PresetsLocalPage.qml
+++ b/src/contents/ui/PresetsLocalPage.qml
@@ -113,7 +113,8 @@ ColumnLayout {
         Layout.fillWidth: true
         placeholderText: i18n("Search")
         onAccepted: {
-            sortedListModel.filterRegularExpression = RegExp(search.text, "i");
+            const re = Common.regExpEscape(search.text);
+            sortedListModel.filterRegularExpression = RegExp(re, "i");
         }
     }
 


### PR DESCRIPTION
Since we can't use [RegExp.escape()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape), I made a simple custom escape for regex.

Also improved the `isEmpty` function to work better with numbers (`0` number type is a [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) value and resulted empty in the previous version).

@wwmm please take a look at [this](https://github.com/wwmm/easyeffects/issues/2960#issuecomment-2531188143) for the issue regarding the list of excluded apps.