### PR TITLE
Add active_preset and active_presets arguments.

### DIFF
--- a/include/presets_manager.hpp
+++ b/include/presets_manager.hpp
@@ -71,6 +71,8 @@ class PresetsManager {
 
   void save_preset_file(const PresetType& preset_type, const std::string& name);
 
+  auto get_loaded_preset(const PresetType& preset_type) -> std::string;
+
   static void write_plugins_preset(const PresetType& preset_type,
                                    const std::vector<std::string>& plugins,
                                    nlohmann::json& json);

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -580,6 +580,14 @@ void PresetsManager::save_preset_file(const PresetType& preset_type, const std::
   util::debug("saved preset: " + output_file.string());
 }
 
+auto PresetsManager::get_loaded_preset(const PresetType& preset_type) -> std::string {
+  const auto* key = (preset_type == PresetType::input) ? "last-loaded-input-preset" : "last-loaded-output-preset";
+
+  const auto* preset = g_settings_get_string(settings, key);
+
+  return preset;
+}
+
 void PresetsManager::write_plugins_preset(const PresetType& preset_type,
                                           const std::vector<std::string>& plugins,
                                           nlohmann::json& json) {


### PR DESCRIPTION
Adds the `active_preset <input|output>` and `active_presets`, which return either the active presets for input and output, or returns the preset for a specific category.