### PR TITLE
UI improvements

### DIFF
--- a/src/contents/ui/Autogain.qml
+++ b/src/contents/ui/Autogain.qml
@@ -160,7 +160,7 @@ Kirigami.ScrollablePage {
                         from: Common.minimumDecibelLevel
                         to: 10
                         value: 0
-                        decimals: 0
+                        decimals: 1
 
                         anchors {
                             left: parent.left
@@ -177,7 +177,7 @@ Kirigami.ScrollablePage {
                         from: Common.minimumDecibelLevel
                         to: 10
                         value: 0
-                        decimals: 0
+                        decimals: 1
 
                         anchors {
                             left: parent.left
@@ -194,7 +194,7 @@ Kirigami.ScrollablePage {
                         from: Common.minimumDecibelLevel
                         to: 10
                         value: 0
-                        decimals: 0
+                        decimals: 1
 
                         anchors {
                             left: parent.left
@@ -211,7 +211,7 @@ Kirigami.ScrollablePage {
                         from: Common.minimumDecibelLevel
                         to: 10
                         value: 0
-                        decimals: 0
+                        decimals: 1
 
                         anchors {
                             left: parent.left
@@ -228,7 +228,7 @@ Kirigami.ScrollablePage {
                         from: 0
                         to: 50
                         value: 0
-                        decimals: 0
+                        decimals: 1
 
                         anchors {
                             left: parent.left
@@ -245,7 +245,7 @@ Kirigami.ScrollablePage {
                         from: Common.minimumDecibelLevel
                         to: 10
                         value: 0
-                        decimals: 0
+                        decimals: 1
 
                         anchors {
                             left: parent.left

--- a/src/contents/ui/Autogain.qml
+++ b/src/contents/ui/Autogain.qml
@@ -79,8 +79,8 @@ Kirigami.ScrollablePage {
                         from: pluginDB.getMinValue("target")
                         to: pluginDB.getMaxValue("target")
                         value: pluginDB.target
-                        decimals: 0
-                        stepSize: 1
+                        decimals: 2
+                        stepSize: 0.1
                         unit: "dB"
                         onValueModified: (v) => {
                             pluginDB.target = v;
@@ -100,8 +100,8 @@ Kirigami.ScrollablePage {
                         from: pluginDB.getMinValue("silenceThreshold")
                         to: pluginDB.getMaxValue("silenceThreshold")
                         value: pluginDB.silenceThreshold
-                        decimals: 0
-                        stepSize: 1
+                        decimals: 2
+                        stepSize: 0.1
                         unit: "dB"
                         onValueModified: (v) => {
                             pluginDB.silenceThreshold = v;

--- a/src/contents/ui/BassEnhancer.qml
+++ b/src/contents/ui/BassEnhancer.qml
@@ -100,7 +100,7 @@ Kirigami.ScrollablePage {
                         from: pluginDB.getMinValue("amount")
                         to: pluginDB.getMaxValue("amount")
                         value: pluginDB.amount
-                        decimals: 1
+                        decimals: 2
                         stepSize: 0.1
                         unit: "dB"
                         onValueModified: (v) => {

--- a/src/contents/ui/BassEnhancer.qml
+++ b/src/contents/ui/BassEnhancer.qml
@@ -82,6 +82,7 @@ Kirigami.ScrollablePage {
             id: cardLayout
 
             Layout.fillWidth: true
+            Layout.topMargin: Kirigami.Units.largeSpacing
 
             Kirigami.Card {
                 id: cardControls

--- a/src/contents/ui/BassEnhancer.qml
+++ b/src/contents/ui/BassEnhancer.qml
@@ -68,7 +68,7 @@ Kirigami.ScrollablePage {
 
             Controls.Label {
                 Layout.alignment: Qt.AlignRight
-                text: i18n("2rd")
+                text: i18n("2nd")
             }
 
         }

--- a/src/contents/ui/Compressor.qml
+++ b/src/contents/ui/Compressor.qml
@@ -584,6 +584,7 @@ Kirigami.ScrollablePage {
         Kirigami.CardsLayout {
             maximumColumns: 2
             uniformCellWidths: true
+            Layout.topMargin: Kirigami.Units.largeSpacing
 
             Kirigami.Card {
                 Layout.fillWidth: false

--- a/src/contents/ui/EeInputOutputGain.qml
+++ b/src/contents/ui/EeInputOutputGain.qml
@@ -40,8 +40,8 @@ Item {
                     from: pluginDB.getMinValue("inputGain")
                     to: pluginDB.getMaxValue("inputGain")
                     value: pluginDB.inputGain
-                    decimals: 0
-                    stepSize: 1
+                    decimals: 2
+                    stepSize: 0.1
                     unit: "dB"
                     boxWidth: 5 * Kirigami.Units.gridUnit
                     onValueModified: (v) => {
@@ -90,8 +90,8 @@ Item {
                     from: pluginDB.getMinValue("outputGain")
                     to: pluginDB.getMaxValue("outputGain")
                     value: pluginDB.outputGain
-                    decimals: 0
-                    stepSize: 1
+                    decimals: 2
+                    stepSize: 0.1
                     unit: "dB"
                     boxWidth: 5 * Kirigami.Units.gridUnit
                     onValueModified: (v) => {

--- a/src/contents/ui/Exciter.qml
+++ b/src/contents/ui/Exciter.qml
@@ -100,7 +100,7 @@ Kirigami.ScrollablePage {
                         from: pluginDB.getMinValue("amount")
                         to: pluginDB.getMaxValue("amount")
                         value: pluginDB.amount
-                        decimals: 1
+                        decimals: 2
                         stepSize: 0.1
                         unit: "dB"
                         onValueModified: (v) => {

--- a/src/contents/ui/Exciter.qml
+++ b/src/contents/ui/Exciter.qml
@@ -82,6 +82,7 @@ Kirigami.ScrollablePage {
             id: cardLayout
 
             Layout.fillWidth: true
+            Layout.topMargin: Kirigami.Units.largeSpacing
 
             Kirigami.Card {
                 id: cardControls

--- a/src/contents/ui/Exciter.qml
+++ b/src/contents/ui/Exciter.qml
@@ -68,7 +68,7 @@ Kirigami.ScrollablePage {
 
             Controls.Label {
                 Layout.alignment: Qt.AlignRight
-                text: i18n("2rd")
+                text: i18n("2nd")
             }
 
         }

--- a/src/contents/ui/Gate.qml
+++ b/src/contents/ui/Gate.qml
@@ -570,6 +570,7 @@ Kirigami.ScrollablePage {
         Kirigami.CardsLayout {
             maximumColumns: 3
             uniformCellWidths: true
+            Layout.topMargin: Kirigami.Units.largeSpacing
 
             Kirigami.Card {
                 Layout.fillWidth: false

--- a/src/contents/ui/Limiter.qml
+++ b/src/contents/ui/Limiter.qml
@@ -375,6 +375,7 @@ Kirigami.ScrollablePage {
 
             Layout.fillWidth: false
             Layout.alignment: Qt.AlignHCenter
+            Layout.topMargin: Kirigami.Units.largeSpacing
 
             contentItem: GridLayout {
                 id: levelGridLayout

--- a/src/contents/ui/Maximizer.qml
+++ b/src/contents/ui/Maximizer.qml
@@ -67,7 +67,7 @@ Kirigami.ScrollablePage {
                         from: pluginDB.getMinValue("threshold")
                         to: pluginDB.getMaxValue("threshold")
                         value: pluginDB.threshold
-                        decimals: 1
+                        decimals: 2
                         stepSize: 0.1
                         unit: "dB"
                         onValueModified: (v) => {

--- a/src/contents/ui/Speex.qml
+++ b/src/contents/ui/Speex.qml
@@ -89,7 +89,7 @@ Kirigami.ScrollablePage {
                         from: pluginDB.getMinValue("noiseSuppression")
                         to: pluginDB.getMaxValue("noiseSuppression")
                         value: pluginDB.noiseSuppression
-                        decimals: 1
+                        decimals: 2
                         stepSize: 0.1
                         unit: "dB"
                         onValueModified: (v) => {


### PR DESCRIPTION
I added decimals to input/output spin buttons of all effects.

But I noticed we have lots of dB controls with various decimals and stepSize. In order to make them similar, I set 2 decimals on all of them. But since the up/down key changes them slowly, I set `0.1` as stepSize. So the user have more precision, but still a faster way to change them through up/down keys.

Is it OK for you? Should I make something similar also for ms controls since we have differences on decimals/stepSize also for these ones.

I added also a top margin for rows/cards that were too close to the widget above. 