### PR TITLE
Update schema converter

### DIFF
--- a/src/contents/ui/Common.js
+++ b/src/contents/ui/Common.js
@@ -7,6 +7,10 @@ function isEmpty(v) {
             return v.length === 0;
         case "number":
             return isNaN(v);
+        case "undefined":
+            return true;
+        case "object":
+            return v === null;
         default:
             return false;
   }

--- a/util/convert_schema_to_kcfg.sh
+++ b/util/convert_schema_to_kcfg.sh
@@ -19,14 +19,15 @@ cat $SCHEMA |
     sed -r 's/type="i"/type="Int"/' |
     sed -r 's/type="d"/type="Double"/' |
     sed -r 's/type="s"/type="String"/' |
-    # replacing schema enums, but they should be moved in the entries list after the script execution,
-    # then empty choice and name properties should be filled with new values
-    sed -r 's/<enum[^>]+>/\t<entry name="" type="Enum">\n\t\t\t<choices>/g' |
-    sed -r 's/<value\s+nick="/\t\t<choice name="">\n\t\t\t\t\t<label>/g' |
-    sed -r 's/"\s+value="[^"]+"\s*\/>/<\/label>\n\t\t\t\t<\/choice>/g' |
-    sed -r 's/<\/enum>/\t\t<\/choices>\n\t\t<default><\/default>\n\t\t<\/entry>/g' |
-    sed -E '/<([?]xml|[/]?schema(list)?)[^>]*>/d' | # removing lines with unneeded tags
-    sed '$ a \\t</group>' | # append closing tags
+    # replacing schema enums, but the property names and the labels should be filled manually afterwards
+    sed -r -z 's|"\s+value="[0-9]+"\s+/>\s+<value nick="|,|g' |
+    sed -r 's/<value\s+nick="/<default>/g' |
+    sed -r 's|"\s+value="[0-9]+"\s+/>|</default>|g' |
+    sed -r 's/<enum[^>]+>/    <entry name="Labels" type="StringList">/g' |
+    sed -r 's|enum="[^"]+">|type="Int">\n                <label></label>|g' |
+    sed -r 's|</enum>|</entry>|g' |
+    sed -r '/<([?]xml|[/]?schema(list)?)[^>]*>/d' | # removing lines with unneeded tags
+    sed '$ a \    </group>' | # append closing tags
     sed '$ a </kcfg>' |
     sed '1 i \
 <?xml version="1.0" encoding="UTF-8"?> \
@@ -35,6 +36,5 @@ cat $SCHEMA |
     xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0 http://www.kde.org/standards/kcfg/1.0/kcfg.xsd"> \
     <kcfgfile name="easyeffectsrc" /> \
     <group name="imported">' |
-    sed -r 's/(<entry[^>]*>)/\1\n\t\t\t\t<label><\/label>/g' |
-    sed -r 's/<range min="([-+]?[0-9.]*)" max="([-+]?[0-9.]*)"\s*\/>/\t<min>\1<\/min>\n\t\t\t\t<max>\2<\/max>/g' |
-    sed -r 's/(<default[^>]*>)/\t\1/g' > $OUTPUT_FILE
+    sed -r 's|<range\s+min="([-+]?[0-9.]*)"\s+max="([-+]?[0-9.]*)"\s*/>|    <min>\1</min>\n                <max>\2</max>|g' |
+    sed -r 's/(<default[^>]*>)/    \1/g' > $OUTPUT_FILE


### PR DESCRIPTION
With the string lists, the schema converter is a little bit easier, but it still needs to manually insert the properties and the labels (and reorder the tags if needed).

I improved the commands changing the delimiter where `/` is used, so there's no need to escape them. Since we use 4 spaces as indentation, I replaced the tabs since they are rendered differently in various editors (in Gnome Text they are reproduced by 2 spaced which does not fit good with the rest). @wwmm Please, test it.

Finally I added also `undefined` and `null` to JS `isEmpty`.