### PR TITLE
Add active-preset and active-presets command line options (QT Port)

### DIFF
--- a/src/command_line_parser.cpp
+++ b/src/command_line_parser.cpp
@@ -18,12 +18,15 @@
  */
 
 #include "command_line_parser.hpp"
+#include "easyeffects_db.h"
+#include "util.hpp"
 #include <qcommandlineparser.h>
 #include <qobject.h>
 #include <qtmetamacros.h>
 #include <KLocalizedString>
 #include <QApplication>
 #include <memory>
+#include <iostream>
 
 CommandLineParser::CommandLineParser(QObject* parent)
     : QObject(parent), parser(std::make_unique<QCommandLineParser>()) {
@@ -37,7 +40,9 @@ CommandLineParser::CommandLineParser(QObject* parent)
                       {{"w", "hide-window"}, i18n("Hide the Window.")},
                       {{"b", "bypass"}, i18n("Global bypass. 1 to enable, 2 to disable and 3 to get status")},
                       {{"l", "load-preset"}, i18n("Hide the Window.")},
-                      {{"p", "presets"}, i18n("Load a preset. Example: easyeffects -l music")}});
+                      {{"p", "presets"}, i18n("Load a preset. Example: easyeffects -l music")},
+                      {{"a", "active-preset"}, i18n("Get the active input/output preset."), i18n("preset-type")},
+                      {{"s", "active-presets"}, i18n("Get the active input and output presets.")}});
 }
 
 void CommandLineParser::process(QApplication* app) {
@@ -53,5 +58,43 @@ void CommandLineParser::process(QApplication* app) {
 
   if (parser->isSet("hide-window")) {
     Q_EMIT onHideWindow();
+  }
+
+  if (parser->isSet("active-preset")) {
+    auto value = parser->value("active-preset");
+    if (value == "input") {
+      auto preset = db::Main::lastLoadedInputPreset();
+      if (preset.length() < 1) {
+        preset = QString("None");
+      }
+      std::cout << preset.toStdString() << "\n";
+    } else if (value == "output") {
+      auto preset = db::Main::lastLoadedOutputPreset();
+      if (preset.length() < 1) {
+        preset = QString("None");
+      }
+      std::cout << preset.toStdString() << "\n";
+    } else {
+      util::fatal("Must specify preset type: input/output.");
+    }
+    //If you have a better way of exiting, let me know.
+    std::exit(0);
+  }
+
+  if (parser->isSet("active-presets")) {
+    auto input = db::Main::lastLoadedInputPreset();
+    auto output = db::Main::lastLoadedOutputPreset();
+
+    if (input.length() < 1) {
+      input = QString("None");
+    }
+    if (output.length() < 1) {
+      output = QString("None");
+    }
+
+    std::cout << "Input: " << input.toStdString() << std::endl;
+    std::cout << "Output: " << output.toStdString() << std::endl;
+
+    std::exit(0);
   }
 }


### PR DESCRIPTION
Adds the stated command line options to get the active preset for a specific type, or get the active presets for both types of presets.

My only issue before I merge this is how to remove the informational text that gets outputted before and after my command line options, because it ends up looking like this:
```
util.cpp:75	directory already exists: /home/caleb/.config/easyeffects/db
Input: None
Output: Laptop
db_manager.cpp:98	Saving settings...
```
(Also I'd like to know how to exit properly instead of `std::exit(0);` lol)