### PR TITLE
Improve implicitWidth for preferences and presets sheet + other little fix

### DIFF
--- a/src/contents/ui/Autogain.qml
+++ b/src/contents/ui/Autogain.qml
@@ -287,7 +287,8 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using %1", TagsPluginName.Package.ebur128)
+            text: i18n("Using %1", `<b>${TagsPluginName.Package.ebur128}</b>`)
+            textFormat: Text.RichText
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/BassEnhancer.qml
+++ b/src/contents/ui/BassEnhancer.qml
@@ -191,7 +191,8 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using %1", TagsPluginName.Package.calf)
+            text: i18n("Using %1", `<b>${TagsPluginName.Package.calf}</b>`)
+            textFormat: Text.RichText
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/Compressor.qml
+++ b/src/contents/ui/Compressor.qml
@@ -816,7 +816,8 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using %1", TagsPluginName.Package.lsp)
+            text: i18n("Using %1", `<b>${TagsPluginName.Package.lsp}</b>`)
+            textFormat: Text.RichText
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/Crossfeed.qml
+++ b/src/contents/ui/Crossfeed.qml
@@ -137,7 +137,8 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using %1", TagsPluginName.Package.bs2b)
+            text: i18n("Using %1", `<b>${TagsPluginName.Package.bs2b}</b>`)
+            textFormat: Text.RichText
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/Crystalizer.qml
+++ b/src/contents/ui/Crystalizer.qml
@@ -71,7 +71,8 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using %1", TagsPluginName.Package.zita)
+            text: i18n("Using %1", `<b>${TagsPluginName.Package.zita}</b>`)
+            textFormat: Text.RichText
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/CrystalizerBand.qml
+++ b/src/contents/ui/CrystalizerBand.qml
@@ -11,6 +11,10 @@ Controls.ItemDelegate {
     property bool mute
     property bool bypass
 
+    function toLocaleLabel(num, decimal, unit) {
+        return Number(num).toLocaleString(Qt.locale(), 'f', decimal) + ` ${unit}`;
+    }
+
     down: false
     hoverEnabled: false
     height: ListView.view.height
@@ -77,31 +81,31 @@ Controls.ItemDelegate {
             text: {
                 switch (index) {
                 case 0:
-                    return Number(250).toLocaleString(Qt.locale(), 'f', 0) + " Hz";
+                    return toLocaleLabel(250, 0, "Hz");
                 case 1:
-                    return Number(750).toLocaleString(Qt.locale(), 'f', 0) + " Hz";
+                    return toLocaleLabel(750, 0, "Hz");
                 case 2:
-                    return Number(1.5).toLocaleString(Qt.locale(), 'f', 1) + " kHz";
+                    return toLocaleLabel(1.5, 1, "kHz");
                 case 3:
-                    return Number(2.5).toLocaleString(Qt.locale(), 'f', 1) + " kHz";
+                    return toLocaleLabel(2.5, 1, "kHz");
                 case 4:
-                    return Number(3.5).toLocaleString(Qt.locale(), 'f', 1) + " kHz";
+                    return toLocaleLabel(3.5, 1, "kHz");
                 case 5:
-                    return Number(4.5).toLocaleString(Qt.locale(), 'f', 1) + " kHz";
+                    return toLocaleLabel(4.5, 1, "kHz");
                 case 6:
-                    return Number(5.5).toLocaleString(Qt.locale(), 'f', 1) + " kHz";
+                    return toLocaleLabel(5.5, 1, "kHz");
                 case 7:
-                    return Number(6.5).toLocaleString(Qt.locale(), 'f', 1) + " kHz";
+                    return toLocaleLabel(6.5, 1, "kHz");
                 case 8:
-                    return Number(7.5).toLocaleString(Qt.locale(), 'f', 1) + " kHz";
+                    return toLocaleLabel(7.5, 1, "kHz");
                 case 9:
-                    return Number(8.5).toLocaleString(Qt.locale(), 'f', 1) + " kHz";
+                    return toLocaleLabel(8.5, 1, "kHz");
                 case 10:
-                    return Number(9.5).toLocaleString(Qt.locale(), 'f', 1) + " kHz";
+                    return toLocaleLabel(9.5, 1, "kHz");
                 case 11:
-                    return Number(12.5).toLocaleString(Qt.locale(), 'f', 1) + " kHz";
+                    return toLocaleLabel(12.5, 1, "kHz");
                 case 12:
-                    return Number(17.5).toLocaleString(Qt.locale(), 'f', 1) + " kHz";
+                    return toLocaleLabel(17.5, 1, "kHz");
                 default:
                     return "Hz";
                 }

--- a/src/contents/ui/DelegateStreamsList.qml
+++ b/src/contents/ui/DelegateStreamsList.qml
@@ -130,7 +130,8 @@ Kirigami.AbstractCard {
                     id: volumeSlider
 
                     function prepareVolumeValue(normalizedValue) {
-                        return DB.Manager.main.useCubicVolumes === false ? normalizedValue * 100 : Math.cbrt(normalizedValue) * 100;
+                        const v = DB.Manager.main.useCubicVolumes === false ? normalizedValue : Math.cbrt(normalizedValue);
+                        return v * 100;
                     }
 
                     Layout.fillWidth: true

--- a/src/contents/ui/EeChart.qml
+++ b/src/contents/ui/EeChart.qml
@@ -188,9 +188,9 @@ Item {
                 Controls.Label {
                     readonly property real value: {
                         if (logarithimicHorizontalAxis !== true)
-                            return xMin + (index) * axisRepeater.step;
+                            return xMin + index * axisRepeater.step;
                         else
-                            return Math.pow(10, xMinLog + (index) * axisRepeater.step);
+                            return Math.pow(10, xMinLog + index * axisRepeater.step);
                     }
 
                     padding: 0

--- a/src/contents/ui/Exciter.qml
+++ b/src/contents/ui/Exciter.qml
@@ -191,7 +191,8 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using %1", TagsPluginName.Package.calf)
+            text: i18n("Using %1", `<b>${TagsPluginName.Package.calf}</b>`)
+            textFormat: Text.RichText
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/Filter.qml
+++ b/src/contents/ui/Filter.qml
@@ -197,7 +197,8 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using %1", TagsPluginName.Package.lsp)
+            text: i18n("Using %1", `<b>${TagsPluginName.Package.lsp}</b>`)
+            textFormat: Text.RichText
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/Gate.qml
+++ b/src/contents/ui/Gate.qml
@@ -912,7 +912,8 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using %1", TagsPluginName.Package.lsp)
+            text: i18n("Using %1", `<b>${TagsPluginName.Package.lsp}</b>`)
+            textFormat: Text.RichText
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/Limiter.qml
+++ b/src/contents/ui/Limiter.qml
@@ -494,7 +494,8 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using %1", TagsPluginName.Package.lsp)
+            text: i18n("Using %1", `<b>${TagsPluginName.Package.lsp}</b>`)
+            textFormat: Text.RichText
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/Maximizer.qml
+++ b/src/contents/ui/Maximizer.qml
@@ -102,7 +102,8 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using %1", TagsPluginName.Package.zam)
+            text: i18n("Using %1", `<b>${TagsPluginName.Package.zam}</b>`)
+            textFormat: Text.RichText
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/PreferencesSheet.qml
+++ b/src/contents/ui/PreferencesSheet.qml
@@ -13,6 +13,7 @@ Kirigami.OverlaySheet {
     focus: true
     title: i18n("Preferences")
     y: appWindow.header.height + Kirigami.Units.gridUnit
+    implicitWidth: Math.min(stack.implicitWidth, appWindow.width * 0.8)
     implicitHeight: Math.min(2 * preferencesSheet.header.height + stack.implicitHeight, preferencesSheet.parent.height - 2 * preferencesSheet.header.height - preferencesSheet.y)
     onVisibleChanged: {
         if (!preferencesSheet.visible) {

--- a/src/contents/ui/PresetsSheet.qml
+++ b/src/contents/ui/PresetsSheet.qml
@@ -29,6 +29,7 @@ Kirigami.OverlaySheet {
     closePolicy: Controls.Popup.CloseOnEscape | Controls.Popup.CloseOnPressOutsideParent
     focus: true
     y: appWindow.header.height + Kirigami.Units.gridUnit
+    implicitWidth: Math.min(stackView.implicitWidth, appWindow.width * 0.8)
     onVisibleChanged: {
         if (control.visible) {
             switch (DB.Manager.main.visiblePresetSheetPage) {
@@ -50,7 +51,7 @@ Kirigami.OverlaySheet {
     Controls.StackView {
         id: stackView
 
-        implicitWidth: appWindow.width * 0.5
+        implicitWidth: Math.max(appWindow.width * 0.5, Kirigami.Units.gridUnit * 40)
         implicitHeight: control.parent.height - 2 * (control.header.height + control.footer.height) - control.y
     }
 

--- a/src/contents/ui/Speex.qml
+++ b/src/contents/ui/Speex.qml
@@ -175,7 +175,8 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using %1", TagsPluginName.Package.speex)
+            text: i18n("Using %1", `<b>${TagsPluginName.Package.speex}</b>`)
+            textFormat: Text.RichText
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/contents/ui/StereoTools.qml
+++ b/src/contents/ui/StereoTools.qml
@@ -456,7 +456,8 @@ Kirigami.ScrollablePage {
 
     footer: RowLayout {
         Controls.Label {
-            text: i18n("Using %1", TagsPluginName.Package.calf)
+            text: i18n("Using %1", `<b>${TagsPluginName.Package.calf}</b>`)
+            textFormat: Text.RichText
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false

--- a/src/tags_plugin_name.cpp
+++ b/src/tags_plugin_name.cpp
@@ -49,7 +49,7 @@ Model::Model(QObject* parent) : QAbstractListModel(parent) {
               {BaseName::reverb, i18n("Reverberation")},
               {BaseName::rnnoise, i18n("Noise Reduction")},
               {BaseName::speex, i18n("Speech Processor")},
-              {BaseName::spectrum, i18n("Sectrum")},
+              {BaseName::spectrum, i18n("Spectrum")},
               {BaseName::stereoTools, i18n("Stereo Tools")}};
 
   auto* proxyModel = new QSortFilterProxyModel(this);


### PR DESCRIPTION
1. Improved the `implicitWidth` for preferences sheet: it takes the minimum between the stack content and the 80% of the main window, so the overlay won't collapse on the lateral borders of the main window.
2. Improved the `implicitWidth` for presets sheet: same as above, but the stack content takes the maximum between `Kirigami.Units.gridUnit * 40` and half of the main window width. Unfortunately I couldn't manage to fix the `implicitHeight`. I will talk about this issue in the relative ticket.
3. Plugin credits now use rich text format to show the libraries in bold style (without changing the strings for translators). This is something I wanted to do also on Libadwaita in the past, but I never figured out how.
4. Use a separate QML function to construct the labels for the Crystalyzer. 
5. Other little fixes for readability.