### PR TITLE
Fix ninja argument order

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -49,5 +49,5 @@ build() {
 
 package() {
   cd ..
-  DESTDIR="${pkgdir}" ninja install -C build
+  DESTDIR="${pkgdir}" ninja -C build install
 }


### PR DESCRIPTION
Flags after positional arguments are technically invalid and broken for samurai (ninja reimplementation in C).