### PR TITLE
Use existing libpipewire in flatpak runtime

### DIFF
--- a/include/tags_app.hpp
+++ b/include/tags_app.hpp
@@ -21,7 +21,7 @@
 
 namespace tags::app {
 
-inline constexpr auto minimum_pw_version = "0.3.44";
+inline constexpr auto minimum_pw_version = "0.3.70";
 
 inline constexpr auto id = "com.github.wwmm.easyeffects";
 

--- a/util/flatpak/easyeffects-modules.json
+++ b/util/flatpak/easyeffects-modules.json
@@ -2,27 +2,6 @@
     "name": "easyeffects-modules",
     "modules": [
         {
-            "name": "pipewire",
-            "buildsystem": "meson",
-            "config-opts": [
-                "-Dgstreamer=disabled",
-                "-Dman=disabled",
-                "-Dsystemd=disabled",
-                "-Dudev=disabled",
-                "-Dudevrulesdir=disabled",
-                "-Dsession-managers=[]",
-                "-Djack=enabled"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/pipewire/pipewire.git",
-                    "tag": "0.3.69",
-                    "commit": "cd8be0ba3b27542253f7744b699c2ede159e2d7c"
-                }
-            ]
-        },
-        {
             "name": "libsigc++",
             "buildsystem": "meson",
             "config-opts": [


### PR DESCRIPTION
easyeffects bundles an older version of libpipewire to maintain compatability with hosts running pipewire < 0.3

Ubuntu 20.04 LTS is the last major distro with a pipewire < 0.3

Ubuntu 20.04 LTS ends general support at 2025-05-29

Since 20.04 is soon outdated, there is no longer a need to bundle an older libpipewire.