### PR TITLE
Implement separate pitch parameters: cents, semitones, and octaves

### DIFF
--- a/data/schemas/com.github.wwmm.easyeffects.pitch.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.pitch.gschema.xml
@@ -12,24 +12,18 @@
             <range min="-36" max="36" />
             <default>0</default>
         </key>
-        <key name="semitones" type="d">
-            <range min="-12.0" max="12.0" />
-            <default>0.0</default>
-        </key>
-        <!-- New keys -->
         <key name="cents" type="d">
-            <default>0.0</default>
-            <summary>Pitch shift in cents</summary>
-            <description>Amount to shift pitch in cents.</description>
+            <range min="-100" max="100" />
+            <default>0</default>
         </key>
-
+        <key name="semitones" type="d">
+            <range min="-12" max="12" />
+            <default>0</default>
+        </key>
         <key name="octaves" type="d">
-            <default>0.0</default>
-            <summary>Pitch shift in octaves</summary>
-            <description>Amount to shift pitch in octaves.</description>
+            <range min="-3" max="3" />
+            <default>0</default>
         </key>
-        <!-- End of new keys -->
-
         <key name="quick-seek" type="b">
             <default>false</default>
         </key>

--- a/data/schemas/com.github.wwmm.easyeffects.pitch.gschema.xml
+++ b/data/schemas/com.github.wwmm.easyeffects.pitch.gschema.xml
@@ -16,6 +16,20 @@
             <range min="-12.0" max="12.0" />
             <default>0.0</default>
         </key>
+        <!-- New keys -->
+        <key name="cents" type="d">
+            <default>0.0</default>
+            <summary>Pitch shift in cents</summary>
+            <description>Amount to shift pitch in cents.</description>
+        </key>
+
+        <key name="octaves" type="d">
+            <default>0.0</default>
+            <summary>Pitch shift in octaves</summary>
+            <description>Amount to shift pitch in octaves.</description>
+        </key>
+        <!-- End of new keys -->
+
         <key name="quick-seek" type="b">
             <default>false</default>
         </key>

--- a/data/ui/pitch.ui
+++ b/data/ui/pitch.ui
@@ -19,269 +19,227 @@
                         <property name="spacing">12</property>
                         <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkGrid">
-                                <property name="margin-bottom">12</property>
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">24</property>
-                                <property name="column-homogeneous">1</property>
+                            <object class="GtkBox">
+                                <property name="spacing">24</property>
+                                <child>
+                                    <object class="AdwPreferencesPage">
+                                        <child>
+                                            <object class="AdwPreferencesGroup">
+                                                <property name="title" translatable="yes">Quality</property>
 
-                                <child>
-                                    <object class="GtkLabel" id="mode_label">
-                                        <property name="label" translatable="yes">Mode</property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkComboBoxText" id="mode">
-                                        <property name="valign">center</property>
-                                        <items>
-                                            <item translatable="yes" id="HighSpeed">High Speed</item>
-                                            <item translatable="yes" id="HighQuality">High Quality</item>
-                                            <item translatable="yes" id="HighConsistency">High Consistency</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">mode_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
+                                                <child>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Quick Seek</property>
+                                                        <property name="title-lines">2</property>
+                                                        <property name="activatable-widget">quick_seek</property>
+                                                        <child>
+                                                            <object class="GtkSwitch" id="quick_seek">
+                                                                <property name="valign">center</property>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
 
-                                <child>
-                                    <object class="GtkLabel" id="formant_label">
-                                        <property name="label" translatable="yes">Formant</property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkComboBoxText" id="formant">
-                                        <property name="valign">center</property>
-                                        <items>
-                                            <item translatable="yes" id="Shifted">Shifted</item>
-                                            <item translatable="yes" id="Preserved">Preserved</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">formant_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
+                                                <child>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Anti-aliasing</property>
+                                                        <property name="title-lines">2</property>
+                                                        <property name="activatable-widget">anti_alias</property>
+                                                        <child>
+                                                            <object class="GtkSwitch" id="anti_alias">
+                                                                <property name="valign">center</property>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
 
-                        <child>
-                            <object class="GtkGrid">
-                                <property name="margin-top">6</property>
-                                <property name="margin-bottom">12</property>
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">48</property>
-                                <property name="column-homogeneous">1</property>
+                                                <child>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Sequence Length</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="sequence_length">
+                                                                <property name="valign">center</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">0</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">0</property>
+                                                                        <property name="upper">100</property>
+                                                                        <property name="step-increment">1</property>
+                                                                        <property name="page-increment">10</property>
+                                                                    </object>
+                                                                </property>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
 
-                                <child>
-                                    <object class="GtkLabel" id="transients_label">
-                                        <property name="label" translatable="yes">Transients</property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkComboBoxText" id="transients">
-                                        <property name="valign">center</property>
-                                        <items>
-                                            <item translatable="yes" id="Crisp">Crisp</item>
-                                            <item translatable="yes" id="Mixed">Mixed</item>
-                                            <item translatable="yes" id="Smooth">Smooth</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">transients_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
+                                                <child>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Seek Window</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="seek_window">
+                                                                <property name="valign">center</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">0</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">0</property>
+                                                                        <property name="upper">100</property>
+                                                                        <property name="step-increment">1</property>
+                                                                        <property name="page-increment">10</property>
+                                                                    </object>
+                                                                </property>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
 
-                                <child>
-                                    <object class="GtkLabel" id="detector_label">
-                                        <property name="label" translatable="yes">Detector</property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkComboBoxText" id="detector">
-                                        <property name="valign">center</property>
-                                        <items>
-                                            <item translatable="yes" id="Compound">Compound</item>
-                                            <item translatable="yes" id="Percussive">Percussive</item>
-                                            <item translatable="yes" id="Soft">Soft</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">detector_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-
-                                <child>
-                                    <object class="GtkLabel" id="phase_label">
-                                        <property name="label" translatable="yes">Phase</property>
-                                        <layout>
-                                            <property name="column">2</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkComboBoxText" id="phase">
-                                        <property name="valign">center</property>
-                                        <items>
-                                            <item translatable="yes" id="Laminar">Laminar</item>
-                                            <item translatable="yes" id="Independent">Independent</item>
-                                        </items>
-                                        <layout>
-                                            <property name="column">2</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">phase_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-
-                        <child>
-                            <object class="GtkGrid">
-                                <property name="margin-top">6</property>
-                                <property name="margin-bottom">12</property>
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">48</property>
-
-                                <child>
-                                    <object class="GtkLabel" id="cents_label">
-                                        <property name="label" translatable="yes">Cents</property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkSpinButton" id="cents">
-                                        <property name="halign">center</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="digits">0</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">-100</property>
-                                                <property name="upper">100</property>
-                                                <property name="step-increment">1</property>
-                                                <property name="page-increment">10</property>
+                                                <child>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Overlap Length</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="overlap_length">
+                                                                <property name="valign">center</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">0</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">0</property>
+                                                                        <property name="upper">100</property>
+                                                                        <property name="step-increment">1</property>
+                                                                        <property name="page-increment">10</property>
+                                                                    </object>
+                                                                </property>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
                                             </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">0</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">cents_label</relation>
-                                        </accessibility>
+                                        </child>
                                     </object>
                                 </child>
 
                                 <child>
-                                    <object class="GtkLabel" id="semitones_label">
-                                        <property name="label" translatable="yes">Semitones</property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkSpinButton" id="semitones">
-                                        <property name="halign">center</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="digits">0</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">-12</property>
-                                                <property name="upper">12</property>
-                                                <property name="step-increment">1</property>
-                                                <property name="page-increment">1</property>
-                                            </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">1</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">semitones_label</relation>
-                                        </accessibility>
-                                    </object>
-                                </child>
+                                    <object class="AdwPreferencesPage">
+                                        <child>
+                                            <object class="AdwPreferencesGroup">
+                                                <property name="title" translatable="yes">Pitch</property>
 
-                                <child>
-                                    <object class="GtkLabel" id="octaves_label">
-                                        <property name="label" translatable="yes">Octaves</property>
-                                        <layout>
-                                            <property name="column">2</property>
-                                            <property name="row">0</property>
-                                        </layout>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkSpinButton" id="octaves">
-                                        <property name="halign">center</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="width-chars">10</property>
-                                        <property name="digits">0</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="adjustment">
-                                            <object class="GtkAdjustment">
-                                                <property name="lower">-3</property>
-                                                <property name="upper">3</property>
-                                                <property name="step-increment">1</property>
-                                                <property name="page-increment">1</property>
+                                                <child>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Cents</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="cents">
+                                                                <property name="valign">center</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">0</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-100</property>
+                                                                        <property name="upper">100</property>
+                                                                        <property name="step-increment">1</property>
+                                                                        <property name="page-increment">1</property>
+                                                                    </object>
+                                                                </property>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Semitones</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="semitones">
+                                                                <property name="valign">center</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">0</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-12</property>
+                                                                        <property name="upper">12</property>
+                                                                        <property name="step-increment">1</property>
+                                                                        <property name="page-increment">1</property>
+                                                                    </object>
+                                                                </property>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Octaves</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="octaves">
+                                                                <property name="valign">center</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">0</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-3</property>
+                                                                        <property name="upper">3</property>
+                                                                        <property name="step-increment">1</property>
+                                                                        <property name="page-increment">1</property>
+                                                                    </object>
+                                                                </property>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Tempo Difference</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="tempo_difference">
+                                                                <property name="valign">center</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">0</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-50</property>
+                                                                        <property name="upper">100</property>
+                                                                        <property name="step-increment">1</property>
+                                                                        <property name="page-increment">10</property>
+                                                                    </object>
+                                                                </property>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
+
+                                                <child>
+                                                    <object class="AdwActionRow">
+                                                        <property name="title" translatable="yes">Rate Difference</property>
+                                                        <property name="title-lines">2</property>
+                                                        <child>
+                                                            <object class="GtkSpinButton" id="rate_difference">
+                                                                <property name="valign">center</property>
+                                                                <property name="width-chars">10</property>
+                                                                <property name="digits">0</property>
+                                                                <property name="adjustment">
+                                                                    <object class="GtkAdjustment">
+                                                                        <property name="lower">-50</property>
+                                                                        <property name="upper">100</property>
+                                                                        <property name="step-increment">1</property>
+                                                                        <property name="page-increment">10</property>
+                                                                    </object>
+                                                                </property>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </child>
                                             </object>
-                                        </property>
-                                        <layout>
-                                            <property name="column">2</property>
-                                            <property name="row">1</property>
-                                        </layout>
-                                        <accessibility>
-                                            <relation name="labelled-by">octaves_label</relation>
-                                        </accessibility>
+                                        </child>
                                     </object>
                                 </child>
                             </object>
@@ -457,43 +415,34 @@
 
                         <child>
                             <object class="GtkBox">
+                                <property name="spacing">6</property>
                                 <property name="hexpand">1</property>
-                                <property name="vexpand">0</property>
-                                <property name="layout-manager">
-                                    <object class="GtkBinLayout"></object>
-                                </property>
+                                <property name="homogeneous">1</property>
+
+                                <!-- Empty placeholder used only for layout reason -->
+                                <child>
+                                    <object class="GtkLabel"> </object>
+                                </child>
 
                                 <child>
                                     <object class="GtkButton" id="reset_button">
                                         <property name="halign">center</property>
                                         <property name="valign">center</property>
-                                        <property name="hexpand">1</property>
                                         <property name="label" translatable="yes">Reset</property>
                                         <signal name="clicked" handler="on_reset" object="PitchBox" />
                                     </object>
                                 </child>
 
                                 <child>
-                                    <object class="GtkBox">
+                                    <object class="GtkLabel" id="plugin_credit">
                                         <property name="halign">end</property>
-                                        <property name="hexpand">1</property>
-                                        <property name="vexpand">0</property>
-                                        <property name="spacing">6</property>
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="halign">end</property>
-                                                <property name="label" translatable="yes">Using</property>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="halign">end</property>
-                                                <property name="label">Rubber Band</property>
-                                                <attributes>
-                                                    <attribute name="weight" value="bold" />
-                                                </attributes>
-                                            </object>
-                                        </child>
+                                        <property name="xalign">1</property>
+                                        <property name="valign">center</property>
+                                        <property name="wrap">1</property>
+                                        <property name="wrap-mode">word</property>
+                                        <attributes>
+                                            <attribute name="weight" value="bold" />
+                                        </attributes>
                                     </object>
                                 </child>
                             </object>

--- a/data/ui/pitch.ui
+++ b/data/ui/pitch.ui
@@ -19,183 +19,269 @@
                         <property name="spacing">12</property>
                         <property name="orientation">vertical</property>
                         <child>
-                            <object class="GtkBox">
-                                <property name="spacing">24</property>
+                            <object class="GtkGrid">
+                                <property name="margin-bottom">12</property>
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">24</property>
+                                <property name="column-homogeneous">1</property>
+
                                 <child>
-                                    <object class="AdwPreferencesPage">
-                                        <child>
-                                            <object class="AdwPreferencesGroup">
-                                                <property name="title" translatable="yes">Quality</property>
-
-                                                <child>
-                                                    <object class="AdwActionRow">
-                                                        <property name="title" translatable="yes">Quick Seek</property>
-                                                        <property name="title-lines">2</property>
-                                                        <property name="activatable-widget">quick_seek</property>
-                                                        <child>
-                                                            <object class="GtkSwitch" id="quick_seek">
-                                                                <property name="valign">center</property>
-                                                            </object>
-                                                        </child>
-                                                    </object>
-                                                </child>
-
-                                                <child>
-                                                    <object class="AdwActionRow">
-                                                        <property name="title" translatable="yes">Anti-aliasing</property>
-                                                        <property name="title-lines">2</property>
-                                                        <property name="activatable-widget">anti_alias</property>
-                                                        <child>
-                                                            <object class="GtkSwitch" id="anti_alias">
-                                                                <property name="valign">center</property>
-                                                            </object>
-                                                        </child>
-                                                    </object>
-                                                </child>
-
-                                                <child>
-                                                    <object class="AdwActionRow">
-                                                        <property name="title" translatable="yes">Sequence Length</property>
-                                                        <property name="title-lines">2</property>
-                                                        <child>
-                                                            <object class="GtkSpinButton" id="sequence_length">
-                                                                <property name="valign">center</property>
-                                                                <property name="width-chars">10</property>
-                                                                <property name="digits">0</property>
-                                                                <property name="adjustment">
-                                                                    <object class="GtkAdjustment">
-                                                                        <property name="lower">0</property>
-                                                                        <property name="upper">100</property>
-                                                                        <property name="step-increment">1</property>
-                                                                        <property name="page-increment">10</property>
-                                                                    </object>
-                                                                </property>
-                                                            </object>
-                                                        </child>
-                                                    </object>
-                                                </child>
-
-                                                <child>
-                                                    <object class="AdwActionRow">
-                                                        <property name="title" translatable="yes">Seek Window</property>
-                                                        <property name="title-lines">2</property>
-                                                        <child>
-                                                            <object class="GtkSpinButton" id="seek_window">
-                                                                <property name="valign">center</property>
-                                                                <property name="width-chars">10</property>
-                                                                <property name="digits">0</property>
-                                                                <property name="adjustment">
-                                                                    <object class="GtkAdjustment">
-                                                                        <property name="lower">0</property>
-                                                                        <property name="upper">100</property>
-                                                                        <property name="step-increment">1</property>
-                                                                        <property name="page-increment">10</property>
-                                                                    </object>
-                                                                </property>
-                                                            </object>
-                                                        </child>
-                                                    </object>
-                                                </child>
-
-                                                <child>
-                                                    <object class="AdwActionRow">
-                                                        <property name="title" translatable="yes">Overlap Length</property>
-                                                        <property name="title-lines">2</property>
-                                                        <child>
-                                                            <object class="GtkSpinButton" id="overlap_length">
-                                                                <property name="valign">center</property>
-                                                                <property name="width-chars">10</property>
-                                                                <property name="digits">0</property>
-                                                                <property name="adjustment">
-                                                                    <object class="GtkAdjustment">
-                                                                        <property name="lower">0</property>
-                                                                        <property name="upper">100</property>
-                                                                        <property name="step-increment">1</property>
-                                                                        <property name="page-increment">10</property>
-                                                                    </object>
-                                                                </property>
-                                                            </object>
-                                                        </child>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
+                                    <object class="GtkLabel" id="mode_label">
+                                        <property name="label" translatable="yes">Mode</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkComboBoxText" id="mode">
+                                        <property name="valign">center</property>
+                                        <items>
+                                            <item translatable="yes" id="HighSpeed">High Speed</item>
+                                            <item translatable="yes" id="HighQuality">High Quality</item>
+                                            <item translatable="yes" id="HighConsistency">High Consistency</item>
+                                        </items>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">mode_label</relation>
+                                        </accessibility>
                                     </object>
                                 </child>
 
                                 <child>
-                                    <object class="AdwPreferencesPage">
-                                        <child>
-                                            <object class="AdwPreferencesGroup">
-                                                <property name="title" translatable="yes">Pitch</property>
+                                    <object class="GtkLabel" id="formant_label">
+                                        <property name="label" translatable="yes">Formant</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkComboBoxText" id="formant">
+                                        <property name="valign">center</property>
+                                        <items>
+                                            <item translatable="yes" id="Shifted">Shifted</item>
+                                            <item translatable="yes" id="Preserved">Preserved</item>
+                                        </items>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">formant_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
 
-                                                <child>
-                                                    <object class="AdwActionRow">
-                                                        <property name="title" translatable="yes">Semitones</property>
-                                                        <property name="title-lines">2</property>
-                                                        <child>
-                                                            <object class="GtkSpinButton" id="semitones">
-                                                                <property name="valign">center</property>
-                                                                <property name="width-chars">10</property>
-                                                                <property name="digits">2</property>
-                                                                <property name="adjustment">
-                                                                    <object class="GtkAdjustment">
-                                                                        <property name="lower">-12</property>
-                                                                        <property name="upper">12</property>
-                                                                        <property name="step-increment">0.01</property>
-                                                                        <property name="page-increment">0.1</property>
-                                                                    </object>
-                                                                </property>
-                                                            </object>
-                                                        </child>
-                                                    </object>
-                                                </child>
+                        <child>
+                            <object class="GtkGrid">
+                                <property name="margin-top">6</property>
+                                <property name="margin-bottom">12</property>
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">48</property>
+                                <property name="column-homogeneous">1</property>
 
-                                                <child>
-                                                    <object class="AdwActionRow">
-                                                        <property name="title" translatable="yes">Tempo Difference</property>
-                                                        <property name="title-lines">2</property>
-                                                        <child>
-                                                            <object class="GtkSpinButton" id="tempo_difference">
-                                                                <property name="valign">center</property>
-                                                                <property name="width-chars">10</property>
-                                                                <property name="digits">0</property>
-                                                                <property name="adjustment">
-                                                                    <object class="GtkAdjustment">
-                                                                        <property name="lower">-50</property>
-                                                                        <property name="upper">100</property>
-                                                                        <property name="step-increment">1</property>
-                                                                        <property name="page-increment">10</property>
-                                                                    </object>
-                                                                </property>
-                                                            </object>
-                                                        </child>
-                                                    </object>
-                                                </child>
+                                <child>
+                                    <object class="GtkLabel" id="transients_label">
+                                        <property name="label" translatable="yes">Transients</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkComboBoxText" id="transients">
+                                        <property name="valign">center</property>
+                                        <items>
+                                            <item translatable="yes" id="Crisp">Crisp</item>
+                                            <item translatable="yes" id="Mixed">Mixed</item>
+                                            <item translatable="yes" id="Smooth">Smooth</item>
+                                        </items>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">transients_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
 
-                                                <child>
-                                                    <object class="AdwActionRow">
-                                                        <property name="title" translatable="yes">Rate Difference</property>
-                                                        <property name="title-lines">2</property>
-                                                        <child>
-                                                            <object class="GtkSpinButton" id="rate_difference">
-                                                                <property name="valign">center</property>
-                                                                <property name="width-chars">10</property>
-                                                                <property name="digits">0</property>
-                                                                <property name="adjustment">
-                                                                    <object class="GtkAdjustment">
-                                                                        <property name="lower">-50</property>
-                                                                        <property name="upper">100</property>
-                                                                        <property name="step-increment">1</property>
-                                                                        <property name="page-increment">10</property>
-                                                                    </object>
-                                                                </property>
-                                                            </object>
-                                                        </child>
-                                                    </object>
-                                                </child>
+                                <child>
+                                    <object class="GtkLabel" id="detector_label">
+                                        <property name="label" translatable="yes">Detector</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkComboBoxText" id="detector">
+                                        <property name="valign">center</property>
+                                        <items>
+                                            <item translatable="yes" id="Compound">Compound</item>
+                                            <item translatable="yes" id="Percussive">Percussive</item>
+                                            <item translatable="yes" id="Soft">Soft</item>
+                                        </items>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">detector_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="phase_label">
+                                        <property name="label" translatable="yes">Phase</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkComboBoxText" id="phase">
+                                        <property name="valign">center</property>
+                                        <items>
+                                            <item translatable="yes" id="Laminar">Laminar</item>
+                                            <item translatable="yes" id="Independent">Independent</item>
+                                        </items>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">phase_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkGrid">
+                                <property name="margin-top">6</property>
+                                <property name="margin-bottom">12</property>
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">48</property>
+
+                                <child>
+                                    <object class="GtkLabel" id="cents_label">
+                                        <property name="label" translatable="yes">Cents</property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="cents">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">0</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-100</property>
+                                                <property name="upper">100</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">10</property>
                                             </object>
-                                        </child>
+                                        </property>
+                                        <layout>
+                                            <property name="column">0</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">cents_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="semitones_label">
+                                        <property name="label" translatable="yes">Semitones</property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="semitones">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">0</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-12</property>
+                                                <property name="upper">12</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">1</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">semitones_label</relation>
+                                        </accessibility>
+                                    </object>
+                                </child>
+
+                                <child>
+                                    <object class="GtkLabel" id="octaves_label">
+                                        <property name="label" translatable="yes">Octaves</property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">0</property>
+                                        </layout>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkSpinButton" id="octaves">
+                                        <property name="halign">center</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="width-chars">10</property>
+                                        <property name="digits">0</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="adjustment">
+                                            <object class="GtkAdjustment">
+                                                <property name="lower">-3</property>
+                                                <property name="upper">3</property>
+                                                <property name="step-increment">1</property>
+                                                <property name="page-increment">1</property>
+                                            </object>
+                                        </property>
+                                        <layout>
+                                            <property name="column">2</property>
+                                            <property name="row">1</property>
+                                        </layout>
+                                        <accessibility>
+                                            <relation name="labelled-by">octaves_label</relation>
+                                        </accessibility>
                                     </object>
                                 </child>
                             </object>
@@ -371,34 +457,43 @@
 
                         <child>
                             <object class="GtkBox">
-                                <property name="spacing">6</property>
                                 <property name="hexpand">1</property>
-                                <property name="homogeneous">1</property>
-
-                                <!-- Empty placeholder used only for layout reason -->
-                                <child>
-                                    <object class="GtkLabel"> </object>
-                                </child>
+                                <property name="vexpand">0</property>
+                                <property name="layout-manager">
+                                    <object class="GtkBinLayout"></object>
+                                </property>
 
                                 <child>
                                     <object class="GtkButton" id="reset_button">
                                         <property name="halign">center</property>
                                         <property name="valign">center</property>
+                                        <property name="hexpand">1</property>
                                         <property name="label" translatable="yes">Reset</property>
                                         <signal name="clicked" handler="on_reset" object="PitchBox" />
                                     </object>
                                 </child>
 
                                 <child>
-                                    <object class="GtkLabel" id="plugin_credit">
+                                    <object class="GtkBox">
                                         <property name="halign">end</property>
-                                        <property name="xalign">1</property>
-                                        <property name="valign">center</property>
-                                        <property name="wrap">1</property>
-                                        <property name="wrap-mode">word</property>
-                                        <attributes>
-                                            <attribute name="weight" value="bold" />
-                                        </attributes>
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">0</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label" translatable="yes">Using</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="halign">end</property>
+                                                <property name="label">Rubber Band</property>
+                                                <attributes>
+                                                    <attribute name="weight" value="bold" />
+                                                </attributes>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
                             </object>

--- a/include/pitch.hpp
+++ b/include/pitch.hpp
@@ -75,15 +75,13 @@ class Pitch : public PluginBase {
   int seek_window_ms = 15;
   int overlap_length_ms = 8;
 
-  // New fields
-  double cents = 0.0;
-  double octaves = 0.0;
-
-  double semitones = 0.0;
+  int cents = 0;
+  int semitones = 0;
+  int octaves = 0;
   double tempo_difference = 0.0;
   double rate_difference = 0.0;
 
-  void set_semitones();
+  void update_pitch();
   void set_sequence_length();
   void set_seek_window();
   void set_overlap_length();
@@ -92,7 +90,4 @@ class Pitch : public PluginBase {
   void set_tempo_difference();
   void set_rate_difference();
   void init_soundtouch();
-
-  // New method:
-  void update_pitch();
 };

--- a/include/pitch.hpp
+++ b/include/pitch.hpp
@@ -75,6 +75,10 @@ class Pitch : public PluginBase {
   int seek_window_ms = 15;
   int overlap_length_ms = 8;
 
+  // New fields
+  double cents = 0.0;
+  double octaves = 0.0;
+
   double semitones = 0.0;
   double tempo_difference = 0.0;
   double rate_difference = 0.0;
@@ -88,4 +92,7 @@ class Pitch : public PluginBase {
   void set_tempo_difference();
   void set_rate_difference();
   void init_soundtouch();
+
+  // New method:
+  void update_pitch();
 };

--- a/src/pitch.cpp
+++ b/src/pitch.cpp
@@ -193,6 +193,30 @@ Pitch::Pitch(const std::string& tag,
                                           }),
                                           this));
 
+  // For cents
+  gconnections.push_back(g_signal_connect(settings, "changed::cents",
+                                          G_CALLBACK(+[](GSettings* settings, char* key, gpointer user_data) {
+                                            auto* self = static_cast<Pitch*>(user_data);
+                                            self->cents = g_settings_get_double(settings, key);
+                                            if (!self->soundtouch_ready) {
+                                              return;
+                                            }
+                                            self->update_pitch();
+                                          }),
+                                          this));
+
+  // For octaves
+  gconnections.push_back(g_signal_connect(settings, "changed::octaves",
+                                          G_CALLBACK(+[](GSettings* settings, char* key, gpointer user_data) {
+                                            auto* self = static_cast<Pitch*>(user_data);
+                                            self->octaves = g_settings_get_double(settings, key);
+                                            if (!self->soundtouch_ready) {
+                                              return;
+                                            }
+                                            self->update_pitch();
+                                          }),
+                                          this));
+
   setup_input_output_gain();
 }
 
@@ -413,13 +437,11 @@ void Pitch::set_rate_difference() {
 
 void Pitch::init_soundtouch() {
   delete snd_touch;
-
   snd_touch = new soundtouch::SoundTouch();
-
   snd_touch->setSampleRate(rate);
   snd_touch->setChannels(2);
-
-  set_semitones();
+  // Calling for an update of the total coefficient:
+  update_pitch();
   set_quick_seek();
   set_anti_alias();
   set_sequence_length();
@@ -432,3 +454,14 @@ void Pitch::init_soundtouch() {
 auto Pitch::get_latency_seconds() -> float {
   return latency_value;
 }
+
+void Pitch::update_pitch() {
+  if (snd_touch == nullptr) {
+    return;
+  }
+  // Calculate total change in semitones:
+  double total_semitones = semitones + (octaves * 12.0) + (cents / 100.0);
+  std::scoped_lock<std::mutex> lock(data_mutex);
+  snd_touch->setPitchSemiTones(total_semitones);
+}
+

--- a/src/pitch_preset.cpp
+++ b/src/pitch_preset.cpp
@@ -57,6 +57,10 @@ void PitchPreset::save(nlohmann::json& json) {
   json[section][instance_name]["rate-difference"] = g_settings_get_double(settings, "rate-difference");
 
   json[section][instance_name]["semitones"] = g_settings_get_double(settings, "semitones");
+
+  // New keys:
+  json[section][instance_name]["cents"] = g_settings_get_double(settings, "cents");
+  json[section][instance_name]["octaves"] = g_settings_get_double(settings, "octaves");
 }
 
 void PitchPreset::load(const nlohmann::json& json) {
@@ -81,4 +85,8 @@ void PitchPreset::load(const nlohmann::json& json) {
   update_key<double>(json.at(section).at(instance_name), settings, "rate-difference", "rate-difference");
 
   update_key<double>(json.at(section).at(instance_name), settings, "semitones", "semitones");
+
+  // New keys:
+  update_key<double>(json.at(section).at(instance_name), settings, "cents", "cents");
+  update_key<double>(json.at(section).at(instance_name), settings, "octaves", "octaves");
 }

--- a/src/pitch_preset.cpp
+++ b/src/pitch_preset.cpp
@@ -58,8 +58,8 @@ void PitchPreset::save(nlohmann::json& json) {
 
   json[section][instance_name]["semitones"] = g_settings_get_double(settings, "semitones");
 
-  // New keys:
   json[section][instance_name]["cents"] = g_settings_get_double(settings, "cents");
+
   json[section][instance_name]["octaves"] = g_settings_get_double(settings, "octaves");
 }
 
@@ -86,7 +86,7 @@ void PitchPreset::load(const nlohmann::json& json) {
 
   update_key<double>(json.at(section).at(instance_name), settings, "semitones", "semitones");
 
-  // New keys:
   update_key<double>(json.at(section).at(instance_name), settings, "cents", "cents");
+
   update_key<double>(json.at(section).at(instance_name), settings, "octaves", "octaves");
 }

--- a/src/pitch_ui.cpp
+++ b/src/pitch_ui.cpp
@@ -67,6 +67,8 @@ struct _PitchBox {
   GSettings* settings;
 
   Data* data;
+
+  GtkSpinButton *cents, *octaves;
 };
 
 // NOLINTNEXTLINE
@@ -126,9 +128,10 @@ void setup(PitchBox* self, std::shared_ptr<Pitch> pitch, const std::string& sche
   gsettings_bind_widgets<"input-gain", "output-gain">(self->settings, self->input_gain, self->output_gain);
 
   gsettings_bind_widgets<"quick-seek", "anti-alias", "sequence-length", "seek-window", "overlap-length",
-                         "tempo-difference", "rate-difference", "semitones">(
-      self->settings, self->quick_seek, self->anti_alias, self->sequence_length, self->seek_window,
-      self->overlap_length, self->tempo_difference, self->rate_difference, self->semitones);
+  "tempo-difference", "rate-difference", "semitones", "cents", "octaves">(
+    self->settings, self->quick_seek, self->anti_alias, self->sequence_length, self->seek_window,
+    self->overlap_length, self->tempo_difference, self->rate_difference, self->semitones, self->cents, self->octaves);
+
 }
 
 void dispose(GObject* object) {
@@ -193,6 +196,9 @@ void pitch_box_class_init(PitchBoxClass* klass) {
   gtk_widget_class_bind_template_child(widget_class, PitchBox, tempo_difference);
   gtk_widget_class_bind_template_child(widget_class, PitchBox, rate_difference);
   gtk_widget_class_bind_template_child(widget_class, PitchBox, semitones);
+  // New:
+  gtk_widget_class_bind_template_child(widget_class, PitchBox, cents);
+  gtk_widget_class_bind_template_child(widget_class, PitchBox, octaves);
 
   gtk_widget_class_bind_template_callback(widget_class, on_reset);
 }

--- a/src/pitch_ui.cpp
+++ b/src/pitch_ui.cpp
@@ -60,15 +60,13 @@ struct _PitchBox {
   GtkLabel *input_level_left_label, *input_level_right_label, *output_level_left_label, *output_level_right_label,
       *plugin_credit;
 
-  GtkSpinButton *semitones, *sequence_length, *seek_window, *overlap_length, *tempo_difference, *rate_difference;
+  GtkSpinButton *cents, *semitones, *octaves, *sequence_length, *seek_window, *overlap_length, *tempo_difference, *rate_difference;
 
   GtkSwitch *quick_seek, *anti_alias;
 
   GSettings* settings;
 
   Data* data;
-
-  GtkSpinButton *cents, *octaves;
 };
 
 // NOLINTNEXTLINE
@@ -196,7 +194,6 @@ void pitch_box_class_init(PitchBoxClass* klass) {
   gtk_widget_class_bind_template_child(widget_class, PitchBox, tempo_difference);
   gtk_widget_class_bind_template_child(widget_class, PitchBox, rate_difference);
   gtk_widget_class_bind_template_child(widget_class, PitchBox, semitones);
-  // New:
   gtk_widget_class_bind_template_child(widget_class, PitchBox, cents);
   gtk_widget_class_bind_template_child(widget_class, PitchBox, octaves);
 


### PR DESCRIPTION
This pull request introduces changes to the Pitch effect plugin to allow users to adjust the pitch using three separate parameters: **cents**, **semitones**, and **octaves**. Previously, only a single semitones parameter was available.

**Changes include:**
- **Code modifications:**  
    - Added new parameters `cents` and `octaves` to the `Pitch` class.
    - Created a new function `update_pitch()` that calculates the overall pitch shift using the formula:  
    ```
    total_semitones = semitones + (octaves * 12) + (cents / 100)
    ```
    and applies it using SoundTouch.
    - Updated signal handlers to react to changes for the new parameters.
    - Modified `init_soundtouch()` to call `update_pitch()` to set the initial pitch.
- **GSettings Schema:**  
    - Updated the GSettings schema to include new keys for `cents` and `octaves`.

- **User Interface:**  
    - Added new GtkSpinButton widgets for `cents` and `octaves` in the UI template.
     - Updated the UI bindings to include the new keys. 

**Notes:**  
- This change does not alter the underlying SoundTouch library usage; it only modifies how parameters are computed and exposed to the user.

Interface before (since v7.0.5):
![image](https://github.com/user-attachments/assets/9d428af5-16ae-4c7b-8354-5d7e270b4eca)

Interface I propose (like it was in v7.0.4), only `cents`, `semitones` and `octaves` are working: 
![image](https://github.com/user-attachments/assets/519ee8f1-4b80-479b-a388-6f8e8cd167fd)

Please review and let me know if any further adjustments are required.