### PR TITLE
Improve Convolver UI

### DIFF
--- a/src/contents/ui/Convolver.qml
+++ b/src/contents/ui/Convolver.qml
@@ -122,6 +122,10 @@ Kirigami.ScrollablePage {
                 id: combinedImpulseName
 
                 label: "Output Impulse Name"
+
+                validator: RegularExpressionValidator {
+                    regularExpression: /^[^\\/]{1,100}$/ //strings without `/` or `\` (max 100 chars)
+                }
             }
 
             Controls.ProgressBar {
@@ -142,7 +146,10 @@ Kirigami.ScrollablePage {
             icon.name: "path-combine-symbolic"
             onTriggered: {
                 progressBar.visible = true;
-                pluginBackend.combineKernels(firstImpulse.currentText, secondImpulse.currentText, combinedImpulseName.text);
+
+                const saneCombinedImpulseName = combinedImpulseName.text.trim().replace(/(?:\.irs)+$/, "");
+                pluginBackend.combineKernels(firstImpulse.currentText, secondImpulse.currentText, saneCombinedImpulseName);
+
                 combinedImpulseName.clear();
             }
         }


### PR DESCRIPTION
1. Avoid showing `nan` labels in the Graph when the impulse is unset. A small function has been added to check if the chart is a non-empty list. Unfortunately `nan` labels are still visible when Spectrum and LogScale buttons are toggled. I don't know how to avoid that, but at least the labels are not shown when the effect is loaded on an empty/unset impulse.
2. Show a message to the user when the impulse is unset rather than `""`.
3. Sanitize the combined output impulse filename like it has been done for new preset names.

Unfortunately I had issues in the last months with Arch Code OSS (I couldn't update the extensions anymore for an unknown issue), so I had to install Microsoft VSCode from AUR to keep using the latest extensions on other projects I need. I have to say it's not bad, even if it's partially closed source with telemetry. But the good news is that I can install official QT and QML extensions which I find better than the older ones. This will show some minor changes in the syntax format.

The extensions also shows lots of warnings for QML files:

![Screenshot From 2025-06-03 16-52-26](https://github.com/user-attachments/assets/c3a0fc53-ca0b-4a6b-b454-a757790bfb47)
  