### PR TITLE
GlobalShortcuts: fix handle tokens management

### DIFF
--- a/src/global_shortcuts.hpp
+++ b/src/global_shortcuts.hpp
@@ -26,6 +26,7 @@
 #include <QApplication>
 #include <QDBusInterface>
 #include <QObject>
+#include "util.hpp"
 
 class GlobalShortcuts : public QObject {
   Q_OBJECT
@@ -42,8 +43,7 @@ class GlobalShortcuts : public QObject {
                                 const QVariantMap& options);
 
  private:
-  const QString handle_token = QString("ee%1").arg(QCoreApplication::applicationPid());
-  const QString session_handle_token = QString("ee%1").arg(QCoreApplication::applicationPid());
+  const QString session_handle_token = QString("easyeffects%1").arg(util::random_string(32));
 
   QDBusObjectPath response_handle, session_obj_path;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -160,7 +160,7 @@ int main(int argc, char* argv[]) {
 
   // Global shortcuts
 
-  // auto global_shortcuts = std::make_unique<GlobalShortcuts>();
+  auto global_shortcuts = std::make_unique<GlobalShortcuts>();
 
   // Initializing QML
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -31,6 +31,7 @@
 #include <memory>
 #include <numbers>
 #include <ostream>
+#include <random>
 #include <regex>
 #include <string>
 #include <thread>
@@ -150,6 +151,21 @@ void str_trim(std::string& str) {
   // Trim both sides of the given string. See above.
   str_trim_end(str);
   str_trim_start(str);
+}
+
+auto random_string(const size_t& length) -> std::string {
+  static const std::string characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+  std::random_device rd;      // Non-deterministic random number generator
+  std::mt19937 engine(rd());  // Mersenne Twister engine
+  std::uniform_int_distribution<> dist(0, characters.size() - 1);
+  std::string result;
+
+  for (size_t i = 0U; i < length; ++i) {
+    result += characters[dist(engine)];
+  }
+
+  return result;
 }
 
 auto search_filename(const std::filesystem::path& path,

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -70,6 +70,8 @@ void str_trim_start(std::string& str);
 void str_trim_end(std::string& str);
 void str_trim(std::string& str);
 
+auto random_string(const size_t& length) -> std::string;
+
 auto search_filename(const std::filesystem::path& path,
                      const std::string& filename,
                      std::string& full_path_result,


### PR DESCRIPTION
Related to #3834 

As it's stated [here](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html), "the token that the caller provides should be unique and not guessable. To avoid clashes with calls made from unrelated libraries, it is a good idea to use a per-library prefix combined with a random number".

So, as far as I understood, the session handle should be a single token for the whole window/service session, but every D-Bus request should have a different (not guessable) token.

I added an util for generating random strings (appended to app name). Maybe it's too much since the recommendation says "random number", but it can be useful in the future, who knows...

@wwmm Since I can't test the `Activate` signal from command line under Gnome, please do it on your system.

**Edit:** I forgot it. Given that we want to add the toggle bypass global shortcut, I suppose we also want to add an internal one? Maybe with `CTRL+B`? As I made in my test: https://github.com/Digitalone1/easyeffects/blob/6f26e2af921ae62bbf59b9a843fd0bd31a5ade49/src/application.cpp#L814-L826

@wwmm What do you think?