### PR TITLE
Improve Global Shortcuts handling and add internal Bypass toggling

### DIFF
--- a/src/contents/kcfg/easyeffects_db.kcfg
+++ b/src/contents/kcfg/easyeffects_db.kcfg
@@ -36,6 +36,10 @@
             <label>Last used output community package.</label>
             <default code="true">""</default>
         </entry>
+        <entry name="xdgGlobalShortcuts" type="Bool">
+            <label>Enable support for XDG Global Shortcuts</label>
+            <default>false</default>
+        </entry>
         <entry name="showNativePluginUi" type="Bool">
             <label>Show Plugin's Native Window</label>
             <default>false</default>

--- a/src/contents/kcfg/easyeffects_db.kcfg
+++ b/src/contents/kcfg/easyeffects_db.kcfg
@@ -129,7 +129,7 @@
     </group>
     <group name="EffectsPipelines">
         <entry name="bypass" type="Bool">
-            <label>Puts the Effects Pipelines in Passthrough Mode.</label>
+            <label>Global Bypass: Puts the Effects Pipelines in Passthrough Mode.</label>
             <default>false</default>
         </entry>
         <entry name="processAllOutputs" type="Bool">

--- a/src/contents/ui/PreferencesSheet.qml
+++ b/src/contents/ui/PreferencesSheet.qml
@@ -320,6 +320,18 @@ Kirigami.OverlaySheet {
         ColumnLayout {
             FormCard.FormCard {
                 EeSwitch {
+                    id: xdgGlobalShortcuts
+
+                    label: i18n("Global Shortcuts")
+                    subtitle: i18n("Enables support for XDG Global Shortcuts (Easy Effects service needs to be restarted)")
+                    isChecked: DB.Manager.main.xdgGlobalShortcuts
+                    onCheckedChanged: {
+                        if (isChecked !== DB.Manager.main.xdgGlobalShortcuts)
+                            DB.Manager.main.xdgGlobalShortcuts = isChecked;
+                    }
+                }
+
+                EeSwitch {
                     id: showNativePluginUi
 
                     label: i18n("Native Plugin Window")

--- a/src/contents/ui/ShortcutsSheet.qml
+++ b/src/contents/ui/ShortcutsSheet.qml
@@ -61,6 +61,34 @@ Kirigami.OverlaySheet {
             }
 
             Kirigami.Chip {
+                text: "B"
+                closable: false
+                checkable: false
+                down: false
+                hoverEnabled: false
+            }
+        }
+
+        Controls.Label {
+            text: i18n("Toggle Global Bypass")
+        }
+
+        RowLayout {
+            Layout.alignment: Qt.AlignRight
+
+            Kirigami.Chip {
+                text: "Ctrl"
+                checkable: false
+                down: false
+                hoverEnabled: false
+                closable: false
+            }
+
+            Controls.Label {
+                text: i18n("+")
+            }
+
+            Kirigami.Chip {
                 text: "W"
                 closable: false
                 checkable: false

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -74,6 +74,13 @@ Kirigami.ApplicationWindow {
     }
 
     Shortcut {
+        sequences: ["Ctrl+B"]
+        onActivated: {
+            DB.Manager.main.bypass = !DB.Manager.main.bypass;
+        }
+    }
+
+    Shortcut {
         sequences: ["Ctrl+W"]
         onActivated: appWindow.close()
     }
@@ -200,7 +207,7 @@ Kirigami.ApplicationWindow {
                         }
                     },
                     Kirigami.Action {
-                        text: i18n("Turn Effects On/Off")
+                        text: i18n("Global Bypass: Turn Effects On/Off")
                         icon.name: "system-shutdown-symbolic"
                         icon.color: checked === true ? Kirigami.Theme.positiveTextColor : Kirigami.Theme.negativeTextColor
                         displayHint: Kirigami.DisplayHint.IconOnly

--- a/src/global_shortcuts.hpp
+++ b/src/global_shortcuts.hpp
@@ -28,10 +28,19 @@
 #include <QObject>
 #include "util.hpp"
 
+struct GlobalShortcutData {
+  QString shortcut_id;
+  QString description;
+  QString preferred_trigger;
+};
+
 class GlobalShortcuts : public QObject {
   Q_OBJECT
 
  public:
+  std::array<GlobalShortcutData, 1> ee_global_shortcuts_array = {
+      {"toggle_global_bypass", "Toggle Global Bypass", "CTRL+ALT+E"}};
+
   explicit GlobalShortcuts(QObject* parent = nullptr);
 
  public Q_SLOTS:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -160,7 +160,13 @@ int main(int argc, char* argv[]) {
 
   // Global shortcuts
 
-  // auto global_shortcuts = std::make_unique<GlobalShortcuts>();
+  std::unique_ptr<GlobalShortcuts> global_shortcuts;
+
+  if (db::Main::xdgGlobalShortcuts()) {
+    util::info("XDG Global Shortcuts experimental feature is enabled for this session.");
+
+    global_shortcuts = std::make_unique<GlobalShortcuts>();
+  }
 
   // Initializing QML
 


### PR DESCRIPTION
1. Global shortcuts are now defined inside an array, so in the future it should be easy to add other shortcuts alongside description and title.
2. Added the experimental option to enable the Global Shortcuts (needs restart to apply).
3. Added the CTRL+B internal shortcut for Global Bypass toggling.

Unfortunately I can't test this further since I should install the dev build like a normal application which is not suitable to my workflow.

For the problem with BindShortcuts spawning the system settings every time, if it's enough to make it only one time and the shortcut remains correctly registered, you may add an internal bool settings to track the binding.

- The first time the user enables the experimental feature (and restart the app/service), the flag is false and the BindShortcuts call is executed.
- If everything goes right, the flag is changed to true and the next time the BindShortcuts call is skipped.
- If the user changes something and the Bind is lost, they can disable and reenable the Global Shortcuts experimental feature (upon disabling, the flag is turned off/false, and the next time the BindShortcuts call is executed).

This is only an idea and, if it works, it seems more straightforward than looking the Shortcut List. I can't test it, but you may give it a try.