### PR TITLE
Various UI improvements

### DIFF
--- a/src/contents/ui/Autogain.qml
+++ b/src/contents/ui/Autogain.qml
@@ -17,7 +17,7 @@ Kirigami.ScrollablePage {
 
     function updateMeters() {
         if (!pluginBackend)
-            return ;
+            return;
 
         momentary.value = pluginBackend.getMomentaryLevel();
         shortterm.value = pluginBackend.getShorttermLevel();
@@ -61,7 +61,7 @@ Kirigami.ScrollablePage {
                         currentIndex: pluginDB.reference
                         editable: false
                         model: [i18n("Momentary"), i18n("Short-Term"), i18n("Integrated"), i18n("Geometric Mean (MSI)"), i18n("Geometric Mean (MS)"), i18n("Geometric Mean (MI)"), i18n("Geometric Mean (SI)")]
-                        onActivated: (idx) => {
+                        onActivated: idx => {
                             pluginDB.reference = idx;
                         }
 
@@ -69,7 +69,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeSpinBox {
@@ -82,7 +81,7 @@ Kirigami.ScrollablePage {
                         decimals: 2
                         stepSize: 0.1
                         unit: "dB"
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.target = v;
                         }
 
@@ -90,7 +89,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeSpinBox {
@@ -103,7 +101,7 @@ Kirigami.ScrollablePage {
                         decimals: 2
                         stepSize: 0.1
                         unit: "dB"
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.silenceThreshold = v;
                         }
 
@@ -111,7 +109,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeSpinBox {
@@ -124,7 +121,7 @@ Kirigami.ScrollablePage {
                         decimals: 0
                         stepSize: 1
                         unit: "s"
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.maximumHistory = v;
                         }
 
@@ -132,11 +129,8 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -166,7 +160,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeProgressBar {
@@ -183,7 +176,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeProgressBar {
@@ -200,7 +192,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeProgressBar {
@@ -217,7 +208,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeProgressBar {
@@ -234,7 +224,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeProgressBar {
@@ -251,7 +240,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeProgressBar {
@@ -268,15 +256,10 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
-
                 }
-
             }
-
         }
-
     }
 
     header: EeInputOutputGain {
@@ -318,7 +301,5 @@ Kirigami.ScrollablePage {
                 }
             ]
         }
-
     }
-
 }

--- a/src/contents/ui/BassEnhancer.qml
+++ b/src/contents/ui/BassEnhancer.qml
@@ -163,6 +163,7 @@ Kirigami.ScrollablePage {
 
                     EeProgressBar {
                         id: harmonicsLevel
+                        Layout.topMargin: Kirigami.Units.largeSpacing
 
                         label: i18n("Harmonics")
                         from: Common.minimumDecibelLevel

--- a/src/contents/ui/Compressor.qml
+++ b/src/contents/ui/Compressor.qml
@@ -18,7 +18,7 @@ Kirigami.ScrollablePage {
 
     function updateMeters() {
         if (!pluginBackend)
-            return ;
+            return;
 
         inputOutputLevels.inputLevelLeft = pluginBackend.getInputLevelLeft();
         inputOutputLevels.inputLevelRight = pluginBackend.getInputLevelRight();
@@ -71,7 +71,7 @@ Kirigami.ScrollablePage {
                             currentIndex: pluginDB.mode
                             editable: false
                             model: [i18n("Downward"), i18n("Upward"), i18n("Boosting")]
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.mode = idx;
                             }
                         }
@@ -91,7 +91,7 @@ Kirigami.ScrollablePage {
                             unit: "dB"
                             enabled: mode.currentIndex === 1
                             visible: mode.currentIndex === 1
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.boostThreshold = v;
                             }
                         }
@@ -111,7 +111,7 @@ Kirigami.ScrollablePage {
                             unit: "dB"
                             enabled: mode.currentIndex === 2
                             visible: mode.currentIndex === 2
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.boostAmount = v;
                             }
                         }
@@ -127,7 +127,7 @@ Kirigami.ScrollablePage {
                             value: pluginDB.ratio
                             decimals: 0
                             stepSize: 1
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.ratio = v;
                             }
                         }
@@ -144,15 +144,12 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "dB"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.knee = v;
                             }
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -184,7 +181,7 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "dB"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.threshold = v;
                             }
                         }
@@ -200,7 +197,7 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "ms"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.attack = v;
                             }
                         }
@@ -217,7 +214,7 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "dB"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.releaseThreshold = v;
                             }
                         }
@@ -233,15 +230,12 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "ms"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.release = v;
                             }
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -270,7 +264,7 @@ Kirigami.ScrollablePage {
                             currentIndex: pluginDB.sidechainType
                             editable: false
                             model: [i18n("Feed-forward"), i18n("Feed-back"), i18n("External"), i18n("Link")]
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.sidechainType = idx;
                             }
                         }
@@ -289,15 +283,13 @@ Kirigami.ScrollablePage {
                                 for (let n = 0; n < PW.ModelNodes.rowCount(); n++) {
                                     if (PW.ModelNodes.getNodeName(n) === pluginDB.sidechainInputDevice)
                                         return n;
-
                                 }
                                 return 0;
                             }
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 let selectedName = PW.ModelNodes.getNodeName(idx);
                                 if (selectedName !== pluginDB.sidechainInputDevice)
                                     pluginDB.sidechainInputDevice = selectedName;
-
                             }
                         }
 
@@ -309,7 +301,7 @@ Kirigami.ScrollablePage {
                             currentIndex: pluginDB.sidechainMode
                             editable: false
                             model: [i18n("Peak"), i18n("RMS"), i18n("Low-Pass"), i18n("SMA")]
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.sidechainMode = idx;
                             }
                         }
@@ -323,7 +315,7 @@ Kirigami.ScrollablePage {
                             editable: false
                             model: [i18n("Middle"), i18n("Side"), i18n("Left"), i18n("Right"), i18n("Min"), i18n("Max")]
                             visible: !pluginDB.stereoSplit
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.sidechainSource = idx;
                             }
                         }
@@ -337,15 +329,12 @@ Kirigami.ScrollablePage {
                             editable: false
                             model: [i18n("Left/Right"), i18n("Right/Left"), i18n("Mid/Side"), i18n("Side/Mid"), i18n("Min"), i18n("Max")]
                             visible: pluginDB.stereoSplit
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.stereoSplitSource = idx;
                             }
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -378,7 +367,7 @@ Kirigami.ScrollablePage {
                             stepSize: 0.01
                             unit: "dB"
                             minusInfinityMode: true
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.sidechainPreamp = v;
                             }
                         }
@@ -395,7 +384,7 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "ms"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.sidechainReactivity = v;
                             }
                         }
@@ -413,7 +402,7 @@ Kirigami.ScrollablePage {
                             decimals: 3
                             stepSize: 0.001
                             unit: "ms"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.sidechainLookahead = v;
                             }
                         }
@@ -428,7 +417,7 @@ Kirigami.ScrollablePage {
                             currentIndex: pluginDB.hpfMode
                             editable: false
                             model: [i18n("Off"), i18n("12 dB/oct"), i18n("24 dB/oct"), i18n("36 dB/oct")]
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.hpfMode = idx;
                             }
                         }
@@ -443,7 +432,7 @@ Kirigami.ScrollablePage {
                             currentIndex: pluginDB.lpfMode
                             editable: false
                             model: [i18n("Off"), i18n("12 dB/oct"), i18n("24 dB/oct"), i18n("36 dB/oct")]
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.lpfMode = idx;
                             }
                         }
@@ -462,7 +451,7 @@ Kirigami.ScrollablePage {
                             stepSize: 1
                             unit: "Hz"
                             visible: hpfMode.currentIndex !== 0
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.hpfFrequency = v;
                             }
                         }
@@ -484,15 +473,12 @@ Kirigami.ScrollablePage {
                             stepSize: 1
                             unit: "Hz"
                             visible: lpfMode.currentIndex !== 0
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.lpfFrequency = v;
                             }
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -516,7 +502,7 @@ Kirigami.ScrollablePage {
                         stepSize: 0.01
                         unit: "dB"
                         minusInfinityMode: true
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.dry = v;
                         }
 
@@ -524,7 +510,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeSpinBox {
@@ -540,7 +525,7 @@ Kirigami.ScrollablePage {
                         stepSize: 0.01
                         unit: "dB"
                         minusInfinityMode: true
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.wet = v;
                         }
 
@@ -548,7 +533,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeSpinBox {
@@ -564,7 +548,7 @@ Kirigami.ScrollablePage {
                         decimals: 2
                         stepSize: 0.01
                         unit: "dB"
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.makeup = v;
                         }
 
@@ -572,13 +556,9 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
-
                 }
-
             }
-
         }
 
         Kirigami.CardsLayout {
@@ -600,15 +580,17 @@ Kirigami.ScrollablePage {
 
                     Controls.Label {
                         Layout.columnSpan: 2
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
+                        topPadding: Kirigami.Units.smallSpacing
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Reduction")
                     }
 
                     Controls.Label {
                         Layout.columnSpan: 2
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         Layout.leftMargin: Kirigami.Units.gridUnit
+                        topPadding: Kirigami.Units.smallSpacing
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Sidechain")
                     }
@@ -667,32 +649,30 @@ Kirigami.ScrollablePage {
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("L")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("R")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         Layout.leftMargin: Kirigami.Units.gridUnit
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("L")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("R")
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -709,15 +689,17 @@ Kirigami.ScrollablePage {
 
                     Controls.Label {
                         Layout.columnSpan: 2
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
+                        topPadding: Kirigami.Units.smallSpacing
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Curve")
                     }
 
                     Controls.Label {
                         Layout.columnSpan: 2
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         Layout.leftMargin: Kirigami.Units.gridUnit
+                        topPadding: Kirigami.Units.smallSpacing
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Envelope")
                     }
@@ -776,36 +758,32 @@ Kirigami.ScrollablePage {
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("L")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("R")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         Layout.leftMargin: Kirigami.Units.gridUnit
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("L")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("R")
                     }
-
                 }
-
             }
-
         }
-
     }
 
     header: EeInputOutputGain {
@@ -852,7 +830,6 @@ Kirigami.ScrollablePage {
                     onTriggered: {
                         if (pluginDB.sidechainListen != checked)
                             pluginDB.sidechainListen = checked;
-
                     }
                 },
                 Kirigami.Action {
@@ -863,7 +840,6 @@ Kirigami.ScrollablePage {
                     onTriggered: {
                         if (pluginDB.stereoSplit != checked)
                             pluginDB.stereoSplit = checked;
-
                     }
                 },
                 Kirigami.Action {
@@ -875,7 +851,5 @@ Kirigami.ScrollablePage {
                 }
             ]
         }
-
     }
-
 }

--- a/src/contents/ui/Convolver.qml
+++ b/src/contents/ui/Convolver.qml
@@ -362,6 +362,7 @@ Kirigami.ScrollablePage {
         RowLayout {
             Layout.alignment: Qt.AlignHCenter
             Layout.maximumWidth: 0.5 * parent.width
+            Layout.topMargin: Kirigami.Units.mediumSpacing * 2
 
             Controls.Label {
                 Layout.alignment: Qt.AlignHCenter

--- a/src/contents/ui/ConvolverImpulseSheet.qml
+++ b/src/contents/ui/ConvolverImpulseSheet.qml
@@ -106,13 +106,9 @@ Kirigami.OverlaySheet {
                             }
                         ]
                     }
-
                 }
-
             }
-
         }
-
     }
 
     footer: ColumnLayout {
@@ -124,7 +120,6 @@ Kirigami.OverlaySheet {
             visible: false
             showCloseButton: true
         }
-
     }
 
     header: Kirigami.ActionToolBar {
@@ -141,5 +136,4 @@ Kirigami.OverlaySheet {
             }
         ]
     }
-
 }

--- a/src/contents/ui/CrystalizerBand.qml
+++ b/src/contents/ui/CrystalizerBand.qml
@@ -40,7 +40,6 @@ Controls.ItemDelegate {
                 onCheckedChanged: {
                     if (checked != pluginDB["muteBand" + index])
                         pluginDB["muteBand" + index] = checked;
-
                 }
             }
 
@@ -52,12 +51,9 @@ Controls.ItemDelegate {
                 onCheckedChanged: {
                     if (checked != pluginDB["bypassBand" + index])
                         pluginDB["bypassBand" + index] = checked;
-
                 }
             }
-
         }
-
     }
 
     contentItem: ColumnLayout {
@@ -127,7 +123,6 @@ Controls.ItemDelegate {
             onMoved: {
                 if (value != pluginDB["intensityBand" + index])
                     pluginDB["intensityBand" + index] = value;
-
             }
         }
 
@@ -136,7 +131,5 @@ Controls.ItemDelegate {
             text: Number(intensitySlider.value).toLocaleString(Qt.locale(), 'f', 0)
             enabled: false
         }
-
     }
-
 }

--- a/src/contents/ui/DelegateClientsList.qml
+++ b/src/contents/ui/DelegateClientsList.qml
@@ -83,9 +83,6 @@ Kirigami.AbstractCard {
                 text: access
                 color: Kirigami.Theme.disabledTextColor
             }
-
         }
-
     }
-
 }

--- a/src/contents/ui/DelegateModulesList.qml
+++ b/src/contents/ui/DelegateModulesList.qml
@@ -69,9 +69,6 @@ Kirigami.AbstractCard {
                 text: description
                 color: Kirigami.Theme.disabledTextColor
             }
-
         }
-
     }
-
 }

--- a/src/contents/ui/DelegatePluginsList.qml
+++ b/src/contents/ui/DelegatePluginsList.qml
@@ -63,7 +63,6 @@ Item {
                             showPassiveNotification("Enabled:" + name);
                             if (checked !== !bypass)
                                 bypass = !checked;
-
                         }
                     },
                     Kirigami.Action {
@@ -90,9 +89,6 @@ Item {
                     listModel.dataChanged(indexStart, indexEnd, []);
                 }
             }
-
         }
-
     }
-
 }

--- a/src/contents/ui/DelegatePluginsList.qml
+++ b/src/contents/ui/DelegatePluginsList.qml
@@ -60,9 +60,13 @@ Item {
                         checkable: true
                         checked: !bypass
                         onTriggered: {
-                            showPassiveNotification("Enabled:" + name);
-                            if (checked !== !bypass)
-                                bypass = !checked;
+                            if (checked === !bypass) {
+                                return;
+                            }
+
+                            bypass = !checked;
+                            const prefix = bypass ? i18n("Effect Disabled") : i18n("Effect Enabled");
+                            showPassiveNotification(prefix + ": " + name);
                         }
                     },
                     Kirigami.Action {

--- a/src/contents/ui/DelegateStreamsList.qml
+++ b/src/contents/ui/DelegateStreamsList.qml
@@ -77,9 +77,7 @@ Kirigami.AbstractCard {
                         text: state + " · " + format + " · " + rate + " · " + nVolumeChannels + i18n(" channels") + " · " + latency
                         color: Kirigami.Theme.disabledTextColor
                     }
-
                 }
-
             }
 
             ColumnLayout {
@@ -104,10 +102,8 @@ Kirigami.AbstractCard {
                     onCheckedChanged: {
                         if (model.isBlocklisted !== checked)
                             model.isBlocklisted = checked;
-
                     }
                 }
-
             }
 
             RowLayout {
@@ -122,7 +118,6 @@ Kirigami.AbstractCard {
                     onCheckedChanged: {
                         if (checked !== mute)
                             PW.Manager.setNodeMute(serial, checked);
-
                     }
                 }
 
@@ -154,11 +149,7 @@ Kirigami.AbstractCard {
                     Layout.alignment: Qt.AlignHCenter
                     text: Math.round(volumeSlider.value) + "%"
                 }
-
             }
-
         }
-
     }
-
 }

--- a/src/contents/ui/EeProgressBar.qml
+++ b/src/contents/ui/EeProgressBar.qml
@@ -64,9 +64,6 @@ FormCard.AbstractFormDelegate {
                 wrapMode: control.wrapMode
                 maximumLineCount: 1
             }
-
         }
-
     }
-
 }

--- a/src/contents/ui/EeSpinBox.qml
+++ b/src/contents/ui/EeSpinBox.qml
@@ -46,7 +46,7 @@ FormCard.AbstractFormDelegate {
 
     focusPolicy: Kirigami.Settings.isMobile ? Qt.StrongFocus : Qt.NoFocus
     onClicked: spinbox.forceActiveFocus()
-    Keys.onPressed: (event) => {
+    Keys.onPressed: event => {
         if (event.key === Qt.Key_PageUp) {
             const v = control.value + pageSteps * stepSize;
             control.valueModified(Common.clamp(v, control.from, control.to));
@@ -88,7 +88,6 @@ FormCard.AbstractFormDelegate {
                 horizontalAlignment: labelAlignment
                 visible: !Common.isEmpty(control.subtitle)
             }
-
         }
 
         SpinBox {
@@ -158,9 +157,6 @@ FormCard.AbstractFormDelegate {
                 validator: spinbox.validator
                 inputMethodHints: Qt.ImhFormattedNumbersOnly
             }
-
         }
-
     }
-
 }

--- a/src/contents/ui/EeSwitch.qml
+++ b/src/contents/ui/EeSwitch.qml
@@ -39,7 +39,6 @@ FormCard.AbstractFormDelegate {
                 maximumLineCount: 2
                 visible: !Common.isEmpty(control.subtitle)
             }
-
         }
 
         Switch {
@@ -51,7 +50,5 @@ FormCard.AbstractFormDelegate {
             Layout.leftMargin: Kirigami.Units.largeSpacing + Kirigami.Units.smallSpacing
             enabled: control.enabled
         }
-
     }
-
 }

--- a/src/contents/ui/EqualizerUi.js
+++ b/src/contents/ui/EqualizerUi.js
@@ -214,81 +214,81 @@ const import_apo_preset = (text_file) => {
 };
 
 const import_graphiceq_preset = (text_file) => {
-  // INTERNAL PROPERTIES
-  // GraphicEq filter class.
-  class GraphicEQ_Band {
-    freq = 1000;
-    gain = 0;
-  }
-
-  // INTERNAL METHODS
-  const parse_graphiceq_config = (srt, bands) => {
-    // The first parsing stage is to ensure the given string contains a
-    // substring corresponding to the GraphicEQ format reported in the documentation:
-    // https://sourceforge.net/p/equalizerapo/wiki/Configuration%20reference/#graphiceq-since-version-10
-
-    // In order to do it, the following regular expression is used:
-    const re_geq = /graphiceq\s*:((?:\s*\d+(?:,\d+)?(?:\.\d+)?\s+[+-]?\d+(?:\.\d+)?[ \t]*(?:;|$))+)/i;
-
-    // That regex is quite permissive since:
-    // - It's case insensitive;
-    // - Gain values can be signed (with leading +/-);
-    // - Frequency values can use a comma as thousand separator.
-
-    // Note that the last class does not include the newline as whitespaces to allow
-    // matching the `$` as the end of line (not needed in this case, but it will also
-    // work if the input string will be multiline in the future).
-    // This ensures the last band is captured with or without the final `;`.
-    // The regex has been tested at https://regex101.com/r/JRwf4G/1
-
-    const geq_format = srt.match(re_geq);
-
-    // If the format of the string is correct, we capture the full match and a
-    // group related to the sequential bands.
-    if (geq_format === null && geq_format.length !== 2) {
-      return false;
+    // INTERNAL PROPERTIES
+    // GraphicEq filter class.
+    class GraphicEQ_Band {
+        freq = 1000;
+        gain = 0;
     }
 
-    // Save the substring with all the bands and use it to extract the values.
-    const bands_substr = geq_format[1];
+    // INTERNAL METHODS
+    const parse_graphiceq_config = (srt, bands) => {
+        // The first parsing stage is to ensure the given string contains a
+        // substring corresponding to the GraphicEQ format reported in the documentation:
+        // https://sourceforge.net/p/equalizerapo/wiki/Configuration%20reference/#graphiceq-since-version-10
 
-    // Couldn't we extract the values in one only regex checking also the GraphicEQ format?
-    // No, there's no way. Even with Perl Compatible Regex (PCRE) checking the whole format
-    // and capturing the values will return only the last repeated group (the last band),
-    // but we need all of them.
+        // In order to do it, the following regular expression is used:
+        const re_geq = /graphiceq\s*:((?:\s*\d+(?:,\d+)?(?:\.\d+)?\s+[+-]?\d+(?:\.\d+)?[ \t]*(?:;|$))+)/i;
 
-    // So we use the following regex to extract the values from each band.
-    const re_geq_band = /(\d+(?:,\d+)?(?:\.\d+)?)\s+([+-]?\d+(?:\.\d+)?)/g;
+        // That regex is quite permissive since:
+        // - It's case insensitive;
+        // - Gain values can be signed (with leading +/-);
+        // - Frequency values can use a comma as thousand separator.
 
-    // And matchAll with global flag to get all the capturing groups
-    const geq_bands_str = bands_substr.matchAll(re_geq_band);
+        // Note that the last class does not include the newline as whitespaces to allow
+        // matching the `$` as the end of line (not needed in this case, but it will also
+        // work if the input string will be multiline in the future).
+        // This ensures the last band is captured with or without the final `;`.
+        // The regex has been tested at https://regex101.com/r/JRwf4G/1
 
-    // Save values on new objects and push them to bands array.
-    for (const geq_band of geq_bands_str) {
-      let geq_band_obj = new GraphicEQ_Band();
+        const geq_format = srt.match(re_geq);
 
-      geq_band_obj.freq = geq_band[1];
-      geq_band_obj.gain = geq_band[2];
+        // If the format of the string is correct, we capture the full match and a
+        // group related to the sequential bands.
+        if (geq_format === null && geq_format.length !== 2) {
+            return false;
+        }
 
-      bands.push(geq_band_obj);
+        // Save the substring with all the bands and use it to extract the values.
+        const bands_substr = geq_format[1];
+
+        // Couldn't we extract the values in one only regex checking also the GraphicEQ format?
+        // No, there's no way. Even with Perl Compatible Regex (PCRE) checking the whole format
+        // and capturing the values will return only the last repeated group (the last band),
+        // but we need all of them.
+
+        // So we use the following regex to extract the values from each band.
+        const re_geq_band = /(\d+(?:,\d+)?(?:\.\d+)?)\s+([+-]?\d+(?:\.\d+)?)/g;
+
+        // And matchAll with global flag to get all the capturing groups
+        const geq_bands_str = bands_substr.matchAll(re_geq_band);
+
+        // Save values on new objects and push them to bands array.
+        for (const geq_band of geq_bands_str) {
+            let geq_band_obj = new GraphicEQ_Band();
+
+            geq_band_obj.freq = geq_band[1];
+            geq_band_obj.gain = geq_band[2];
+
+            bands.push(geq_band_obj);
+        }
+
+        return bands.length > 0;
+    };
+
+    // FUNCTION BODY
+    let bands = [];
+
+    const lines = text_file.match(/[^\n]+/g);
+
+    for (const line of lines) {
+        // Avoid commented lines.
+        if (line.match(/^[ \t]*#/) !== null) {
+            continue;
+        }
+
+        if (parse_graphiceq_config(line, bands)) {
+            break;
+        }
     }
-
-    return bands.length > 0;
-  };
-
-  // FUNCTION BODY
-  let bands = [];
-
-  const lines = text_file.match(/[^\n]+/g);
-
-  for (const line of lines) {
-    // Avoid commented lines.
-    if (line.match(/^[ \t]*#/) !== null) {
-      continue;
-    }
-
-    if (parse_graphiceq_config(line, bands)) {
-      break;
-    }
-  }
 }

--- a/src/contents/ui/Exciter.qml
+++ b/src/contents/ui/Exciter.qml
@@ -163,6 +163,7 @@ Kirigami.ScrollablePage {
 
                     EeProgressBar {
                         id: harmonicsLevel
+                        Layout.topMargin: Kirigami.Units.largeSpacing
 
                         label: i18n("Harmonics")
                         from: Common.minimumDecibelLevel

--- a/src/contents/ui/Expander.qml
+++ b/src/contents/ui/Expander.qml
@@ -18,7 +18,7 @@ Kirigami.ScrollablePage {
 
     function updateMeters() {
         if (!pluginBackend)
-            return ;
+            return;
 
         inputOutputLevels.inputLevelLeft = pluginBackend.getInputLevelLeft();
         inputOutputLevels.inputLevelRight = pluginBackend.getInputLevelRight();
@@ -71,7 +71,7 @@ Kirigami.ScrollablePage {
                             currentIndex: pluginDB.mode
                             editable: false
                             model: [i18n("Downward"), i18n("Upward")]
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.mode = idx;
                             }
                         }
@@ -87,7 +87,7 @@ Kirigami.ScrollablePage {
                             value: pluginDB.ratio
                             decimals: 0
                             stepSize: 1
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.ratio = v;
                             }
                         }
@@ -104,15 +104,12 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "dB"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.knee = v;
                             }
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -144,7 +141,7 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "dB"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.threshold = v;
                             }
                         }
@@ -160,7 +157,7 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "ms"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.attack = v;
                             }
                         }
@@ -178,7 +175,7 @@ Kirigami.ScrollablePage {
                             stepSize: 0.01
                             unit: "dB"
                             minusInfinityMode: true
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.releaseThreshold = v;
                             }
                         }
@@ -194,15 +191,12 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "ms"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.release = v;
                             }
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -231,7 +225,7 @@ Kirigami.ScrollablePage {
                             currentIndex: pluginDB.sidechainType
                             editable: false
                             model: [i18n("Internal"), i18n("External"), i18n("Link")]
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.sidechainType = idx;
                             }
                         }
@@ -250,15 +244,13 @@ Kirigami.ScrollablePage {
                                 for (let n = 0; n < PW.ModelNodes.rowCount(); n++) {
                                     if (PW.ModelNodes.getNodeName(n) === pluginDB.sidechainInputDevice)
                                         return n;
-
                                 }
                                 return 0;
                             }
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 let selectedName = PW.ModelNodes.getNodeName(idx);
                                 if (selectedName !== pluginDB.sidechainInputDevice)
                                     pluginDB.sidechainInputDevice = selectedName;
-
                             }
                         }
 
@@ -270,7 +262,7 @@ Kirigami.ScrollablePage {
                             currentIndex: pluginDB.sidechainMode
                             editable: false
                             model: [i18n("Peak"), i18n("RMS"), i18n("Low-Pass"), i18n("SMA")]
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.sidechainMode = idx;
                             }
                         }
@@ -284,7 +276,7 @@ Kirigami.ScrollablePage {
                             editable: false
                             model: [i18n("Middle"), i18n("Side"), i18n("Left"), i18n("Right"), i18n("Min"), i18n("Max")]
                             visible: !pluginDB.stereoSplit
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.sidechainSource = idx;
                             }
                         }
@@ -298,15 +290,12 @@ Kirigami.ScrollablePage {
                             editable: false
                             model: [i18n("Left/Right"), i18n("Right/Left"), i18n("Mid/Side"), i18n("Side/Mid"), i18n("Min"), i18n("Max")]
                             visible: pluginDB.stereoSplit
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.stereoSplitSource = idx;
                             }
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -339,7 +328,7 @@ Kirigami.ScrollablePage {
                             stepSize: 0.01
                             unit: "dB"
                             minusInfinityMode: true
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.sidechainPreamp = v;
                             }
                         }
@@ -356,7 +345,7 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "ms"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.sidechainReactivity = v;
                             }
                         }
@@ -374,7 +363,7 @@ Kirigami.ScrollablePage {
                             decimals: 3
                             stepSize: 0.001
                             unit: "ms"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.sidechainLookahead = v;
                             }
                         }
@@ -389,7 +378,7 @@ Kirigami.ScrollablePage {
                             currentIndex: pluginDB.hpfMode
                             editable: false
                             model: [i18n("Off"), i18n("12 dB/oct"), i18n("24 dB/oct"), i18n("36 dB/oct")]
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.hpfMode = idx;
                             }
                         }
@@ -404,7 +393,7 @@ Kirigami.ScrollablePage {
                             currentIndex: pluginDB.lpfMode
                             editable: false
                             model: [i18n("Off"), i18n("12 dB/oct"), i18n("24 dB/oct"), i18n("36 dB/oct")]
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.lpfMode = idx;
                             }
                         }
@@ -423,7 +412,7 @@ Kirigami.ScrollablePage {
                             stepSize: 1
                             unit: "Hz"
                             visible: hpfMode.currentIndex !== 0
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.hpfFrequency = v;
                             }
                         }
@@ -445,15 +434,12 @@ Kirigami.ScrollablePage {
                             stepSize: 1
                             unit: "Hz"
                             visible: lpfMode.currentIndex !== 0
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.lpfFrequency = v;
                             }
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -477,7 +463,7 @@ Kirigami.ScrollablePage {
                         stepSize: 0.01
                         unit: "dB"
                         minusInfinityMode: true
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.dry = v;
                         }
 
@@ -485,7 +471,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeSpinBox {
@@ -501,7 +486,7 @@ Kirigami.ScrollablePage {
                         stepSize: 0.01
                         unit: "dB"
                         minusInfinityMode: true
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.wet = v;
                         }
 
@@ -509,7 +494,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeSpinBox {
@@ -525,7 +509,7 @@ Kirigami.ScrollablePage {
                         decimals: 2
                         stepSize: 0.01
                         unit: "dB"
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.makeup = v;
                         }
 
@@ -533,13 +517,9 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
-
                 }
-
             }
-
         }
 
         Kirigami.CardsLayout {
@@ -561,15 +541,17 @@ Kirigami.ScrollablePage {
 
                     Controls.Label {
                         Layout.columnSpan: 2
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
+                        topPadding: Kirigami.Units.smallSpacing
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Reduction")
                     }
 
                     Controls.Label {
                         Layout.columnSpan: 2
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         Layout.leftMargin: Kirigami.Units.gridUnit
+                        topPadding: Kirigami.Units.smallSpacing
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Sidechain")
                     }
@@ -628,32 +610,30 @@ Kirigami.ScrollablePage {
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("L")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("R")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         Layout.leftMargin: Kirigami.Units.gridUnit
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("L")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("R")
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -670,15 +650,17 @@ Kirigami.ScrollablePage {
 
                     Controls.Label {
                         Layout.columnSpan: 2
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
+                        topPadding: Kirigami.Units.smallSpacing
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Curve")
                     }
 
                     Controls.Label {
                         Layout.columnSpan: 2
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         Layout.leftMargin: Kirigami.Units.gridUnit
+                        topPadding: Kirigami.Units.smallSpacing
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Envelope")
                     }
@@ -737,36 +719,32 @@ Kirigami.ScrollablePage {
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("L")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("R")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         Layout.leftMargin: Kirigami.Units.gridUnit
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("L")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("R")
                     }
-
                 }
-
             }
-
         }
-
     }
 
     header: EeInputOutputGain {
@@ -813,7 +791,6 @@ Kirigami.ScrollablePage {
                     onTriggered: {
                         if (pluginDB.sidechainListen != checked)
                             pluginDB.sidechainListen = checked;
-
                     }
                 },
                 Kirigami.Action {
@@ -824,7 +801,6 @@ Kirigami.ScrollablePage {
                     onTriggered: {
                         if (pluginDB.stereoSplit != checked)
                             pluginDB.stereoSplit = checked;
-
                     }
                 },
                 Kirigami.Action {
@@ -836,7 +812,5 @@ Kirigami.ScrollablePage {
                 }
             ]
         }
-
     }
-
 }

--- a/src/contents/ui/Gate.qml
+++ b/src/contents/ui/Gate.qml
@@ -18,7 +18,7 @@ Kirigami.ScrollablePage {
 
     function updateMeters() {
         if (!pluginBackend)
-            return ;
+            return;
 
         inputOutputLevels.inputLevelLeft = pluginBackend.getInputLevelLeft();
         inputOutputLevels.inputLevelRight = pluginBackend.getInputLevelRight();
@@ -78,7 +78,7 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "ms"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.attack = v;
                             }
                         }
@@ -95,7 +95,7 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "ms"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.release = v;
                             }
                         }
@@ -113,7 +113,7 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "dB"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.reduction = v;
                             }
                         }
@@ -130,7 +130,7 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "dB"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.curveThreshold = v;
                             }
                         }
@@ -147,15 +147,12 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "dB"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.curveZone = v;
                             }
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -184,7 +181,6 @@ Kirigami.ScrollablePage {
                             onCheckedChanged: {
                                 if (isChecked !== pluginDB.hysteresis)
                                     pluginDB.hysteresis = isChecked;
-
                             }
                         }
 
@@ -201,7 +197,7 @@ Kirigami.ScrollablePage {
                             stepSize: 0.01
                             unit: "dB"
                             enabled: hysteresis.isChecked
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.hysteresisThreshold = v;
                             }
                         }
@@ -219,15 +215,12 @@ Kirigami.ScrollablePage {
                             stepSize: 0.01
                             unit: "dB"
                             enabled: hysteresis.isChecked
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.hysteresisZone = v;
                             }
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -256,7 +249,7 @@ Kirigami.ScrollablePage {
                             currentIndex: pluginDB.sidechainType
                             editable: false
                             model: [i18n("Internal"), i18n("External"), i18n("Link")]
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.sidechainType = idx;
                             }
                         }
@@ -275,15 +268,13 @@ Kirigami.ScrollablePage {
                                 for (let n = 0; n < PW.ModelNodes.rowCount(); n++) {
                                     if (PW.ModelNodes.getNodeName(n) === pluginDB.sidechainInputDevice)
                                         return n;
-
                                 }
                                 return 0;
                             }
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 let selectedName = PW.ModelNodes.getNodeName(idx);
                                 if (selectedName !== pluginDB.sidechainInputDevice)
                                     pluginDB.sidechainInputDevice = selectedName;
-
                             }
                         }
 
@@ -295,7 +286,7 @@ Kirigami.ScrollablePage {
                             currentIndex: pluginDB.sidechainMode
                             editable: false
                             model: [i18n("Peak"), i18n("RMS"), i18n("Low-Pass"), i18n("SMA")]
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.sidechainMode = idx;
                             }
                         }
@@ -309,7 +300,7 @@ Kirigami.ScrollablePage {
                             editable: false
                             model: [i18n("Middle"), i18n("Side"), i18n("Left"), i18n("Right"), i18n("Min"), i18n("Max")]
                             visible: !pluginDB.stereoSplit
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.sidechainSource = idx;
                             }
                         }
@@ -323,15 +314,12 @@ Kirigami.ScrollablePage {
                             editable: false
                             model: [i18n("Left/Right"), i18n("Right/Left"), i18n("Mid/Side"), i18n("Side/Mid"), i18n("Min"), i18n("Max")]
                             visible: pluginDB.stereoSplit
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.stereoSplitSource = idx;
                             }
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -364,7 +352,7 @@ Kirigami.ScrollablePage {
                             stepSize: 0.01
                             unit: "dB"
                             minusInfinityMode: true
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.sidechainPreamp = v;
                             }
                         }
@@ -381,7 +369,7 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "ms"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.sidechainReactivity = v;
                             }
                         }
@@ -399,7 +387,7 @@ Kirigami.ScrollablePage {
                             decimals: 3
                             stepSize: 0.001
                             unit: "ms"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.sidechainLookahead = v;
                             }
                         }
@@ -414,7 +402,7 @@ Kirigami.ScrollablePage {
                             currentIndex: pluginDB.hpfMode
                             editable: false
                             model: [i18n("Off"), i18n("12 dB/oct"), i18n("24 dB/oct"), i18n("36 dB/oct")]
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.hpfMode = idx;
                             }
                         }
@@ -429,7 +417,7 @@ Kirigami.ScrollablePage {
                             currentIndex: pluginDB.lpfMode
                             editable: false
                             model: [i18n("Off"), i18n("12 dB/oct"), i18n("24 dB/oct"), i18n("36 dB/oct")]
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.lpfMode = idx;
                             }
                         }
@@ -448,7 +436,7 @@ Kirigami.ScrollablePage {
                             stepSize: 1
                             unit: "Hz"
                             visible: hpfMode.currentIndex !== 0
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.hpfFrequency = v;
                             }
                         }
@@ -470,15 +458,12 @@ Kirigami.ScrollablePage {
                             stepSize: 1
                             unit: "Hz"
                             visible: lpfMode.currentIndex !== 0
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.lpfFrequency = v;
                             }
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -502,7 +487,7 @@ Kirigami.ScrollablePage {
                         stepSize: 0.01
                         unit: "dB"
                         minusInfinityMode: true
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.dry = v;
                         }
 
@@ -510,7 +495,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeSpinBox {
@@ -526,7 +510,7 @@ Kirigami.ScrollablePage {
                         stepSize: 0.01
                         unit: "dB"
                         minusInfinityMode: true
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.wet = v;
                         }
 
@@ -534,7 +518,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeSpinBox {
@@ -550,7 +533,7 @@ Kirigami.ScrollablePage {
                         decimals: 2
                         stepSize: 0.01
                         unit: "dB"
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.makeup = v;
                         }
 
@@ -558,13 +541,9 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
-
                 }
-
             }
-
         }
 
         Kirigami.CardsLayout {
@@ -586,15 +565,17 @@ Kirigami.ScrollablePage {
 
                     Controls.Label {
                         Layout.columnSpan: 2
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
+                        topPadding: Kirigami.Units.smallSpacing
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Reduction")
                     }
 
                     Controls.Label {
                         Layout.columnSpan: 2
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         Layout.leftMargin: Kirigami.Units.gridUnit
+                        topPadding: Kirigami.Units.smallSpacing
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Sidechain")
                     }
@@ -653,32 +634,30 @@ Kirigami.ScrollablePage {
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("L")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("R")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         Layout.leftMargin: Kirigami.Units.gridUnit
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("L")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("R")
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -695,15 +674,17 @@ Kirigami.ScrollablePage {
 
                     Controls.Label {
                         Layout.columnSpan: 2
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
+                        topPadding: Kirigami.Units.smallSpacing
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Curve")
                     }
 
                     Controls.Label {
                         Layout.columnSpan: 2
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         Layout.leftMargin: Kirigami.Units.gridUnit
+                        topPadding: Kirigami.Units.smallSpacing
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Envelope")
                     }
@@ -762,32 +743,30 @@ Kirigami.ScrollablePage {
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("L")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("R")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         Layout.leftMargin: Kirigami.Units.gridUnit
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("L")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("R")
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -797,23 +776,24 @@ Kirigami.ScrollablePage {
                 contentItem: GridLayout {
                     readonly property real radius: 2.5 * Kirigami.Units.gridUnit
 
-                    columnSpacing: Kirigami.Units.largeSpacing
+                    columnSpacing: Kirigami.Units.smallSpacing
                     rowSpacing: Kirigami.Units.largeSpacing
                     columns: 4
                     rows: 3
-                    uniformCellWidths: true
 
                     Controls.Label {
                         Layout.columnSpan: 2
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
+                        topPadding: Kirigami.Units.smallSpacing
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Attack")
                     }
 
                     Controls.Label {
                         Layout.columnSpan: 2
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         Layout.leftMargin: Kirigami.Units.gridUnit
+                        topPadding: Kirigami.Units.smallSpacing
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Release")
                     }
@@ -872,36 +852,32 @@ Kirigami.ScrollablePage {
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Start")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Threshold")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         Layout.leftMargin: Kirigami.Units.gridUnit
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Start")
                     }
 
                     Controls.Label {
-                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Text.AlignHCenter
                         text: i18n("Threshold")
                     }
-
                 }
-
             }
-
         }
-
     }
 
     header: EeInputOutputGain {
@@ -948,7 +924,6 @@ Kirigami.ScrollablePage {
                     onTriggered: {
                         if (pluginDB.sidechainListen != checked)
                             pluginDB.sidechainListen = checked;
-
                     }
                 },
                 Kirigami.Action {
@@ -959,7 +934,6 @@ Kirigami.ScrollablePage {
                     onTriggered: {
                         if (pluginDB.stereoSplit != checked)
                             pluginDB.stereoSplit = checked;
-
                     }
                 },
                 Kirigami.Action {
@@ -971,7 +945,5 @@ Kirigami.ScrollablePage {
                 }
             ]
         }
-
     }
-
 }

--- a/src/contents/ui/Limiter.qml
+++ b/src/contents/ui/Limiter.qml
@@ -18,7 +18,7 @@ Kirigami.ScrollablePage {
 
     function updateMeters() {
         if (!pluginBackend)
-            return ;
+            return;
 
         inputOutputLevels.inputLevelLeft = pluginBackend.getInputLevelLeft();
         inputOutputLevels.inputLevelRight = pluginBackend.getInputLevelRight();
@@ -53,7 +53,7 @@ Kirigami.ScrollablePage {
                         currentIndex: pluginDB.mode
                         editable: false
                         model: [i18n("Herm Thin"), i18n("Herm Wide"), i18n("Herm Tail"), i18n("Herm Duck"), i18n("Exp Thin"), i18n("Exp Wide"), i18n("Exp Tail"), i18n("Exp Duck"), i18n("Line Thin"), i18n("Line Wide"), i18n("Line Tail"), i18n("Line Duck")]
-                        onActivated: (idx) => {
+                        onActivated: idx => {
                             pluginDB.mode = idx;
                         }
 
@@ -61,7 +61,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     FormCard.FormComboBoxDelegate {
@@ -72,7 +71,7 @@ Kirigami.ScrollablePage {
                         currentIndex: pluginDB.oversampling
                         editable: false
                         model: [i18n("None"), i18n("Half x2/16 bit"), i18n("Half x2/24 bit"), i18n("Half x3/16 bit"), i18n("Half x3/24 bit"), i18n("Half x4/16 bit"), i18n("Half x4/24 bit"), i18n("Half x6/16 bit"), i18n("Half x6/24 bit"), i18n("Half x8/16 bit"), i18n("Half x8/24 bit"), i18n("Full x2/16 bit"), i18n("Full x2/24 bit"), i18n("Full x3/16 bit"), i18n("Full x3/24 bit"), i18n("Full x4/16 bit"), i18n("Full x4/24 bit"), i18n("Full x6/16 bit"), i18n("Full x6/24 bit"), i18n("Full x8/16 bit"), i18n("Full x8/24 bit")]
-                        onActivated: (idx) => {
+                        onActivated: idx => {
                             pluginDB.oversampling = idx;
                         }
 
@@ -80,7 +79,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     FormCard.FormComboBoxDelegate {
@@ -91,7 +89,7 @@ Kirigami.ScrollablePage {
                         currentIndex: pluginDB.dithering
                         editable: false
                         model: [i18n("None"), i18n("7 bit"), i18n("8 bit"), i18n("11 bit"), i18n("12 bit"), i18n("15 bit"), i18n("16 bit"), i18n("23 bit"), i18n("24 bit")]
-                        onActivated: (idx) => {
+                        onActivated: idx => {
                             pluginDB.dithering = idx;
                         }
 
@@ -99,11 +97,8 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -125,7 +120,7 @@ Kirigami.ScrollablePage {
                         decimals: 2
                         stepSize: 0.01
                         unit: "dB"
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.threshold = v;
                         }
 
@@ -133,7 +128,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeSpinBox {
@@ -146,7 +140,7 @@ Kirigami.ScrollablePage {
                         decimals: 2
                         stepSize: 0.01
                         unit: "ms"
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.attack = v;
                         }
 
@@ -154,7 +148,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeSpinBox {
@@ -167,7 +160,7 @@ Kirigami.ScrollablePage {
                         decimals: 2
                         stepSize: 0.01
                         unit: "ms"
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.release = v;
                         }
 
@@ -175,7 +168,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeSpinBox {
@@ -188,7 +180,7 @@ Kirigami.ScrollablePage {
                         decimals: 1
                         stepSize: 0.1
                         unit: "%"
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.stereoLink = v;
                         }
 
@@ -196,11 +188,8 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -232,7 +221,7 @@ Kirigami.ScrollablePage {
                             currentIndex: pluginDB.sidechainType
                             editable: false
                             model: [i18n("Internal"), i18n("External"), i18n("Link")]
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 pluginDB.sidechainType = idx;
                             }
                         }
@@ -251,15 +240,13 @@ Kirigami.ScrollablePage {
                                 for (let n = 0; n < PW.ModelNodes.rowCount(); n++) {
                                     if (PW.ModelNodes.getNodeName(n) === pluginDB.sidechainInputDevice)
                                         return n;
-
                                 }
                                 return 0;
                             }
-                            onActivated: (idx) => {
+                            onActivated: idx => {
                                 let selectedName = PW.ModelNodes.getNodeName(idx);
                                 if (selectedName !== pluginDB.sidechainInputDevice)
                                     pluginDB.sidechainInputDevice = selectedName;
-
                             }
                         }
 
@@ -276,7 +263,7 @@ Kirigami.ScrollablePage {
                             stepSize: 0.01
                             unit: "dB"
                             minusInfinityMode: true
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.sidechainPreamp = v;
                             }
                         }
@@ -293,15 +280,12 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "ms"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.lookahead = v;
                             }
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -325,7 +309,7 @@ Kirigami.ScrollablePage {
                         decimals: 2
                         stepSize: 0.01
                         unit: "ms"
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.alrAttack = v;
                         }
 
@@ -333,7 +317,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeSpinBox {
@@ -346,7 +329,7 @@ Kirigami.ScrollablePage {
                         decimals: 1
                         stepSize: 0.1
                         unit: "ms"
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.alrRelease = v;
                         }
 
@@ -354,7 +337,6 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
 
                     EeSpinBox {
@@ -367,7 +349,7 @@ Kirigami.ScrollablePage {
                         decimals: 2
                         stepSize: 0.01
                         unit: "dB"
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.alrKnee = v;
                         }
 
@@ -375,13 +357,9 @@ Kirigami.ScrollablePage {
                             left: parent.left
                             right: parent.right
                         }
-
                     }
-
                 }
-
             }
-
         }
 
         Kirigami.Card {
@@ -403,15 +381,17 @@ Kirigami.ScrollablePage {
 
                 Controls.Label {
                     Layout.columnSpan: 2
-                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignHCenter
+                    topPadding: Kirigami.Units.smallSpacing
                     horizontalAlignment: Text.AlignHCenter
                     text: i18n("Gain")
                 }
 
                 Controls.Label {
                     Layout.columnSpan: 2
-                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignHCenter
                     Layout.leftMargin: Kirigami.Units.gridUnit
+                    topPadding: Kirigami.Units.smallSpacing
                     horizontalAlignment: Text.AlignHCenter
                     text: i18n("Sidechain")
                 }
@@ -470,34 +450,31 @@ Kirigami.ScrollablePage {
                 }
 
                 Controls.Label {
-                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignHCenter
                     horizontalAlignment: Text.AlignHCenter
                     text: i18n("L")
                 }
 
                 Controls.Label {
-                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignHCenter
                     horizontalAlignment: Text.AlignHCenter
                     text: i18n("R")
                 }
 
                 Controls.Label {
-                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignHCenter
                     Layout.leftMargin: Kirigami.Units.gridUnit
                     horizontalAlignment: Text.AlignHCenter
                     text: i18n("L")
                 }
 
                 Controls.Label {
-                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignHCenter
                     horizontalAlignment: Text.AlignHCenter
                     text: i18n("R")
                 }
-
             }
-
         }
-
     }
 
     header: EeInputOutputGain {
@@ -544,7 +521,6 @@ Kirigami.ScrollablePage {
                     onTriggered: {
                         if (pluginDB.gainBoost != checked)
                             pluginDB.gainBoost = checked;
-
                     }
                 },
                 Kirigami.Action {
@@ -555,7 +531,6 @@ Kirigami.ScrollablePage {
                     onTriggered: {
                         if (pluginDB.alr != checked)
                             pluginDB.alr = checked;
-
                     }
                 },
                 Kirigami.Action {
@@ -567,7 +542,5 @@ Kirigami.ScrollablePage {
                 }
             ]
         }
-
     }
-
 }

--- a/src/contents/ui/Maximizer.qml
+++ b/src/contents/ui/Maximizer.qml
@@ -75,6 +75,7 @@ Kirigami.ScrollablePage {
 
                     EeProgressBar {
                         id: reductionLevel
+                        Layout.topMargin: Kirigami.Units.largeSpacing
 
                         label: i18n("Reduction")
                         unit: "dB"

--- a/src/contents/ui/PageStreamsEffects.qml
+++ b/src/contents/ui/PageStreamsEffects.qml
@@ -69,13 +69,9 @@ Kirigami.Page {
                     icon.name: "folder-music-symbolic"
                 }
 
-                delegate: DelegateStreamsList {
-                }
-
+                delegate: DelegateStreamsList {}
             }
-
         }
-
     }
 
     Component {
@@ -103,7 +99,8 @@ Kirigami.Page {
             function createPluginStack(name, baseName, pluginDB) {
                 switch (baseName) {
                 case TagsPluginName.BaseName.autogain:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Autogain.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -111,7 +108,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.bassEnhancer:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/BassEnhancer.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -119,7 +117,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.bassLoudness:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/BassLoudness.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -127,7 +126,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.compressor:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Compressor.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -135,7 +135,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.convolver:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Convolver.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -143,7 +144,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.crossfeed:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Crossfeed.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -151,7 +153,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.crystalizer:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Crystalizer.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -159,7 +162,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.delay:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Delay.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -167,7 +171,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.deesser:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Deesser.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -175,7 +180,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.exciter:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Exciter.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -183,7 +189,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.echoCanceller:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/EchoCanceller.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -191,7 +198,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.expander:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Expander.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -199,7 +207,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.filter:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Filter.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -207,7 +216,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.gate:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Gate.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -215,7 +225,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.levelMeter:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/LevelMeter.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -223,7 +234,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.limiter:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Limiter.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -231,7 +243,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.loudness:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Loudness.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -239,7 +252,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.maximizer:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Maximizer.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -247,7 +261,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.pitch:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Pitch.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -255,7 +270,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.reverb:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Reverb.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -263,7 +279,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.rnnoise:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/RNNoise.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -271,7 +288,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.speex:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/Speex.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -279,7 +297,8 @@ Kirigami.Page {
                     });
                     break;
                 case TagsPluginName.BaseName.stereoTools:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     pluginsStack.push("qrc:ui/StereoTools.qml", {
                         "name": name,
                         "pluginDB": pluginDB,
@@ -287,7 +306,8 @@ Kirigami.Page {
                     });
                     break;
                 default:
-                    while (pluginsStack.depth > 1)pluginsStack.pop()
+                    while (pluginsStack.depth > 1)
+                        pluginsStack.pop();
                     console.log(logTag + " invalid plugin name: " + baseName);
                 }
             }
@@ -299,7 +319,7 @@ Kirigami.Page {
                     if (!streamDB.plugins.includes(streamDB.visiblePlugin))
                         streamDB.visiblePlugin = streamDB.plugins[0];
 
-                    pluginsListView.currentIndex = streamDB.plugins.findIndex((v) => {
+                    pluginsListView.currentIndex = streamDB.plugins.findIndex(v => {
                         return v == streamDB.visiblePlugin;
                     });
                     let baseNames = TagsPluginName.PluginsNameModel.getBaseNames();
@@ -327,7 +347,6 @@ Kirigami.Page {
                 onTriggered: {
                     if (pluginsStack.depth > 1)
                         pluginsStack.currentItem.updateMeters();
-
                 }
             }
 
@@ -339,12 +358,11 @@ Kirigami.Page {
                         currentList.push(pluginsListModel.get(n).name);
                     }
                     if (Common.equalArrays(newList, currentList))
-                        return ;
+                        return;
 
                     populatePluginsListModel(newList);
                     if (newList.length === 1 && pluginsListView.currentIndex === -1)
                         pluginsListView.currentIndex = 0;
-
                 }
 
                 target: pipelineInstance
@@ -361,7 +379,8 @@ Kirigami.Page {
 
                     if (newList.length === 0) {
                         streamDB.visiblePlugin = "";
-                        while (pluginsStack.depth > 1)pluginsStack.pop()
+                        while (pluginsStack.depth > 1)
+                            pluginsStack.pop();
                     }
                 }
 
@@ -410,7 +429,6 @@ Kirigami.Page {
                             duration: Kirigami.Units.longDuration
                             easing.type: Easing.InOutQuad
                         }
-
                     }
 
                     header: RowLayout {
@@ -428,7 +446,6 @@ Kirigami.Page {
                             text: pageType === 0 ? i18n("Players") : i18n("Input Device")
                             enabled: false
                         }
-
                     }
 
                     footer: RowLayout {
@@ -446,11 +463,8 @@ Kirigami.Page {
                             text: pageType === 0 ? "Output Device" : i18n("Recorders")
                             enabled: false
                         }
-
                     }
-
                 }
-
             }
 
             Kirigami.Separator {
@@ -472,13 +486,9 @@ Kirigami.Page {
                         explanation: i18n("Audio Stream Not Modified")
                         icon.name: "folder-music-symbolic"
                     }
-
                 }
-
             }
-
         }
-
     }
 
     Controls.StackView {
@@ -524,7 +534,6 @@ Kirigami.Page {
 
             target: pipelineInstance
         }
-
     }
 
     footer: Kirigami.AbstractApplicationHeader {
@@ -572,7 +581,6 @@ Kirigami.Page {
                             wrapMode: Text.Wrap
                             enabled: false
                         }
-
                     },
                     Kirigami.Action {
                         id: actionLevelSaturation
@@ -607,7 +615,6 @@ Kirigami.Page {
                         actionRateValue.text = `${rate} kHz`;
                     }
                 }
-
             }
 
             Kirigami.ActionToolBar {
@@ -652,9 +659,6 @@ Kirigami.Page {
                     }
                 ]
             }
-
         }
-
     }
-
 }

--- a/src/contents/ui/PipeWirePage.qml
+++ b/src/contents/ui/PipeWirePage.qml
@@ -66,7 +66,6 @@ Kirigami.Page {
                 const comboRow = comboFindRow(PW.ModelSourceDevices, deviceName);
                 if (comboRow !== -1)
                     comboInputDevice.currentIndex = comboRow;
-
             }
 
             function updateOutputDevComboSelection() {
@@ -74,7 +73,6 @@ Kirigami.Page {
                 const comboRow = comboFindRow(PW.ModelSinkDevices, deviceName);
                 if (comboRow !== -1)
                     comboOutputDevice.currentIndex = comboRow;
-
             }
 
             Connections {
@@ -113,7 +111,6 @@ Kirigami.Page {
 
                         if (isChecked !== DB.Manager.streamInputs.useDefaultInputDevice)
                             DB.Manager.streamInputs.useDefaultInputDevice = isChecked;
-
                     }
                 }
 
@@ -126,18 +123,16 @@ Kirigami.Page {
                     model: PW.ModelSourceDevices
                     textRole: "description"
                     enabled: !DB.Manager.streamInputs.useDefaultInputDevice
-                    onActivated: (idx) => {
+                    onActivated: idx => {
                         const proxyIndex = PW.ModelSourceDevices.index(idx, 0);
                         const sourceIndex = PW.ModelSourceDevices.mapToSource(proxyIndex);
                         const nodeName = PW.ModelNodes.getNodeName(sourceIndex.row);
                         if (DB.Manager.streamInputs.inputDevice !== nodeName) {
                             if (!Common.isEmpty(nodeName))
                                 DB.Manager.streamInputs.inputDevice = nodeName;
-
                         }
                     }
                 }
-
             }
 
             FormCard.FormCard {
@@ -154,7 +149,6 @@ Kirigami.Page {
 
                         if (isChecked !== DB.Manager.streamOutputs.useDefaultOutputDevice)
                             DB.Manager.streamOutputs.useDefaultOutputDevice = isChecked;
-
                     }
                 }
 
@@ -167,18 +161,16 @@ Kirigami.Page {
                     model: PW.ModelSinkDevices
                     textRole: "description"
                     enabled: !DB.Manager.streamOutputs.useDefaultOutputDevice
-                    onActivated: (idx) => {
+                    onActivated: idx => {
                         const proxyIndex = PW.ModelSinkDevices.index(idx, 0);
                         const sourceIndex = PW.ModelSinkDevices.mapToSource(proxyIndex);
                         const nodeName = PW.ModelNodes.getNodeName(sourceIndex.row);
                         if (DB.Manager.streamOutputs.outputDevice !== nodeName) {
                             if (!Common.isEmpty(nodeName))
                                 DB.Manager.streamOutputs.outputDevice = nodeName;
-
                         }
                     }
                 }
-
             }
 
             FormCard.FormHeader {
@@ -220,11 +212,8 @@ Kirigami.Page {
                     text: i18n("Default Quantum")
                     description: PW.Manager.defaultQuantum
                 }
-
             }
-
         }
-
     }
 
     Component {
@@ -245,13 +234,9 @@ Kirigami.Page {
                     text: i18n("No Modules")
                 }
 
-                delegate: DelegateModulesList {
-                }
-
+                delegate: DelegateModulesList {}
             }
-
         }
-
     }
 
     Component {
@@ -272,13 +257,9 @@ Kirigami.Page {
                     text: i18n("No Clients")
                 }
 
-                delegate: DelegateClientsList {
-                }
-
+                delegate: DelegateClientsList {}
             }
-
         }
-
     }
 
     Component {
@@ -298,10 +279,8 @@ Kirigami.Page {
                     onCheckedChanged: {
                         if (isChecked !== DB.Manager.testSignals.enable)
                             DB.Manager.testSignals.enable = isChecked;
-
                     }
                 }
-
             }
 
             FormCard.FormHeader {
@@ -319,7 +298,6 @@ Kirigami.Page {
                     onCheckedChanged: {
                         if (checked !== DB.Manager.testSignals.channels)
                             DB.Manager.testSignals.channels = 0;
-
                     }
                 }
 
@@ -331,7 +309,6 @@ Kirigami.Page {
                     onCheckedChanged: {
                         if (checked !== DB.Manager.testSignals.channels)
                             DB.Manager.testSignals.channels = 1;
-
                     }
                 }
 
@@ -343,10 +320,8 @@ Kirigami.Page {
                     onCheckedChanged: {
                         if (checked !== DB.Manager.testSignals.channels)
                             DB.Manager.testSignals.channels = 2;
-
                     }
                 }
-
             }
 
             FormCard.FormHeader {
@@ -364,7 +339,6 @@ Kirigami.Page {
                     onCheckedChanged: {
                         if (checked !== DB.Manager.testSignals.signalType)
                             DB.Manager.testSignals.signalType = 0;
-
                     }
                 }
 
@@ -376,7 +350,6 @@ Kirigami.Page {
                     onCheckedChanged: {
                         if (checked !== DB.Manager.testSignals.signalType)
                             DB.Manager.testSignals.signalType = 1;
-
                     }
                 }
 
@@ -391,17 +364,13 @@ Kirigami.Page {
                     stepSize: 1
                     unit: "Hz"
                     enabled: sineWave.checked
-                    onValueModified: (v) => {
+                    onValueModified: v => {
                         if (v !== DB.Manager.testSignals.frequency)
                             DB.Manager.testSignals.frequency = v;
-
                     }
                 }
-
             }
-
         }
-
     }
 
     GridLayout {
@@ -470,11 +439,8 @@ Kirigami.Page {
                         color: Kirigami.Theme.textColor
                         wrapMode: Text.WordWrap
                     }
-
                 }
-
             }
-
         }
 
         Kirigami.Separator {
@@ -488,7 +454,5 @@ Kirigami.Page {
             Layout.fillHeight: true
             Layout.fillWidth: true
         }
-
     }
-
 }

--- a/src/contents/ui/PresetsLocalPage.qml
+++ b/src/contents/ui/PresetsLocalPage.qml
@@ -102,7 +102,6 @@ ColumnLayout {
         validator: RegularExpressionValidator {
             regularExpression: /^[^\\/]{1,100}$/ //strings without `/` or `\` (max 100 chars)
         }
-
     }
 
     Kirigami.SearchField {
@@ -148,7 +147,6 @@ ColumnLayout {
                 onClicked: {
                     if (Presets.Manager.loadLocalPresetFile(pipeline, name) === false)
                         showPresetsMenuStatus(i18n("The Preset %1 failed to load", name));
-
                 }
 
                 contentItem: RowLayout {
@@ -183,11 +181,8 @@ ColumnLayout {
                             }
                         ]
                     }
-
                 }
-
             }
-
         }
 
         Controls.ScrollBar {
@@ -196,7 +191,6 @@ ColumnLayout {
             parent: listviewRow
             Layout.fillHeight: true
         }
-
     }
 
     Kirigami.InlineMessage {
@@ -207,5 +201,4 @@ ColumnLayout {
         visible: false
         showCloseButton: true
     }
-
 }

--- a/src/contents/ui/Reverb.qml
+++ b/src/contents/ui/Reverb.qml
@@ -17,7 +17,7 @@ Kirigami.ScrollablePage {
 
     function updateMeters() {
         if (!pluginBackend)
-            return ;
+            return;
 
         inputOutputLevels.inputLevelLeft = pluginBackend.getInputLevelLeft();
         inputOutputLevels.inputLevelRight = pluginBackend.getInputLevelRight();
@@ -53,7 +53,7 @@ Kirigami.ScrollablePage {
                         currentIndex: pluginDB.roomSize
                         editable: false
                         model: [i18n("Small"), i18n("Medium"), i18n("Large"), i18n("Tunnel-like"), i18n("Large/smooth"), i18n("Experimental")]
-                        onActivated: (idx) => {
+                        onActivated: idx => {
                             pluginDB.roomSize = idx;
                         }
                     }
@@ -68,7 +68,7 @@ Kirigami.ScrollablePage {
                         decimals: 2
                         stepSize: 0.01
                         unit: "s"
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.decayTime = v;
                         }
                     }
@@ -83,7 +83,7 @@ Kirigami.ScrollablePage {
                         decimals: 0
                         stepSize: 1
                         unit: "ms"
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.predelay = v;
                         }
                     }
@@ -98,13 +98,11 @@ Kirigami.ScrollablePage {
                         decimals: 2
                         stepSize: 0.01
                         unit: "%"
-                        onValueModified: (v) => {
+                        onValueModified: v => {
                             pluginDB.diffusion = v;
                         }
                     }
-
                 }
-
             }
 
             Kirigami.Card {
@@ -133,7 +131,7 @@ Kirigami.ScrollablePage {
                             decimals: 2
                             stepSize: 0.01
                             unit: "Hz"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.hfDamp = v;
                             }
                         }
@@ -150,7 +148,7 @@ Kirigami.ScrollablePage {
                             decimals: 0
                             stepSize: 1
                             unit: "Hz"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.bassCut = v;
                             }
                         }
@@ -167,7 +165,7 @@ Kirigami.ScrollablePage {
                             decimals: 0
                             stepSize: 1
                             unit: "Hz"
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.trebleCut = v;
                             }
                         }
@@ -185,7 +183,7 @@ Kirigami.ScrollablePage {
                             stepSize: 0.1
                             unit: "dB"
                             minusInfinityMode: true
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.dry = v;
                             }
                         }
@@ -203,19 +201,14 @@ Kirigami.ScrollablePage {
                             stepSize: 0.1
                             unit: "dB"
                             minusInfinityMode: true
-                            onValueModified: (v) => {
+                            onValueModified: v => {
                                 pluginDB.amount = v;
                             }
                         }
-
                     }
-
                 }
-
             }
-
         }
-
     }
 
     Kirigami.MenuDialog {
@@ -354,7 +347,5 @@ Kirigami.ScrollablePage {
                 }
             ]
         }
-
     }
-
 }


### PR DESCRIPTION
As the title says.

I noticed in the Gate level meters that the padding is not natural on labels as the other widgets. It seems that `fillwidth: true` let the text collapse on the container border. Using Qt style center alignment in its place is better. Besides using the `uniformCellWidths` is not a good idea because translations can have different lengths showing an unnecessary empty space on a single side of the container.

@wwmm If you work on the port of the next plugins, can you please prioritize Multiband Gate and Equalizer? If these two are implemented, I could definitively switch to the Qt branch installing it in place of the current one. This could help me in discovering bugs.

Porting these two plugins, do you think it's ready to be used on a daily basis? Does presets autoload work?