### PR TITLE
pulseeffects: Fix Boost 1.88 compilation with boost::process::v1

### DIFF
--- a/include/boost_process_compat.hpp
+++ b/include/boost_process_compat.hpp
@@ -1,0 +1,33 @@
+/*
+ * Work around a missing boost/process/v1.h header as of boost 1.88
+ * -> https://github.com/boostorg/process/issues/480
+ */
+
+#include <boost/version.hpp>
+#if BOOST_VERSION < 108800
+#include <boost/process.hpp>
+#else
+#if !defined(BOOST_PROCESS_VERSION)
+#define  BOOST_PROCESS_VERSION 1
+#define  BOOST_PROCESS_V1_INLINE inline
+#endif
+#include <boost/process/v1/args.hpp>
+#include <boost/process/v1/async.hpp>
+#include <boost/process/v1/async_system.hpp>
+#include <boost/process/v1/group.hpp>
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/cmd.hpp>
+#include <boost/process/v1/env.hpp>
+#include <boost/process/v1/environment.hpp>
+#include <boost/process/v1/error.hpp>
+#include <boost/process/v1/exe.hpp>
+#include <boost/process/v1/group.hpp>
+#include <boost/process/v1/handles.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/pipe.hpp>
+#include <boost/process/v1/shell.hpp>
+#include <boost/process/v1/search_path.hpp>
+#include <boost/process/v1/spawn.hpp>
+#include <boost/process/v1/system.hpp>
+#include <boost/process/v1/start_dir.hpp>
+#endif

--- a/src/pulse_info_ui.cpp
+++ b/src/pulse_info_ui.cpp
@@ -19,7 +19,7 @@
 
 #include "pulse_info_ui.hpp"
 #include <boost/algorithm/string.hpp>
-#include <boost/process.hpp>
+#include "boost_process_compat.hpp"
 #include "util.hpp"
 
 PulseInfoUi::PulseInfoUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& builder, PulseManager* pm_ptr)


### PR DESCRIPTION
Boost 1.88 switched the boost/process implementation from v1 to v2.

See https://github.com/boostorg/process/issues/480

This breaks compilation of pulse_info_ui.cpp with the errors:

> ../easyeffects-4.8.7/src/pulse_info_ui.cpp:182:21: error: ipstream is not a member of boost::process
>  182 |     boost::process::ipstream pipe_stream;
>      |                     ^~~~~~~~
>../easyeffects-4.8.7/src/pulse_info_ui.cpp:183:21: error: child is not a member of boost::process
>  183 |     boost::process::child c(command, boost::process::std_out > pipe_stream);
>      |                     ^~~~~
>../easyeffects-4.8.7/src/pulse_info_ui.cpp:187:12: error: pipe_stream was not declared in this scope; did you mean pa_stream?
>  187 |     while (pipe_stream && std::getline(pipe_stream, line) && !line.empty()) {
>      |            ^~~~~~~~~~~`

This PR adds a compatibility include file to pull in the boost:process:v1 headers.