### PR TITLE
Replace gain scale widgets with spinButtons

### DIFF
--- a/data/ui/equalizer.ui
+++ b/data/ui/equalizer.ui
@@ -390,11 +390,9 @@
                             <object class="GtkBox">
                                 <property name="hexpand">1</property>
                                 <property name="vexpand">0</property>
-                                <property name="homogeneous">1</property>
-                                <property name="spacing">6</property>
+                                <property name="spacing">12</property>
                                 <child>
                                     <object class="GtkBox">
-                                        <property name="hexpand">1</property>
                                         <property name="vexpand">0</property>
                                         <property name="spacing">6</property>
                                         <child>
@@ -406,8 +404,8 @@
                                         </child>
                                         <child>
                                             <object class="GtkSpinButton" id="input_gain">
-                                                <property name="hexpand">1</property>
                                                 <property name="valign">center</property>
+                                                <property name="width-chars">11</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
                                                         <property name="lower">-36</property>
@@ -427,6 +425,7 @@
                                 <child>
                                     <object class="GtkBox">
                                         <property name="orientation">vertical</property>
+                                        <property name="hexpand">1</property>
                                         <child>
                                             <object class="GtkBox">
                                                 <property name="spacing">6</property>
@@ -472,11 +471,9 @@
                             <object class="GtkBox">
                                 <property name="hexpand">1</property>
                                 <property name="vexpand">0</property>
-                                <property name="homogeneous">1</property>
-                                <property name="spacing">6</property>
+                                <property name="spacing">12</property>
                                 <child>
                                     <object class="GtkBox">
-                                        <property name="hexpand">1</property>
                                         <property name="vexpand">0</property>
                                         <property name="spacing">6</property>
                                         <child>
@@ -488,8 +485,8 @@
                                         </child>
                                         <child>
                                             <object class="GtkSpinButton" id="output_gain">
-                                                <property name="hexpand">1</property>
                                                 <property name="valign">center</property>
+                                                <property name="width-chars">11</property>
                                                 <property name="adjustment">
                                                     <object class="GtkAdjustment">
                                                         <property name="lower">-36</property>
@@ -509,6 +506,7 @@
                                 <child>
                                     <object class="GtkBox">
                                         <property name="orientation">vertical</property>
+                                        <property name="hexpand">1</property>
                                         <child>
                                             <object class="GtkBox">
                                                 <property name="spacing">6</property>

--- a/data/ui/equalizer.ui
+++ b/data/ui/equalizer.ui
@@ -405,7 +405,7 @@
                                             </object>
                                         </child>
                                         <child>
-                                            <object class="GtkScale" id="input_gain">
+                                            <object class="GtkSpinButton" id="input_gain">
                                                 <property name="hexpand">1</property>
                                                 <property name="valign">center</property>
                                                 <property name="adjustment">
@@ -416,9 +416,7 @@
                                                         <property name="page-increment">1</property>
                                                     </object>
                                                 </property>
-                                                <property name="draw-value">1</property>
                                                 <property name="digits">1</property>
-                                                <property name="value-pos">right</property>
                                                 <accessibility>
                                                     <property name="label" translatable="yes">Plugin Input Gain</property>
                                                 </accessibility>
@@ -489,7 +487,7 @@
                                             </object>
                                         </child>
                                         <child>
-                                            <object class="GtkScale" id="output_gain">
+                                            <object class="GtkSpinButton" id="output_gain">
                                                 <property name="hexpand">1</property>
                                                 <property name="valign">center</property>
                                                 <property name="adjustment">
@@ -500,9 +498,7 @@
                                                         <property name="page-increment">1</property>
                                                     </object>
                                                 </property>
-                                                <property name="draw-value">1</property>
                                                 <property name="digits">1</property>
-                                                <property name="value-pos">right</property>
                                                 <accessibility>
                                                     <property name="label" translatable="yes">Plugin Output Gain</property>
                                                 </accessibility>

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -100,7 +100,7 @@ struct _EqualizerBox {
 
   AdwToastOverlay* toast_overlay;
 
-  GtkScale *input_gain, *output_gain;
+  GtkSpinButton *input_gain, *output_gain;
 
   GtkLevelBar *input_level_left, *input_level_right, *output_level_left, *output_level_right;
 
@@ -1183,7 +1183,7 @@ void equalizer_box_init(EqualizerBox* self) {
 
   prepare_spinbuttons<"st">(self->pitch_left, self->pitch_right);
 
-  prepare_scales<"dB">(self->input_gain, self->output_gain);
+  prepare_spinbuttons<"dB">(self->input_gain, self->output_gain);
 }
 
 auto create() -> EqualizerBox* {


### PR DESCRIPTION
First ever PR on any project, so forgive me if I put the cart before the horse on anything, like if I'm supposed to get an Issue added first.

**The issue:**
Using scale widgets for gain adjustment is dangerous, in my experience. The gain range is from -30dB to +30dB, a 60dB swing. I personally use an EQ for my headphones based on Oratory1990's Harman adjustment for Sennheiser HD650s, which calls for a -9.3dB gain. 

But inadvertently clicking on the bar at any point instantly changes the gain to that level. More crucially, clicking on the label to the right of the scale (still part of the scale widget) instantly raises the gain the maximum +30dB setting. I clicked on the label hoping that it was editable, because using my mouse to edit the gain made it hard to enter -9.3dB exactly. It kept skipping over. When I clicked, I was hit with a +40dB blast of distorted noise.

**Solution**
For this reason, a spin button is better. Much finer control, the ability to enter in a value using keyboard values, and no risk of accidentally damaging hearing/equipment.

Two files are changed, fairly self-explanatory if you look at the changes below. I used AI to help with the .ui file, as I don't have experience with Gtk layout. Hopefully the changes are not too clumsy.
