### PR TITLE
APO export: handle unsupported LSP EQ filters

### DIFF
--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -586,7 +586,14 @@ auto export_apo_preset(EqualizerBox* self, GFile* file) {
     }
 
     APO_Band apo_band;
-    apo_band.type = EasyEffectsToApoFilter.at(curr_band_type);
+
+    try {
+      apo_band.type = EasyEffectsToApoFilter.at(curr_band_type);
+    } catch (std::out_of_range const&) {
+      // LSP filters not supported in APO defaults to Peak/Bell (see ticket #3882)
+      apo_band.type = "PK";
+    }
+
     apo_band.freq = g_settings_get_double(self->settings_left, band_frequency[i].data());
     apo_band.gain = g_settings_get_double(self->settings_left, band_gain[i].data());
     apo_band.quality = g_settings_get_double(self->settings_left, band_q[i].data());

--- a/util/NEWS.yaml
+++ b/util/NEWS.yaml
@@ -4,10 +4,12 @@ Date: UNRELEASED_DATE
 
 Description: 
 - Features∶
-- 
+- The Pitch plugin has new cents and octaves parameters.
+- The client-rt.conf is ignored on 1.4.0 or newer PipeWire versions.
 
 - Bug fixes∶
-- 
+- APO export does not crash anymore when an unsupported LSP Equalizer filter is set.
+- Fixed a bug in LADSPA wrapper.
 
 - Other notes∶
 - 


### PR DESCRIPTION
Related to #3882 

Can we make this as the last release before the Qt switch?