### PR TITLE
Add JSDoc + small fixes

### DIFF
--- a/src/contents/ui/Common.js
+++ b/src/contents/ui/Common.js
@@ -1,6 +1,13 @@
+/** @type {number} */
 var minimumLinearLevel = 0.00001;
+/** @type {number} */
 var minimumDecibelLevel = -100.0;
 
+/**
+ * Check if a variable of any type is empty.
+ * @param {*} v 
+ * @returns {boolean}
+ */
 function isEmpty(v) {
     switch (typeof v) {
         case "string":
@@ -16,6 +23,12 @@ function isEmpty(v) {
     }
 }
 
+/**
+ * Check if two given arrays are equal.
+ * @param {Array} a 
+ * @param {Array} b 
+ * @returns {boolean}
+ */
 function equalArrays(a, b) {
     if (a.length !== b.length) {
         return false;
@@ -33,12 +46,34 @@ function equalArrays(a, b) {
     return true;
 }
 
+/**
+ * Clamps a number within the range of min and max parameters.
+ * @param {number} num The number to clamp. 
+ * @param {number} min Minimum bound.
+ * @param {number} max Maximum bound.
+ * @returns {number} Clamped value.
+ */
 function clamp(num, min, max) { return Math.min(Math.max(num, min), max); }
 
+/**
+ * A simple polyfill implementation of RegExp.escape() static method which is currently not available in QML 
+ * Javascript engine.
+ * Given a regex string as parameter, it escapes any potential regex syntax characters and returns a new string 
+ * that can be safely used as a literal pattern for the RegExp() constructor.
+ * Mostly used for QML SearchField widgets.
+ * @param {string} str Original regex.
+ * @returns {string} Escaped regex.
+ */
 function regExpEscape(str) {
     return str.replace(/[\\/^$*+?.()|[\]{}\-]/g, '\\$&');
 }
 
+/**
+ * Returns the decibel level of a linear value. If the value is lesser then minimumLinearLevel, 
+ * the minimumDecibelLevel is returned.
+ * @param {*} value The linear value.
+ * @returns {number} The decibel level.
+ */
 function linearTodb(value) {
     if (value >= minimumLinearLevel) {
         return 20.0 * Math.log10(value);
@@ -47,8 +82,13 @@ function linearTodb(value) {
     return minimumDecibelLevel;
 }
 
+/**
+ * A debugging function which prints the properties of a given object or any other collection type such as Array.
+ * Since it uses the "in" operator, an exception can be raised if a primitive type is given as a parameter.
+ * @param {*} obj 
+ */
 function printObjectProperties(obj) {
-    for (var prop in obj) {
+    for (let prop in obj) {
         print(prop += " (" + typeof (obj[prop]) + ") = " + obj[prop]);
     }
 }

--- a/src/equalizer.cpp
+++ b/src/equalizer.cpp
@@ -82,7 +82,7 @@ Equalizer::Equalizer(const std::string& tag, pw::Manager* pipe_manager, Pipeline
   */
 
   connect(settings, &db::Equalizer::numBandsChanged, [&]() {
-    for (int n = 0U; n < max_bands; n++) {
+    for (int n = 0; n < max_bands; n++) {
       if (n >= settings->numBands()) {  // turn off unused bands
         settings_left->setProperty(tags::equalizer::band_type[n].data(), 0);
 
@@ -240,8 +240,8 @@ void Equalizer::sort_bands() {
     bool mute;
   };
 
-  const auto used_bands = static_cast<uint>(settings->numBands());
-  if (used_bands < 1U || used_bands > max_bands) {
+  const auto used_bands = settings->numBands();
+  if (used_bands < 1 || used_bands > max_bands) {
     return;
   }
 
@@ -256,7 +256,7 @@ void Equalizer::sort_bands() {
   // for (auto* channel : settings_channels) {
   //   std::multimap<double, struct EQ_Band> sorted_bands;
 
-  //   for (uint n = 0U; n < used_bands; n++) {
+  //   for (int n = 0; n < used_bands; n++) {
   //     const auto f = g_settings_get_double(channel, band_frequency[n].data());
 
   //     sorted_bands.emplace(
@@ -271,7 +271,7 @@ void Equalizer::sort_bands() {
   //                                               .mute = g_settings_get_boolean(channel, band_mute[n].data())}));
   //   }
 
-  //   for (uint n = 0U; const auto& p : sorted_bands) {
+  //   for (int n = 0; const auto& p : sorted_bands) {
   //     g_settings_set_double(channel, band_frequency[n].data(), p.second.freq);
   //     g_settings_set_enum(channel, band_type[n].data(), p.second.type);
   //     g_settings_set_enum(channel, band_mode[n].data(), p.second.mode);

--- a/src/equalizer.hpp
+++ b/src/equalizer.hpp
@@ -66,7 +66,7 @@ class Equalizer : public PluginBase {
 
   Q_INVOKABLE void calculateFrequencies();
 
-  static constexpr int max_bands = 32U;
+  static constexpr int max_bands = 32;
 
  private:
   db::Equalizer* settings = nullptr;


### PR DESCRIPTION
Added the JSDoc syntax to Javascript files to keep them documented.

In the past I made the drafts for the APO/GraphicEQ import, but for some reasons I didn't make the ones for the export. I will make them in the next weeks if I have time.

Regarding the import, I suppose it's just a matter of passing the APO file content to the Javascript function from the QML code. Then the Javascript function returns the imported data and we have to update the widgets from the QML code, right?

So the difference from Libadwaita is that we imported the data from the C++ code and updated the gsettings keys, while now we import it from the QML code and we update the UI. Am I correct?

Regarding the export instead, can we write a file from the QML code? 