### PR TITLE
Equalizer: small UI improvements

### DIFF
--- a/src/contents/ui/EqualizerBand.qml
+++ b/src/contents/ui/EqualizerBand.qml
@@ -48,7 +48,7 @@ Controls.ItemDelegate {
                 if (f < 1000) {
                     return toLocaleLabel(f, 0, "Hz");
                 } else {
-                    toLocaleLabel(f * 0.001, 1, "kHz");
+                    return toLocaleLabel(f * 0.001, 1, "kHz");
                 }
             }
             enabled: false

--- a/src/contents/ui/EqualizerBand.qml
+++ b/src/contents/ui/EqualizerBand.qml
@@ -73,7 +73,7 @@ Controls.ItemDelegate {
             from: delegate.bandDB.getMinValue(bandName)
             to: delegate.bandDB.getMaxValue(bandName)
             value: delegate.bandDB[bandName]
-            stepSize: 1
+            stepSize: 0.01
             enabled: true
             onMoved: {
                 if (value != delegate.bandDB[bandName])
@@ -83,7 +83,7 @@ Controls.ItemDelegate {
 
         Controls.Label {
             Layout.alignment: Qt.AlignHCenter
-            text: Number(gainSlider.value).toLocaleString(Qt.locale(), 'f', 0)
+            text: Number(gainSlider.value).toLocaleString(Qt.locale(), 'f', 2)
             enabled: false
         }
     }

--- a/src/contents/ui/EqualizerBand.qml
+++ b/src/contents/ui/EqualizerBand.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls as Controls
+import org.kde.kirigami as Kirigami
 
 Controls.ItemDelegate {
     id: delegate
@@ -67,6 +68,7 @@ Controls.ItemDelegate {
 
             Layout.alignment: Qt.AlignHCenter
             Layout.fillHeight: true
+            Layout.minimumHeight: Kirigami.Units.largeSpacing * 10
             orientation: Qt.Vertical
             from: delegate.bandDB.getMinValue(bandName)
             to: delegate.bandDB.getMaxValue(bandName)


### PR DESCRIPTION
I added a minimum height to the gain slider since it's too little when the window height is highly reduced. But we need to attach a vertical scrollbar when the equalizer bands are longer than the container. I tried to add it, but failed.

Unfortunately, if you reduce the window width, the horizontal scrollbar overlaps the gain labels. Can we do something to avoid it?

Regarding the band gain, I added the decimals to the label and the `0.01` step size to the slider (as in Libadwaita), but I suppose we need also the page up/down control as we already have for the spinboxes, right? At the moment, pressing page up/down doesn't change the value.

Another thing. When I compiled the first time, I got the following warning:

```
easyeffects/src/convolver.cpp:645:44: warning: 
‘_LIBCPP_VERSION’ is not defined, evaluates to ‘0’ [-Wundef]
  645 | #if defined(ENABLE_LIBCPP_WORKAROUNDS) || (_LIBCPP_VERSION < 170000 || defined(_LIBCPP_HAS_NO_INCOMPLETE_PSTL))

```