### PR TITLE
Remove unused QML import

### DIFF
--- a/src/contents/ui/EqualizerBand.qml
+++ b/src/contents/ui/EqualizerBand.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls as Controls
-import org.kde.kirigami as Kirigami
 
 Controls.ItemDelegate {
     id: delegate


### PR DESCRIPTION
Since the spacing has been moved in another file, the Kirigami import is not needed anymore.