### PR TITLE
Improve Kirigami inline messages

### DIFF
--- a/src/contents/ui/Equalizer.qml
+++ b/src/contents/ui/Equalizer.qml
@@ -55,9 +55,9 @@ Kirigami.ScrollablePage {
         nameFilters: [i18n("APO Presets") + " (*.txt)"]
         onAccepted: {
             if (pluginBackend.importApoPreset(apoFileDialog.selectedFiles) === true)
-                showStatus(i18n("Preset file imported!"));
+                showStatus(i18n("Preset File Imported."));
             else
-                showStatus(i18n("Failed to import the APO preset file!"));
+                showStatus(i18n("Failed to Import the APO Preset File."));
         }
     }
 
@@ -69,9 +69,9 @@ Kirigami.ScrollablePage {
         nameFilters: [i18n("GraphicEQ Presets") + " (*.txt)"]
         onAccepted: {
             if (pluginBackend.importApoGraphicEqPreset(apoGraphicEqFileDialog.selectedFiles) === true)
-                showStatus(i18n("Preset file imported!"));
+                showStatus(i18n("Preset File Imported."));
             else
-                showStatus(i18n("Failed to import the APO preset file!"));
+                showStatus(i18n("Failed to Import the APO Preset File."));
         }
     }
 
@@ -83,9 +83,9 @@ Kirigami.ScrollablePage {
         nameFilters: [i18n("APO Preset") + " (*.txt)"]
         onAccepted: {
             if (pluginBackend.exportApoPreset(apoExportFileDialog.selectedFile) === true)
-                showStatus(i18n("Preset file exported!"));
+                showStatus(i18n("Preset File Exported."));
             else
-                showStatus(i18n("Failed to export the APO preset file!"));
+                showStatus(i18n("Failed to Export the APO Preset File."));
         }
     }
 

--- a/src/contents/ui/Equalizer.qml
+++ b/src/contents/ui/Equalizer.qml
@@ -33,6 +33,7 @@ Kirigami.ScrollablePage {
     function showStatus(label) {
         status.text = label;
         status.visible = true;
+        autoHideStatusTimer.start();
     }
 
     Component.onCompleted: {
@@ -268,6 +269,15 @@ Kirigami.ScrollablePage {
             Layout.maximumWidth: parent.width
             visible: false
             showCloseButton: true
+        }
+
+        Timer {
+            id: autoHideStatusTimer
+            interval: 5000
+            onTriggered: {
+                status.visible = false;
+                autoHideStatusTimer.stop();
+            }
         }
 
         RowLayout {

--- a/src/contents/ui/Equalizer.qml
+++ b/src/contents/ui/Equalizer.qml
@@ -30,10 +30,17 @@ Kirigami.ScrollablePage {
         inputOutputLevels.outputLevelRight = pluginBackend.getOutputLevelRight();
     }
 
-    function showStatus(label) {
+    function showStatus(label, positive = true) {
         status.text = label;
+
+        if (positive) {
+            status.type = Kirigami.MessageType.Positive;
+            autoHideStatusTimer.start();
+        } else {
+            status.type = Kirigami.MessageType.Error;
+        }
+
         status.visible = true;
-        autoHideStatusTimer.start();
     }
 
     Component.onCompleted: {
@@ -56,9 +63,9 @@ Kirigami.ScrollablePage {
         nameFilters: [i18n("APO Presets") + " (*.txt)"]
         onAccepted: {
             if (pluginBackend.importApoPreset(apoFileDialog.selectedFiles) === true)
-                showStatus(i18n("Preset File Imported."));
+                showStatus(i18n("APO Preset File Imported."));
             else
-                showStatus(i18n("Failed to Import the APO Preset File."));
+                showStatus(i18n("Failed to Import the APO Preset File."), false);
         }
     }
 
@@ -70,9 +77,9 @@ Kirigami.ScrollablePage {
         nameFilters: [i18n("GraphicEQ Presets") + " (*.txt)"]
         onAccepted: {
             if (pluginBackend.importApoGraphicEqPreset(apoGraphicEqFileDialog.selectedFiles) === true)
-                showStatus(i18n("Preset File Imported."));
+                showStatus(i18n("GraphicEQ Preset File Imported."));
             else
-                showStatus(i18n("Failed to Import the APO Preset File."));
+                showStatus(i18n("Failed to Import the GraphicEQ Preset File."), false);
         }
     }
 
@@ -84,9 +91,9 @@ Kirigami.ScrollablePage {
         nameFilters: [i18n("APO Preset") + " (*.txt)"]
         onAccepted: {
             if (pluginBackend.exportApoPreset(apoExportFileDialog.selectedFile) === true)
-                showStatus(i18n("Preset File Exported."));
+                showStatus(i18n("APO Preset File Exported."));
             else
-                showStatus(i18n("Failed to Export the APO Preset File."));
+                showStatus(i18n("Failed to Export the APO Preset File."), false);
         }
     }
 

--- a/src/contents/ui/RNNoise.qml
+++ b/src/contents/ui/RNNoise.qml
@@ -44,9 +44,9 @@ Kirigami.ScrollablePage {
         nameFilters: ["RNNoise (*.rnnn)"]
         onAccepted: {
             if (Presets.Manager.importRNNoiseModel(fileDialog.selectedFiles) === 0)
-                showStatus(i18n("Model files imported!"));
+                showStatus(i18n("Model Files Imported."));
             else
-                showStatus(i18n("Failed to import the model file!"));
+                showStatus(i18n("Failed to Import the Model File."));
         }
     }
 


### PR DESCRIPTION
For the status messages, I used the same format as we use in other labels.

Then I wanted to do something to autohide the message after the preset was imported and with the help of ChatGPT I managed to add a Timer. It was pretty easy, but then I realized that it's better if we autohide only the positive statuses, while the failed ones remains visible so the user can have more time to read them.

To highlight successful and failed actions, I used the proper Kirigami message types. You can test them using a correct APO preset or an empty text file.

Do you like it? I made this only for the Equalizer, but I can replicate it for RNNoise if you want.