### PR TITLE
Add systemd user service file for EasyEffects

### DIFF
--- a/debian/easyeffects/systemd/easyeffects.service
+++ b/debian/easyeffects/systemd/easyeffects.service
@@ -1,0 +1,19 @@
+# You may symlink this file in $HOME/.config/systemd/user/easyeffects.service
+#ln -s /path/to/easyeffects/debian/easyeffects/easyeffects.service ~/.config/systemd/user/easyeffects.service
+# Start it thereafter with
+#systemctl --user daemon-reload
+#systemctl --user enable --now easyeffects.service
+[Unit]
+Description=EasyEffects Service
+After=pipewire-pulse.service
+BindsTo=pipewire-pulse.service
+PartOf=pipewire-pulse.service
+
+[Service]
+ExecStart=easyeffects --gapplication-service
+Restart=no
+StartLimitInterval=3
+GuessMainPID=yes
+
+[Install]
+WantedBy=graphical-session.target


### PR DESCRIPTION
Provides easyeffects.service to run EasyEffects as a user service. Includes instructions for manual setup in the user systemd directory.