### PR TITLE
Convolver impulse sheet: try to fix the height when inline messages are visible

### DIFF
--- a/src/contents/ui/ConvolverImpulseSheet.qml
+++ b/src/contents/ui/ConvolverImpulseSheet.qml
@@ -31,7 +31,7 @@ Kirigami.OverlaySheet {
     focus: true
     y: appWindow.header.height + Kirigami.Units.gridUnit
     implicitWidth: Math.max(Kirigami.Units.gridUnit * 40, appWindow.width * 0.5)
-    implicitHeight: control.parent.height - 2 * (control.header.height + control.footer.height) - control.y
+    implicitHeight: (control.parent.height * 0.8) - control.y
     onClosed: {
         status.visible = false;
     }


### PR DESCRIPTION
As I said in #3949, the height doesn't change when you ignore the footer. I made a simpler calculation removing also the header.

If you accept it, you could even add a `Math.max(...)` to enforce a minimum height...