### PR TITLE
Improve Common.toLocaleLabel

### DIFF
--- a/src/contents/ui/Common.js
+++ b/src/contents/ui/Common.js
@@ -13,7 +13,7 @@ function isEmpty(v) {
         case "string":
             return v.length === 0;
         case "number":
-            return isNaN(v);
+            return Number.isNaN(v);
         case "undefined":
             return true;
         case "object":
@@ -94,10 +94,28 @@ function printObjectProperties(obj) {
 }
 
 /**
- * Returns the number converted to the current user loale.
- * @param {*} value The input value.
- * @returns {number} The converted value.
+ * Converts a value to a numeric string using the current system user locale.
+ * Optional decimal and unit parameters can be provided.
+ * If the value cannot be converted, an empty string is returned
+ * @param {number|string} num The value to convert.
+ * @param {number} [decimal=0] A positive integer representing the decimal precision.
+ * @param {?string} [unit=null] An optional unit string to concatenate to the converted value.
+ * @returns {number} The string in locale format.
  */
-function toLocaleLabel(num, decimal, unit) {
-    return Number(num).toLocaleString(Qt.locale(), 'f', decimal) + ` ${unit}`;
+function toLocaleLabel(num, decimal = 0, unit = null) {
+    // Convert to number if necessary.
+    const n = (typeof num === "number") ? num : Number(num);
+
+    /**
+     * Since we already have a number type, we can use `Number.isNaN()` static method
+     * avoiding the type coercion which is done by `isNaN()` global function.
+     * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN 
+     */
+    if (Number.isNaN(n)) {
+        console.error("Cannot convert " + num + " in locale format.")
+        return "";
+    }
+
+    // Sum has precedence over ternary operator, so we need parentheses. 
+    return n.toLocaleString(Qt.locale(), 'f', decimal) + ((unit === null) ? "" : ` ${unit}`);
 }

--- a/src/contents/ui/EeSpinBox.qml
+++ b/src/contents/ui/EeSpinBox.qml
@@ -135,9 +135,9 @@ FormCard.AbstractFormDelegate {
                 const regex_result = re.exec(text) ?? [];
                 try {
                     const n = Number.fromLocaleString(locale, regex_result[0]);
-                    return (!isNaN(n)) ? Math.round(n * spinbox.decimalFactor) : spinbox.value;
+                    return (!Number.isNaN(n)) ? Math.round(n * spinbox.decimalFactor) : spinbox.value;
                 } catch (error) {
-                    console.log(error);
+                    console.error(error);
                     return spinbox.value;
                 }
             }

--- a/src/contents/ui/PageStreamsEffects.qml
+++ b/src/contents/ui/PageStreamsEffects.qml
@@ -645,10 +645,10 @@ Kirigami.Page {
                     onTriggered: {
                         let left = Number(pipelineInstance.getOutputLevelLeft());
                         let right = Number(pipelineInstance.getOutputLevelRight());
-                        if (isNaN(left) || left < pageStreamsEffects.minLeftLevel)
+                        if (Number.isNaN(left) || left < pageStreamsEffects.minLeftLevel)
                             left = pageStreamsEffects.minLeftLevel;
 
-                        if (isNaN(right) || right < pageStreamsEffects.minRightLevel)
+                        if (Number.isNaN(right) || right < pageStreamsEffects.minRightLevel)
                             right = pageStreamsEffects.minRightLevel;
 
                         if ((left > 0 || right > 0) && actionLevelSaturation.visible !== true)


### PR DESCRIPTION
Improved the JSDoc for `toLocaleLabel()` common function. It actually returns a string and has additional optional parameters.

It's better to hint that the function expects a number or a string as the mandatory first parameter, but it can also fail to convert it to locale format, so I managed that case returning an empty string.

@wwmm At the moment the Multiband Gate fails in two situations to convert the value. The error log tells that it takes an undefined value. Please check it on your system.   

I saw also that every time we check the `NaN` value, we do it on numbers. In that case, it's slightly better to use the `Number.NaN()` static method. That's because it checks `NaN` directly, while global `isNaN()` tries to convert the value to number or, in the worst case, it makes an additional conversion to number type. See [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN#difference_between_number.isnan_and_global_isnan). 