### PR TITLE
Various UI improvements

### DIFF
--- a/src/contents/com.github.wwmm.easyeffects.desktop
+++ b/src/contents/com.github.wwmm.easyeffects.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 # Translators: This is a variable for the application name, don't translate!
-Name=EasyEffects
+Name=Easy Effects
 GenericName=Equalizer, Compressor and Other Audio Effects
 Comment=Audio Effects for PipeWire Applications
 Keywords=limiter;compressor;reverberation;equalizer;autovolume;

--- a/src/contents/com.github.wwmm.easyeffects.desktop.template
+++ b/src/contents/com.github.wwmm.easyeffects.desktop.template
@@ -1,6 +1,6 @@
 [Desktop Entry]
 # Translators: This is a variable for the application name, don't translate!
-_Name=EasyEffects
+_Name=Easy Effects
 _GenericName=Equalizer, Compressor and Other Audio Effects
 _Comment=Audio Effects for PipeWire Applications
 Keywords=limiter;compressor;reverberation;equalizer;autovolume;

--- a/src/contents/kcfg/easyeffects_db.kcfg
+++ b/src/contents/kcfg/easyeffects_db.kcfg
@@ -161,11 +161,11 @@
             <default>false</default>
         </entry>
         <entry name="processAllOutputs" type="Bool">
-            <label>Automatically moves Audio Streams to EasyEffects Virtual Sink.</label>
+            <label>Automatically moves Audio Streams to Easy Effects Virtual Sink.</label>
             <default>true</default>
         </entry>
         <entry name="processAllInputs" type="Bool">
-            <label>Automatically moves Audio Streams to EasyEffects Virtual Source.</label>
+            <label>Automatically moves Audio Streams to Easy Effects Virtual Source.</label>
             <default>true</default>
         </entry>
         <entry name="excludeMonitorStreams" type="Bool">

--- a/src/contents/ui/EeSpinBox.qml
+++ b/src/contents/ui/EeSpinBox.qml
@@ -35,6 +35,8 @@ FormCard.AbstractFormDelegate {
     property bool labelAbove: false
     property bool labelFillWidth: true
     property bool spinboxLayoutFillWidth: false
+    property real spinboxMaximumWidth: -1
+    property real spinboxMinimumWidth: -1
     property int elide: Text.ElideRight
     property int wrapMode: Text.Wrap
     property int spinboxAlignment: Qt.AlignRight
@@ -101,6 +103,8 @@ FormCard.AbstractFormDelegate {
             }
 
             Layout.fillWidth: control.spinboxLayoutFillWidth
+            Layout.maximumWidth: control.spinboxMaximumWidth
+            Layout.minimumWidth: control.spinboxMinimumWidth
             Layout.alignment: spinboxAlignment
             implicitWidth: control.boxWidth
             focusPolicy: control.focusPolicy

--- a/src/contents/ui/Limiter.qml
+++ b/src/contents/ui/Limiter.qml
@@ -39,6 +39,7 @@ Kirigami.ScrollablePage {
             id: cardLayout
 
             maximumColumns: 4
+            minimumColumnWidth: Kirigami.Units.gridUnit * 15
             uniformCellWidths: true
 
             Kirigami.Card {
@@ -114,6 +115,7 @@ Kirigami.ScrollablePage {
                         id: threshold
 
                         label: i18n("Threshold")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 6
                         from: pluginDB.getMinValue("threshold")
                         to: pluginDB.getMaxValue("threshold")
                         value: pluginDB.threshold
@@ -134,6 +136,7 @@ Kirigami.ScrollablePage {
                         id: attack
 
                         label: i18n("Attack")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 6
                         from: pluginDB.getMinValue("attack")
                         to: pluginDB.getMaxValue("attack")
                         value: pluginDB.attack
@@ -154,6 +157,7 @@ Kirigami.ScrollablePage {
                         id: release
 
                         label: i18n("Release")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 6
                         from: pluginDB.getMinValue("release")
                         to: pluginDB.getMaxValue("release")
                         value: pluginDB.release
@@ -174,6 +178,7 @@ Kirigami.ScrollablePage {
                         id: stereoLink
 
                         label: i18n("Stereo Link")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 6
                         from: pluginDB.getMinValue("stereoLink")
                         to: pluginDB.getMaxValue("stereoLink")
                         value: pluginDB.stereoLink
@@ -303,6 +308,7 @@ Kirigami.ScrollablePage {
                         id: alrAttack
 
                         label: i18n("Attack")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 6
                         from: pluginDB.getMinValue("alrAttack")
                         to: pluginDB.getMaxValue("alrAttack")
                         value: pluginDB.alrAttack
@@ -323,6 +329,7 @@ Kirigami.ScrollablePage {
                         id: alrRelease
 
                         label: i18n("Release")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 6
                         from: pluginDB.getMinValue("alrRelease")
                         to: pluginDB.getMaxValue("alrRelease")
                         value: pluginDB.alrRelease
@@ -343,6 +350,7 @@ Kirigami.ScrollablePage {
                         id: alrKnee
 
                         label: i18n("Knee")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 6
                         from: pluginDB.getMinValue("alrKnee")
                         to: pluginDB.getMaxValue("alrKnee")
                         value: pluginDB.alrKnee

--- a/src/contents/ui/MultibandCompressor.qml
+++ b/src/contents/ui/MultibandCompressor.qml
@@ -161,6 +161,10 @@ Kirigami.ScrollablePage {
                 id: bandControlsLayout
 
                 maximumColumns: 4
+                // The following is the minimumColumnWidth that contains
+                // all the spinboxes in the gainFrame without overflowing
+                // on the right border.
+                minimumColumnWidth: Kirigami.Units.gridUnit * 20
                 uniformCellWidths: true
 
                 anchors {
@@ -336,6 +340,7 @@ Kirigami.ScrollablePage {
                             label: i18n("Ratio")
                             labelAbove: true
                             spinboxLayoutFillWidth: true
+                            Layout.minimumWidth: Kirigami.Units.gridUnit * 6
                             from: pluginDB.getMinValue(multibandCompressorPage.bandId + "Ratio")
                             to: pluginDB.getMaxValue(multibandCompressorPage.bandId + "Ratio")
                             value: pluginDB[multibandCompressorPage.bandId + "Ratio"]
@@ -350,6 +355,7 @@ Kirigami.ScrollablePage {
                             label: i18n("Knee")
                             labelAbove: true
                             spinboxLayoutFillWidth: true
+                            Layout.minimumWidth: Kirigami.Units.gridUnit * 6
                             from: pluginDB.getMinValue(multibandCompressorPage.bandId + "Knee")
                             to: pluginDB.getMaxValue(multibandCompressorPage.bandId + "Knee")
                             value: pluginDB[multibandCompressorPage.bandId + "Knee"]
@@ -366,6 +372,7 @@ Kirigami.ScrollablePage {
                             label: i18n("Makeup")
                             labelAbove: true
                             spinboxLayoutFillWidth: true
+                            Layout.minimumWidth: Kirigami.Units.gridUnit * 6
                             from: pluginDB.getMinValue(multibandCompressorPage.bandId + "Makeup")
                             to: pluginDB.getMaxValue(multibandCompressorPage.bandId + "Makeup")
                             value: pluginDB[multibandCompressorPage.bandId + "Makeup"]

--- a/src/contents/ui/MultibandCompressor.qml
+++ b/src/contents/ui/MultibandCompressor.qml
@@ -847,6 +847,10 @@ Kirigami.ScrollablePage {
                                 checked: !multibandCompressorPage.pluginDB.viewSidechain
                                 icon.name: "arrow-left-symbolic"
                                 onTriggered: {
+                                    if (multibandCompressorPage.pluginDB.viewSidechain === false) {
+                                        return;
+                                    }
+
                                     multibandCompressorPage.pluginDB.viewSidechain = false;
                                     bandStackview.replace(bandCompressorControls);
                                 }
@@ -857,6 +861,10 @@ Kirigami.ScrollablePage {
                                 checked: multibandCompressorPage.pluginDB.viewSidechain
                                 icon.name: "arrow-right-symbolic"
                                 onTriggered: {
+                                    if (multibandCompressorPage.pluginDB.viewSidechain === true) {
+                                        return;
+                                    }
+
                                     multibandCompressorPage.pluginDB.viewSidechain = true;
                                     bandStackview.replace(bandSidechainControls);
                                 }

--- a/src/contents/ui/MultibandGate.qml
+++ b/src/contents/ui/MultibandGate.qml
@@ -96,6 +96,7 @@ Kirigami.ScrollablePage {
 
             Kirigami.CardsLayout {
                 maximumColumns: 5
+                minimumColumnWidth: Kirigami.Units.gridUnit * 15
                 uniformCellWidths: true
 
                 anchors {

--- a/src/contents/ui/MultibandGate.qml
+++ b/src/contents/ui/MultibandGate.qml
@@ -821,6 +821,10 @@ Kirigami.ScrollablePage {
                                 checked: !multibandGatePage.pluginDB.viewSidechain
                                 icon.name: "arrow-left-symbolic"
                                 onTriggered: {
+                                    if (multibandGatePage.pluginDB.viewSidechain === false) {
+                                        return;
+                                    }
+
                                     multibandGatePage.pluginDB.viewSidechain = false;
                                     bandStackview.replace(bandGateControls);
                                 }
@@ -831,6 +835,10 @@ Kirigami.ScrollablePage {
                                 checked: multibandGatePage.pluginDB.viewSidechain
                                 icon.name: "arrow-right-symbolic"
                                 onTriggered: {
+                                    if (multibandGatePage.pluginDB.viewSidechain === true) {
+                                        return;
+                                    }
+
                                     multibandGatePage.pluginDB.viewSidechain = true;
                                     bandStackview.replace(bandSidechainControls);
                                 }

--- a/src/contents/ui/ShortcutsSheet.qml
+++ b/src/contents/ui/ShortcutsSheet.qml
@@ -119,7 +119,7 @@ Kirigami.OverlaySheet {
                 }
 
                 Kirigami.Chip {
-                    text: "Q"
+                    text: "T"
                     closable: false
                     checkable: false
                     down: false
@@ -128,7 +128,7 @@ Kirigami.OverlaySheet {
             }
 
             Controls.Label {
-                text: i18n("Quit Easy Effects Service")
+                text: i18n("Terminate Easy Effects Service")
             }
 
             Kirigami.Chip {

--- a/src/contents/ui/ShortcutsSheet.qml
+++ b/src/contents/ui/ShortcutsSheet.qml
@@ -44,7 +44,7 @@ Kirigami.OverlaySheet {
             }
 
             Controls.Label {
-                text: i18n("Fullscreen / Restore from fullscreen")
+                text: i18n("Toggle Fullscreen")
             }
 
             RowLayout {
@@ -128,7 +128,7 @@ Kirigami.OverlaySheet {
             }
 
             Controls.Label {
-                text: i18n("Quit EasyEffects")
+                text: i18n("Quit Easy Effects Service")
             }
 
             Kirigami.Chip {
@@ -211,7 +211,7 @@ Kirigami.OverlaySheet {
             }
 
             Controls.Label {
-                text: i18n("Enable/Disable Effects")
+                text: i18n("Toggle Global Bypass")
             }
         }
     }

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -100,6 +100,12 @@ Kirigami.ApplicationWindow {
         onActivated: appWindow.close()
     }
 
+    Shortcut {
+        // This one replaces CTRL+Q that might not work outside KDE.
+        sequences: ["Ctrl+T"]
+        onActivated: Qt.quit()
+    }
+
     PreferencesSheet {
         id: preferencesSheet
     }

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -116,7 +116,7 @@ Kirigami.ApplicationWindow {
         id: resetPromptDialog
 
         title: i18n("Reset Settings?")
-        subtitle: i18n("Are you sure you want to reset all EasyEffects settings?")
+        subtitle: i18n("Are you sure you want to reset all Easy Effects settings?")
         standardButtons: Kirigami.Dialog.Ok | Kirigami.Dialog.Cancel
         onAccepted: DB.Manager.resetAll()
     }
@@ -414,7 +414,7 @@ Kirigami.ApplicationWindow {
                         displayHint: Kirigami.DisplayHint.AlwaysHide
                     },
                     Kirigami.Action {
-                        text: i18n("About EasyEffects")
+                        text: i18n("About Easy Effects")
                         icon.name: "com.github.wwmm.easyeffects"
                         displayHint: Kirigami.DisplayHint.AlwaysHide
                         onTriggered: {


### PR DESCRIPTION
1. When clicking repeatedly the same arrow, the related view is not replaced multiple times in the Multiband plugins.
2. Ensure all Multiband spinboxes have the proper width and are contained in their card (setting a lower card width may let the spinboxes to overflow outside the card).
3.  Implement CTRL+T in place of CTRL+Q (should quit the service on all DE).
4. EESpinBox can now set a min/max width on the spinbox. This fixes the following issue where the labels are unnecessarily wrapped.
<img width="346" height="393" alt="Screenshot From 2025-08-28 16-01-06" src="https://github.com/user-attachments/assets/e8512333-3dff-448d-8cca-2fdefe37d9f4" />
