### PR TITLE
Various UI improvements

### DIFF
--- a/src/contents/ui/DelegateStreamsList.qml
+++ b/src/contents/ui/DelegateStreamsList.qml
@@ -74,7 +74,7 @@ Kirigami.AbstractCard {
                 RowLayout {
                     Controls.Label {
                         wrapMode: Text.WordWrap
-                        text: state + " · " + format + " · " + rate + " · " + nVolumeChannels + i18n(" channels") + " · " + latency
+                        text: (state === "" ? "" : `${state} · `) + `${format} · ${rate} · ${nVolumeChannels} ` + i18n("channels") + ` · ${latency}`
                         color: Kirigami.Theme.disabledTextColor
                     }
                 }

--- a/src/contents/ui/MenuAddPlugins.qml
+++ b/src/contents/ui/MenuAddPlugins.qml
@@ -125,7 +125,7 @@ Kirigami.OverlaySheet {
                             plugins.push(new_name);
                         }
                         streamDB.plugins = plugins;
-                        showMenuStatus(i18n("Added Plugin") + ": " + translatedName);
+                        showMenuStatus(i18n("Added Effect") + `: <strong>${translatedName}</strong>`);
                     }
                 }
             }

--- a/src/contents/ui/PreferencesSheet.qml
+++ b/src/contents/ui/PreferencesSheet.qml
@@ -395,8 +395,8 @@ Kirigami.OverlaySheet {
                 EeSwitch {
                     id: showNativePluginUi
 
-                    label: i18n("Native Plugin Window")
-                    subtitle: i18n("Allows The Native Plugin Window to be Shown/Hidden")
+                    label: i18n("Native Window of Effects")
+                    subtitle: i18n("Allows the Native User Interface of Effects to be Shown/Hidden")
                     isChecked: DB.Manager.main.showNativePluginUi
                     onCheckedChanged: {
                         if (isChecked !== DB.Manager.main.showNativePluginUi)

--- a/src/contents/ui/PresetsCommunityPage.qml
+++ b/src/contents/ui/PresetsCommunityPage.qml
@@ -34,6 +34,11 @@ ColumnLayout {
         status.text = label;
         status.visible = true;
     }
+    function showPresetsMenuError(label) {
+        status.text = label;
+        status.visible = true;
+        status.type = Kirigami.MessageType.Error;
+    }
 
     ListModel {
         id: listModel
@@ -83,7 +88,7 @@ ColumnLayout {
                 width: listView.width
                 onClicked: {
                     if (Presets.Manager.loadCommunityPresetFile(pipeline, path, presetPackage) === false)
-                        showPresetsMenuStatus(i18n("The Preset %1 failed to load", name));
+                        showPresetsMenuError(i18n("The Preset %1 Failed to Load", `<strong>${name}</strong>`));
                 }
 
                 contentItem: RowLayout {
@@ -106,9 +111,9 @@ ColumnLayout {
                                 displayHint: Kirigami.DisplayHint.AlwaysHide
                                 onTriggered: {
                                     if (Presets.Manager.importFromCommunityPackage(pipeline, path, presetPackage) === true)
-                                        showPresetsMenuStatus(i18n("Imported the Community Preset") + ": " + name);
+                                        showPresetsMenuStatus(i18n("Imported the Community Preset") + ": " + `<strong>${name}</strong>`);
                                     else
-                                        showPresetsMenuStatus(i18n("Failed to Import the Community Preset") + ": " + name);
+                                        showPresetsMenuError(i18n("Failed to Import the Community Preset") + ": " + `<strong>${name}</strong>`);
                                 }
                             }
                         ]

--- a/src/contents/ui/PresetsLocalPage.qml
+++ b/src/contents/ui/PresetsLocalPage.qml
@@ -22,6 +22,11 @@ ColumnLayout {
         status.text = label;
         status.visible = true;
     }
+    function showPresetsMenuError(label) {
+        status.text = label;
+        status.visible = true;
+        status.type = Kirigami.MessageType.Error;
+    }
 
     FileDialog {
         id: fileDialog
@@ -31,9 +36,9 @@ ColumnLayout {
         nameFilters: ["JSON files (*.json)"]
         onAccepted: {
             if (Presets.Manager.importPresets(pipeline, fileDialog.selectedFiles) === true)
-                showPresetsMenuStatus(i18n("Preset files imported!"));
+                showPresetsMenuStatus(i18n("Preset File Imported."));
             else
-                showPresetsMenuStatus(i18n("Failed to import the presets!"));
+                showPresetsMenuError(i18n("Failed to Import the Preset."));
         }
     }
 
@@ -75,10 +80,10 @@ ColumnLayout {
                     if (!Common.isEmpty(newName.trim())) {
                         if (Presets.Manager.add(pipeline, newName) === true) {
                             newPresetName.accepted();
-                            showPresetsMenuStatus(i18n("New Preset Created") + ": " + newName);
+                            showPresetsMenuStatus(i18n("New Preset Created") + `: <strong>${newName}</strong>`);
                             newPresetName.text = "";
                         } else {
-                            showPresetsMenuStatus(i18n("Failed to Create Preset") + ": " + newName);
+                            showPresetsMenuError(i18n("Failed to Create Preset") + `: <strong>${newName}</strong>`);
                         }
                     }
                 }
@@ -146,7 +151,7 @@ ColumnLayout {
                 width: listView.width
                 onClicked: {
                     if (Presets.Manager.loadLocalPresetFile(pipeline, name) === false)
-                        showPresetsMenuStatus(i18n("The Preset %1 failed to load", name));
+                        showPresetsMenuError(i18n("The Preset %1 Failed to Load", `<strong>${name}</strong>`));
                 }
 
                 contentItem: RowLayout {
@@ -163,9 +168,9 @@ ColumnLayout {
                                 displayHint: Kirigami.DisplayHint.AlwaysHide
                                 onTriggered: {
                                     if (Presets.Manager.savePresetFile(pipeline, name) === true)
-                                        showPresetsMenuStatus(i18n("Settings Saved to: %1", name));
+                                        showPresetsMenuStatus(i18n("Settings Saved to: %1", `<strong>${name}</strong>`));
                                     else
-                                        showPresetsMenuStatus(i18n("Failed to Save Settings to: %1", name));
+                                        showPresetsMenuError(i18n("Failed to Save Settings to: %1", `<strong>${name}</strong>`));
                                 }
                             },
                             Kirigami.Action {
@@ -174,9 +179,9 @@ ColumnLayout {
                                 displayHint: Kirigami.DisplayHint.AlwaysHide
                                 onTriggered: {
                                     if (Presets.Manager.remove(pipeline, name) === true)
-                                        showPresetsMenuStatus(i18n("The Preset %1 Has Been Removed", name));
+                                        showPresetsMenuStatus(i18n("The Preset %1 Has Been Removed", `<strong>${name}</strong>`));
                                     else
-                                        showPresetsMenuStatus(i18n("The Preset %1 Could Not Be Removed", name));
+                                        showPresetsMenuError(i18n("The Preset %1 Could Not Be Removed", `<strong>${name}</strong>`));
                                 }
                             }
                         ]

--- a/src/contents/ui/PresetsSheet.qml
+++ b/src/contents/ui/PresetsSheet.qml
@@ -104,8 +104,9 @@ Kirigami.OverlaySheet {
             if (Common.isEmpty(lastLoadedPresetName))
                 return i18n("No Preset Loaded");
 
-            const tag = Common.isEmpty(lastLoadedCommunityPackage) ? i18n("<strong>Local: </strong>") : i18n("<strong>Community: </strong>");
-            return tag + lastLoadedPresetName;
+            const presetType = Common.isEmpty(lastLoadedCommunityPackage) ? i18n("Local") : i18n("Community");
+
+            return `${presetType}: <strong>${lastLoadedPresetName}<strong>`;
         }
     }
 }


### PR DESCRIPTION
Doing these changes I discovered some issues:

1. The app logo in the README is broken.
2. The PipeWire node state is not provided anymore. Indeed you can see from your screenshot that the final row in the app info card is starting with a middle dot. I can reproduce it also on my system. Don't know why this is happening, but I modified the string to not start with a leading middle dot when the state is missing.
3.  In presets menu, when an inline message is shown (i.e. when a preset is created/removed), the frame height changes. This is the same issue happening in the convolver menu. We fixed it not counting the footer/header in the implicit height: https://github.com/wwmm/easyeffects/pull/3950/commits/7293c9356a90b16ac034bef9a1fd7ad617efb5a2
4. I didn't fix the issue above because there's another problem to solve in the plugin menu: when the autoloading tab is visible, the frame footer collapses on the bottom of the main window. I don't know how to fix this one. Please @wwmm, take a look at both issues.
5. When I was testing the inline messages in the plugin menu, I could switch between good presets and corrupted ones (that contains errors in the JSON format). But I found out another issue: when loading an empty corrupted preset (a text file without characters), I'm not able to load another preset. The pipeline is stuck, this is what happens:
<img width="352" height="441" alt="Screenshot From 2025-08-29 22-57-24" src="https://github.com/user-attachments/assets/b8e19eff-2ba4-4952-8b44-f2519fea4fa8" />
