### PR TITLE
Add qml format and qml lint

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -322,3 +322,42 @@ jobs:
 
       - name: Run KCFG numeric-defaults checker
         run: ./util/check-kcfg-numeric-defaults.sh
+
+  check-qmlformat:
+    name: Check QML format
+    runs-on: ubuntu-24.04
+    container:
+      image: archlinux
+    steps:
+      # install deps first to get git for later on
+      - name: Install deps
+        run: pacman -Syu --noconfirm qt6-declarative git
+
+      - name: Checkout code
+        uses: actions/checkout@v5.0.0
+
+      - name: Set git permissions
+        # workarounds the permission differences due to this being run in a container
+        run: git config --global --add safe.directory $PWD
+
+      - name: Run QML format
+        run: ./util/qmlformat.sh
+
+      - name: Check git diff
+        run: git diff --quiet --exit-code || { echo 'git showed a diff after running qmlformat, did you forget to run ./util/qmlformat.sh? The following files need to be formatted:'; git diff --name-only; exit 1; }
+
+  check-qmllint:
+    name: Check QML lint
+    runs-on: ubuntu-24.04
+    container:
+      image: archlinux
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5.0.0
+
+      - name: Install deps
+        run: pacman -Syu --noconfirm qt6-declarative
+
+      - name: Run QML lint
+        run: ./util/qmllint.sh
+

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -71,7 +71,8 @@ jobs:
       with:
         bundle: easyeffects-flatpak-${{ needs.prepare.outputs.github_commit_desc }}.flatpak
         manifest-path: util/flatpak/com.github.wwmm.easyeffects.Devel.json
-        cache-key: flatpak-builder-${{ github.sha }}
+        # put the arch earlier in this string, to help avoid using caches from the wrong architecture
+        cache-key: flatpak-builder-${{ matrix.variant.arch }}-${{ github.sha }}
         arch: ${{ matrix.variant.arch }}
         run-tests: true
 

--- a/.qmlformat.ini
+++ b/.qmlformat.ini
@@ -1,0 +1,9 @@
+; Reference: https://doc.qt.io/qt-6/qtqml-tooling-qmlformat.html#settings-file
+[General]
+FunctionsSpacing=false
+IndentWidth=4
+MaxColumnWidth=-1
+NewlineType=unix
+NormalizeOrder=false
+ObjectsSpacing=false
+UseTabs=false

--- a/.qmllint.ini
+++ b/.qmllint.ini
@@ -1,0 +1,11 @@
+; Reference: https://doc.qt.io/qt-6/qtqml-tooling-qmllint.html#settings
+[General]
+MaxWarnings=0
+
+[Warnings]
+UnqualifiedAccess=disable
+MissingProperty=disable
+UnresolvedType=disable
+ImportFailure=disable
+# Be very careful when enabling this one. Somehow, it shows errors in ci but not locally, despite both using up-to-date arch linux qt qml packages.
+RequiredProperty=disable

--- a/src/contents/ui/Common.js
+++ b/src/contents/ui/Common.js
@@ -5,28 +5,28 @@ var minimumDecibelLevel = -100.0;
 
 /**
  * Check if a variable of any type is empty.
- * @param {*} v 
+ * @param {*} v
  * @returns {boolean}
  */
 function isEmpty(v) {
     switch (typeof v) {
-        case "string":
-            return v.length === 0;
-        case "number":
-            return Number.isNaN(v);
-        case "undefined":
-            return true;
-        case "object":
-            return v === null;
-        default:
-            return false;
+    case "string":
+        return v.length === 0;
+    case "number":
+        return Number.isNaN(v);
+    case "undefined":
+        return true;
+    case "object":
+        return v === null;
+    default:
+        return false;
     }
 }
 
 /**
  * Check if two given arrays are equal.
- * @param {Array} a 
- * @param {Array} b 
+ * @param {Array} a
+ * @param {Array} b
  * @returns {boolean}
  */
 function equalArrays(a, b) {
@@ -48,17 +48,19 @@ function equalArrays(a, b) {
 
 /**
  * Clamps a number within the range of min and max parameters.
- * @param {number} num The number to clamp. 
+ * @param {number} num The number to clamp.
  * @param {number} min Minimum bound.
  * @param {number} max Maximum bound.
  * @returns {number} Clamped value.
  */
-function clamp(num, min, max) { return Math.min(Math.max(num, min), max); }
+function clamp(num, min, max) {
+    return Math.min(Math.max(num, min), max);
+}
 
 /**
- * A simple polyfill implementation of RegExp.escape() static method which is currently not available in QML 
+ * A simple polyfill implementation of RegExp.escape() static method which is currently not available in QML
  * Javascript engine.
- * Given a regex string as parameter, it escapes any potential regex syntax characters and returns a new string 
+ * Given a regex string as parameter, it escapes any potential regex syntax characters and returns a new string
  * that can be safely used as a literal pattern for the RegExp() constructor.
  * Mostly used for QML SearchField widgets.
  * @param {string} str Original regex.
@@ -69,7 +71,7 @@ function regExpEscape(str) {
 }
 
 /**
- * Returns the decibel level of a linear value. If the value is lesser then minimumLinearLevel, 
+ * Returns the decibel level of a linear value. If the value is lesser then minimumLinearLevel,
  * the minimumDecibelLevel is returned.
  * @param {number|string} value The linear value.
  * @returns {number} The decibel level.
@@ -86,7 +88,7 @@ function linearTodb(value) {
 }
 
 /**
- * Returns the linear level of a decibel value. If the value is lesser then minimumDecibelLevel, 
+ * Returns the linear level of a decibel value. If the value is lesser then minimumDecibelLevel,
  * the minimumLinearLevel is returned.
  * @param {number|string} value The decibel value.
  * @returns {number} The linear level.
@@ -105,7 +107,7 @@ function dbToLinear(dbValue) {
 /**
  * A debugging function which prints the properties of a given object or any other collection type such as Array.
  * Since it uses the "in" operator, an exception can be raised if a primitive type is given as a parameter.
- * @param {*} obj 
+ * @param {*} obj
  */
 function printObjectProperties(obj) {
     for (let prop in obj) {
@@ -129,13 +131,13 @@ function toLocaleLabel(num, decimal = 0, unit = null) {
     /**
      * Since we already have a number type, we can use `Number.isNaN()` static method
      * avoiding the type coercion which is done by `isNaN()` global function.
-     * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN 
+     * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN
      */
     if (Number.isNaN(n)) {
-        console.error("Cannot convert " + num + " in locale format.")
+        console.error("Cannot convert " + num + " in locale format.");
         return "";
     }
 
-    // Sum has precedence over ternary operator, so we need parentheses. 
+    // Sum has precedence over ternary operator, so we need parentheses.
     return n.toLocaleString(Qt.locale(), 'f', decimal) + ((unit === null) ? "" : ` ${unit}`);
 }

--- a/util/qmlformat.sh
+++ b/util/qmlformat.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ ! -f .qmlformat.ini ]]; then
+    echo "ERROR: Run this in the root directory of the repository where the .qmlformat.ini file is"
+    exit 1
+fi
+
+# unlike qmllint, this can also be used on js files, not just qml files, so glob everything in the directory
+
+# for some reason the arch qt6-declarative package doesn't add this to the normally searched directories
+if [[ -f /usr/lib/qt6/bin/qmlformat ]]; then
+    /usr/lib/qt6/bin/qmlformat src/contents/ui/* --inplace "$@"
+# for fedora
+elif command -v qmlformat-qt6 --help &>/dev/null; then
+    qmlformat-qt6 src/contents/ui/* --inplace "$@"
+else
+    echo "ERROR: Could not find qmlformat qt6"
+    exit 1
+fi

--- a/util/qmllint.sh
+++ b/util/qmllint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ ! -f .qmllint.ini ]]; then
+    echo "ERROR: Run this in the root directory of the repository where the .qmllint.ini file is"
+    exit 1
+fi
+
+# for some reason the arch qt6-declarative package doesn't add this to the normally searched directories
+if [[ -f /usr/lib/qt6/bin/qmllint ]]; then
+    /usr/lib/qt6/bin/qmllint src/contents/ui/*.qml "$@"
+# for fedora
+elif command -v qmllint-qt6 --help &>/dev/null; then
+    qmllint-qt6 src/contents/ui/*.qml "$@"
+else
+    echo "ERROR: Could not find qmllint qt6"
+    exit 1
+fi


### PR DESCRIPTION
Adds 2 new tools for the qml files. These tools are much faster and less clunky than clang tidy thankfully. The main irritating thing here is for some reach the arch qt qml package does not put the qmllint and qmlformat binaries on the usual search paths, so I wrote a simple wrapper script for both commands that tries to find the binary.

I originally learned about these tools from reading this article. Some of these tips may be worth reviewing if you have not seen this already. I think some of the currently disabled checks in the qmllint ini file are relevant here.
https://planet.kde.org/kdab-on-qt-2024-10-23-10-tips-to-make-your-qml-code-faster-and-more-maintainable/

Another interesting tool is [qmlpreview](https://doc.qt.io/qt-6/qtqml-tooling-qmlpreview.html) which I did not try out. It lets you live edit the qml like "hot reloading" in web development. I wonder how difficult it would be to get that working here.