### PR TITLE
Fix update translation templates ci

### DIFF
--- a/.github/workflows/translation-templates.yaml
+++ b/.github/workflows/translation-templates.yaml
@@ -23,16 +23,17 @@ jobs:
           pacman -Syu --noconfirm ninja gcc pkgconf python3 python-pip which
           # install easyeffects deps
           source ./PKGBUILD && pacman -Syu --noconfirm --needed --asdeps "${makedepends[@]}" "${depends[@]}"
+          # install deps for translation templates
+          pacman -Syu --noconfirm kde-dev-scripts
           
       # workaround upstream permissions issue github.com/peter-evans/create-pull-request/issues/1170
       - name: Change git permissions
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Run cmake targets
+      - name: Run extract translation messages script
         run: |
-          cmake -B build -S . -G Ninja -Wno-dev
-          cd build
-          ../util/update_translation_templates.sh
+          cd util
+          ./extract-translation-messages.sh
           cd ..
 
       - name: Check for non-timestamp diff

--- a/util/extract-translation-messages.sh
+++ b/util/extract-translation-messages.sh
@@ -1,9 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # https://techbase.kde.org/Development/Tutorials/Localization/i18n_Build_Systems/Outside_KDE_repositories
 # the command extractrc is provided by the pacakge kde-dev-scripts
 
 # https://api.kde.org/frameworks/ki18n/html/prg_guide.html
+
+set -euo pipefail
 
 BASEDIR="../"	# root of translatable sources
 PROJECT="easyeffects"	# project name

--- a/util/update_translation_templates.sh
+++ b/util/update_translation_templates.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-ninja easyeffects-pot
-ninja easyeffects-update-po
-ninja easyeffects-news-pot
-ninja easyeffects-news-update-po


### PR DESCRIPTION
This deletes the old translation update script and changes ci to call the newer one. I believe this is enough to manage the translations on a normal basis? We don't need any automation/ci for `util/port_po_files.py` correct?