### PR TITLE
Various UI improvements

### DIFF
--- a/src/contents/ui/Autogain.qml
+++ b/src/contents/ui/Autogain.qml
@@ -75,6 +75,7 @@ Kirigami.ScrollablePage {
                         id: target
 
                         label: i18n("Target")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: autogainPage.pluginDB.getMinValue("target")
                         to: autogainPage.pluginDB.getMaxValue("target")
                         value: autogainPage.pluginDB.target
@@ -95,6 +96,7 @@ Kirigami.ScrollablePage {
                         id: silenceThreshold
 
                         label: i18n("Silence")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: autogainPage.pluginDB.getMinValue("silenceThreshold")
                         to: autogainPage.pluginDB.getMaxValue("silenceThreshold")
                         value: autogainPage.pluginDB.silenceThreshold
@@ -115,6 +117,7 @@ Kirigami.ScrollablePage {
                         id: maximumHistory
 
                         label: i18n("Maximum History")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: autogainPage.pluginDB.getMinValue("maximumHistory")
                         to: autogainPage.pluginDB.getMaxValue("maximumHistory")
                         value: autogainPage.pluginDB.maximumHistory

--- a/src/contents/ui/Autogain.qml
+++ b/src/contents/ui/Autogain.qml
@@ -40,6 +40,7 @@ Kirigami.ScrollablePage {
         Kirigami.CardsLayout {
             id: cardLayout
 
+            minimumColumnWidth: Kirigami.Units.gridUnit * 17
             uniformCellWidths: true
 
             Kirigami.Card {

--- a/src/contents/ui/BassEnhancer.qml
+++ b/src/contents/ui/BassEnhancer.qml
@@ -94,6 +94,7 @@ Kirigami.ScrollablePage {
                         id: amount
 
                         label: i18n("Amount")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("amount")
                         to: pluginDB.getMaxValue("amount")
                         value: pluginDB.amount
@@ -109,6 +110,7 @@ Kirigami.ScrollablePage {
                         id: harmonics
 
                         label: i18n("Harmonics")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("harmonics")
                         to: pluginDB.getMaxValue("harmonics")
                         value: pluginDB.harmonics
@@ -123,6 +125,7 @@ Kirigami.ScrollablePage {
                         id: scope
 
                         label: i18n("Scope")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("scope")
                         to: pluginDB.getMaxValue("scope")
                         value: pluginDB.scope
@@ -149,6 +152,7 @@ Kirigami.ScrollablePage {
                         id: floor
 
                         label: i18n("Floor")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("floor")
                         to: pluginDB.getMaxValue("floor")
                         value: pluginDB.floor

--- a/src/contents/ui/BassLoudness.qml
+++ b/src/contents/ui/BassLoudness.qml
@@ -46,6 +46,7 @@ Kirigami.ScrollablePage {
                         id: loudness
 
                         label: i18n("Loudness")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("loudness")
                         to: pluginDB.getMaxValue("loudness")
                         value: pluginDB.loudness
@@ -61,6 +62,7 @@ Kirigami.ScrollablePage {
                         id: output
 
                         label: i18n("Output")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("output")
                         to: pluginDB.getMaxValue("output")
                         value: pluginDB.output
@@ -76,6 +78,7 @@ Kirigami.ScrollablePage {
                         id: link
 
                         label: i18n("Link")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("link")
                         to: pluginDB.getMaxValue("link")
                         value: pluginDB.link

--- a/src/contents/ui/Compressor.qml
+++ b/src/contents/ui/Compressor.qml
@@ -42,6 +42,7 @@ Kirigami.ScrollablePage {
         Kirigami.CardsLayout {
             id: cardLayout
 
+            minimumColumnWidth: Kirigami.Units.gridUnit * 17
             maximumColumns: 5
             uniformCellWidths: true
 

--- a/src/contents/ui/Convolver.qml
+++ b/src/contents/ui/Convolver.qml
@@ -161,7 +161,9 @@ Kirigami.ScrollablePage {
         }
 
         Kirigami.Card {
+            Layout.minimumWidth: Kirigami.Units.gridUnit * 16
             Layout.fillHeight: true
+
             actions: [
                 Kirigami.Action {
                     text: qsTr("Impulses")

--- a/src/contents/ui/Crossfeed.qml
+++ b/src/contents/ui/Crossfeed.qml
@@ -62,6 +62,7 @@ Kirigami.ScrollablePage {
                         id: fcut
 
                         label: i18n("Cutoff")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("fcut")
                         to: pluginDB.getMaxValue("fcut")
                         value: pluginDB.fcut
@@ -77,6 +78,7 @@ Kirigami.ScrollablePage {
                         id: feed
 
                         label: i18n("Feed")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("feed")
                         to: pluginDB.getMaxValue("feed")
                         value: pluginDB.feed

--- a/src/contents/ui/DeepFilterNet.qml
+++ b/src/contents/ui/DeepFilterNet.qml
@@ -78,6 +78,7 @@ Kirigami.ScrollablePage {
                         id: minProcessingThreshold
 
                         label: i18n("Minimum Processing Threshold")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 8
                         from: pluginDB.getMinValue("minProcessingThreshold")
                         to: pluginDB.getMaxValue("minProcessingThreshold")
                         value: pluginDB.minProcessingThreshold
@@ -93,6 +94,7 @@ Kirigami.ScrollablePage {
                         id: maxErbProcessingThreshold
 
                         label: i18n("Maximum ERB Processing threshold")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 8
                         from: pluginDB.getMinValue("maxErbProcessingThreshold")
                         to: pluginDB.getMaxValue("maxErbProcessingThreshold")
                         value: pluginDB.maxErbProcessingThreshold
@@ -108,6 +110,7 @@ Kirigami.ScrollablePage {
                         id: maxDfProcessingThreshold
 
                         label: i18n("Maximum ERB Processing threshold")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 8
                         from: pluginDB.getMinValue("maxDfProcessingThreshold")
                         to: pluginDB.getMaxValue("maxDfProcessingThreshold")
                         value: pluginDB.maxDfProcessingThreshold
@@ -123,6 +126,7 @@ Kirigami.ScrollablePage {
                         id: minProcessingBuffer
 
                         label: i18n("Maximum ERB Processing threshold")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 8
                         from: pluginDB.getMinValue("minProcessingBuffer")
                         to: pluginDB.getMaxValue("minProcessingBuffer")
                         value: pluginDB.minProcessingBuffer
@@ -138,6 +142,7 @@ Kirigami.ScrollablePage {
                         id: postFilterBeta
 
                         label: i18n("Post Filter Beta")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 8
                         from: pluginDB.getMinValue("postFilterBeta")
                         to: pluginDB.getMaxValue("postFilterBeta")
                         value: pluginDB.postFilterBeta

--- a/src/contents/ui/Deesser.qml
+++ b/src/contents/ui/Deesser.qml
@@ -35,6 +35,7 @@ Kirigami.ScrollablePage {
         Kirigami.CardsLayout {
             id: cardLayout
 
+            minimumColumnWidth: Kirigami.Units.gridUnit * 17
             implicitWidth: cardLayout.maximumColumnWidth
             uniformCellWidths: true
 
@@ -246,12 +247,13 @@ Kirigami.ScrollablePage {
                     }
                 }
             }
+        }
 
+        RowLayout {
             Kirigami.Card {
                 id: cardDetectionLevels
 
-                Layout.columnSpan: 2
-
+                Layout.topMargin: Kirigami.Units.smallSpacing
                 header: Kirigami.Heading {
                     text: i18n("Level")
                     level: 2

--- a/src/contents/ui/Delay.qml
+++ b/src/contents/ui/Delay.qml
@@ -32,6 +32,7 @@ Kirigami.ScrollablePage {
         Kirigami.CardsLayout {
             id: cardLayout
 
+            minimumColumnWidth: Kirigami.Units.gridUnit * 17
             implicitWidth: cardLayout.maximumColumnWidth
             uniformCellWidths: true
 

--- a/src/contents/ui/EchoCanceller.qml
+++ b/src/contents/ui/EchoCanceller.qml
@@ -46,6 +46,7 @@ Kirigami.ScrollablePage {
                         id: filterLength
 
                         label: i18n("Filter Length")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("filterLength")
                         to: pluginDB.getMaxValue("filterLength")
                         value: pluginDB.filterLength
@@ -61,6 +62,7 @@ Kirigami.ScrollablePage {
                         id: residualEchoSuppression
 
                         label: i18n("Residual Echo Suppression")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("residualEchoSuppression")
                         to: pluginDB.getMaxValue("residualEchoSuppression")
                         value: pluginDB.residualEchoSuppression
@@ -76,6 +78,7 @@ Kirigami.ScrollablePage {
                         id: nearEndSuppression
 
                         label: i18n("Near End Suppression")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("nearEndSuppression")
                         to: pluginDB.getMaxValue("nearEndSuppression")
                         value: pluginDB.nearEndSuppression

--- a/src/contents/ui/Exciter.qml
+++ b/src/contents/ui/Exciter.qml
@@ -94,6 +94,7 @@ Kirigami.ScrollablePage {
                         id: amount
 
                         label: i18n("Amount")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("amount")
                         to: pluginDB.getMaxValue("amount")
                         value: pluginDB.amount
@@ -109,6 +110,7 @@ Kirigami.ScrollablePage {
                         id: harmonics
 
                         label: i18n("Harmonics")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("harmonics")
                         to: pluginDB.getMaxValue("harmonics")
                         value: pluginDB.harmonics
@@ -123,6 +125,7 @@ Kirigami.ScrollablePage {
                         id: scope
 
                         label: i18n("Scope")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("scope")
                         to: pluginDB.getMaxValue("scope")
                         value: pluginDB.scope
@@ -149,6 +152,7 @@ Kirigami.ScrollablePage {
                         id: ceil
 
                         label: i18n("Ceil")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("ceil")
                         to: pluginDB.getMaxValue("ceil")
                         value: pluginDB.ceil

--- a/src/contents/ui/Expander.qml
+++ b/src/contents/ui/Expander.qml
@@ -42,6 +42,7 @@ Kirigami.ScrollablePage {
         Kirigami.CardsLayout {
             id: cardLayout
 
+            minimumColumnWidth: Kirigami.Units.gridUnit * 17
             maximumColumns: 5
             uniformCellWidths: true
 

--- a/src/contents/ui/Filter.qml
+++ b/src/contents/ui/Filter.qml
@@ -32,6 +32,7 @@ Kirigami.ScrollablePage {
         Kirigami.CardsLayout {
             id: cardLayout
 
+            minimumColumnWidth: Kirigami.Units.gridUnit * 17
             implicitWidth: cardLayout.maximumColumnWidth
             uniformCellWidths: true
 

--- a/src/contents/ui/Filter.qml
+++ b/src/contents/ui/Filter.qml
@@ -109,6 +109,7 @@ Kirigami.ScrollablePage {
                         id: frequency
 
                         label: i18n("Frequency")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("frequency")
                         to: pluginDB.getMaxValue("frequency")
                         value: pluginDB.frequency
@@ -124,6 +125,7 @@ Kirigami.ScrollablePage {
                         id: width
 
                         label: i18n("Width")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("width")
                         to: pluginDB.getMaxValue("width")
                         value: pluginDB.width
@@ -138,6 +140,7 @@ Kirigami.ScrollablePage {
                         id: gain
 
                         label: i18n("Gain")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("gain")
                         to: pluginDB.getMaxValue("gain")
                         value: pluginDB.gain
@@ -153,6 +156,7 @@ Kirigami.ScrollablePage {
                         id: quality
 
                         label: i18n("Quality")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("quality")
                         to: pluginDB.getMaxValue("quality")
                         value: pluginDB.quality
@@ -167,6 +171,7 @@ Kirigami.ScrollablePage {
                         id: balance
 
                         label: i18n("Balance")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("balance")
                         to: pluginDB.getMaxValue("balance")
                         value: pluginDB.balance

--- a/src/contents/ui/Gate.qml
+++ b/src/contents/ui/Gate.qml
@@ -549,7 +549,7 @@ Kirigami.ScrollablePage {
 
         Kirigami.CardsLayout {
             maximumColumns: 3
-            minimumColumnWidth: Kirigami.Units.gridUnit * 16
+            minimumColumnWidth: Kirigami.Units.gridUnit * 17
             uniformCellWidths: true
             Layout.topMargin: Kirigami.Units.largeSpacing
 

--- a/src/contents/ui/Gate.qml
+++ b/src/contents/ui/Gate.qml
@@ -42,17 +42,13 @@ Kirigami.ScrollablePage {
         pluginBackend = pipelineInstance.getPluginInstance(name);
     }
 
-    Column {
+    ColumnLayout {
         Kirigami.CardsLayout {
             id: cardLayout
 
             maximumColumns: 5
+            minimumColumnWidth: Kirigami.Units.gridUnit * 16
             uniformCellWidths: true
-
-            anchors {
-                left: parent.left
-                right: parent.right
-            }
 
             Kirigami.Card {
 
@@ -553,13 +549,9 @@ Kirigami.ScrollablePage {
 
         Kirigami.CardsLayout {
             maximumColumns: 3
+            minimumColumnWidth: Kirigami.Units.gridUnit * 16
             uniformCellWidths: true
             Layout.topMargin: Kirigami.Units.largeSpacing
-
-            anchors {
-                left: parent.left
-                right: parent.right
-            }
 
             Kirigami.Card {
                 Layout.fillWidth: false

--- a/src/contents/ui/LevelMeter.qml
+++ b/src/contents/ui/LevelMeter.qml
@@ -37,6 +37,7 @@ Kirigami.ScrollablePage {
         Kirigami.CardsLayout {
             id: cardLayout
 
+            minimumColumnWidth: Kirigami.Units.gridUnit * 17
             Layout.fillWidth: true
             uniformCellWidths: true
 

--- a/src/contents/ui/Limiter.qml
+++ b/src/contents/ui/Limiter.qml
@@ -39,7 +39,7 @@ Kirigami.ScrollablePage {
             id: cardLayout
 
             maximumColumns: 4
-            minimumColumnWidth: Kirigami.Units.gridUnit * 15
+            minimumColumnWidth: Kirigami.Units.gridUnit * 16
             uniformCellWidths: true
 
             Kirigami.Card {

--- a/src/contents/ui/Maximizer.qml
+++ b/src/contents/ui/Maximizer.qml
@@ -47,6 +47,7 @@ Kirigami.ScrollablePage {
                         id: release
 
                         label: i18n("Release")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("release")
                         to: pluginDB.getMaxValue("release")
                         value: pluginDB.release
@@ -62,6 +63,7 @@ Kirigami.ScrollablePage {
                         id: threshold
 
                         label: i18n("Threshold")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
                         from: pluginDB.getMinValue("threshold")
                         to: pluginDB.getMaxValue("threshold")
                         value: pluginDB.threshold

--- a/src/contents/ui/Pitch.qml
+++ b/src/contents/ui/Pitch.qml
@@ -32,6 +32,7 @@ Kirigami.ScrollablePage {
             id: cardLayout
 
             Layout.fillWidth: true
+            minimumColumnWidth: Kirigami.Units.gridUnit * 17
             uniformCellWidths: true
 
             Kirigami.Card {
@@ -47,6 +48,7 @@ Kirigami.ScrollablePage {
                         id: sequenceLength
 
                         label: i18n("Sequence Length")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 6
                         from: pitchPage.pluginDB.getMinValue("sequenceLength")
                         to: pitchPage.pluginDB.getMaxValue("sequenceLength")
                         value: pitchPage.pluginDB.sequenceLength
@@ -62,6 +64,7 @@ Kirigami.ScrollablePage {
                         id: seekWindow
 
                         label: i18n("Seek Window")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 6
                         from: pitchPage.pluginDB.getMinValue("seekWindow")
                         to: pitchPage.pluginDB.getMaxValue("seekWindow")
                         value: pitchPage.pluginDB.seekWindow
@@ -77,6 +80,7 @@ Kirigami.ScrollablePage {
                         id: overlapLength
 
                         label: i18n("Overlap Length")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 6
                         from: pitchPage.pluginDB.getMinValue("overlapLength")
                         to: pitchPage.pluginDB.getMaxValue("overlapLength")
                         value: pitchPage.pluginDB.overlapLength

--- a/src/contents/ui/RNNoise.qml
+++ b/src/contents/ui/RNNoise.qml
@@ -62,6 +62,7 @@ Kirigami.ScrollablePage {
         Kirigami.CardsLayout {
             id: cardLayout
 
+            minimumColumnWidth: Kirigami.Units.gridUnit * 17
             Layout.fillWidth: true
             uniformCellWidths: true
 

--- a/src/contents/ui/RNNoise.qml
+++ b/src/contents/ui/RNNoise.qml
@@ -89,6 +89,7 @@ Kirigami.ScrollablePage {
                         id: vadThres
 
                         label: i18n("Threshold")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 8
                         from: pluginDB.getMinValue("vadThres")
                         to: pluginDB.getMaxValue("vadThres")
                         value: pluginDB.vadThres
@@ -104,6 +105,7 @@ Kirigami.ScrollablePage {
                         id: wet
 
                         label: i18n("Wet Level")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 8
                         from: pluginDB.getMinValue("wet")
                         to: pluginDB.getMaxValue("wet")
                         value: pluginDB.wet
@@ -119,6 +121,7 @@ Kirigami.ScrollablePage {
                         id: release
 
                         label: i18n("Release")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 8
                         from: pluginDB.getMinValue("release")
                         to: pluginDB.getMaxValue("release")
                         value: pluginDB.release

--- a/src/contents/ui/Reverb.qml
+++ b/src/contents/ui/Reverb.qml
@@ -62,6 +62,7 @@ Kirigami.ScrollablePage {
                         id: decayTime
 
                         label: i18n("Decay Time")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 6
                         from: pluginDB.getMinValue("decayTime")
                         to: pluginDB.getMaxValue("decayTime")
                         value: pluginDB.decayTime
@@ -77,6 +78,7 @@ Kirigami.ScrollablePage {
                         id: predelay
 
                         label: i18n("Pre Delay")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 6
                         from: pluginDB.getMinValue("predelay")
                         to: pluginDB.getMaxValue("predelay")
                         value: pluginDB.predelay
@@ -92,6 +94,7 @@ Kirigami.ScrollablePage {
                         id: diffusion
 
                         label: i18n("Diffusion")
+                        spinboxMaximumWidth: Kirigami.Units.gridUnit * 6
                         from: pluginDB.getMinValue("diffusion")
                         to: pluginDB.getMaxValue("diffusion")
                         value: pluginDB.diffusion

--- a/src/contents/ui/Reverb.qml
+++ b/src/contents/ui/Reverb.qml
@@ -33,6 +33,7 @@ Kirigami.ScrollablePage {
         Kirigami.CardsLayout {
             id: cardLayout
 
+            minimumColumnWidth: Kirigami.Units.gridUnit * 17
             implicitWidth: cardLayout.maximumColumnWidth
             uniformCellWidths: true
 

--- a/src/contents/ui/Speex.qml
+++ b/src/contents/ui/Speex.qml
@@ -31,6 +31,7 @@ Kirigami.ScrollablePage {
         Kirigami.CardsLayout {
             id: cardLayout
 
+            minimumColumnWidth: Kirigami.Units.gridUnit * 17
             Layout.fillWidth: true
 
             Kirigami.Card {

--- a/src/contents/ui/StereoTools.qml
+++ b/src/contents/ui/StereoTools.qml
@@ -33,6 +33,7 @@ Kirigami.ScrollablePage {
         Kirigami.CardsLayout {
             id: cardLayout
 
+            minimumColumnWidth: Kirigami.Units.gridUnit * 17
             maximumColumns: 4
             uniformCellWidths: true
 


### PR DESCRIPTION
@wwmm The commit https://github.com/wwmm/easyeffects/commit/97d74706d781cc9ee1d136a1f7cac42e98413542 is good, but it still produces a non optimal result:

<img width="355" height="427" alt="Screenshot From 2025-09-14 10-50-25" src="https://github.com/user-attachments/assets/56714467-f6dc-43a5-afd9-5ce5cad9f25a" />

Specifiyng the spinbox minimum width is better:

<img width="320" height="427" alt="Screenshot From 2025-09-14 11-01-02" src="https://github.com/user-attachments/assets/f8e3ca26-2f4c-497b-9ff6-ebeeb9b181c0" /> 



I also restored the ColumnLayout in the Gate since reducing the width is leading to a freeze on my system. I used the same structure as the Compressor specifying a minimum width for the cards and it does not freeze anymore.

Other changes:

- Set a minimum width for cards that were too narrow when the window width is reduced.
- Added a minimum width to Convolver chart. 
