### PR TITLE
Various UI improvements

### DIFF
--- a/src/contents/ui/DelegateStreamsList.qml
+++ b/src/contents/ui/DelegateStreamsList.qml
@@ -22,8 +22,8 @@ Kirigami.AbstractCard {
     required property string mediaClass
     required property string state
     required property string format
-    required property string rate
-    required property string latency
+    required property real rate
+    required property real latency
 
     visible: {
         if (!isBlocklisted)
@@ -76,7 +76,12 @@ Kirigami.AbstractCard {
                 RowLayout {
                     Controls.Label {
                         wrapMode: Text.WordWrap
-                        text: `${root.state} · ` + `${root.format} · ${root.rate} · ${root.nVolumeChannels} ` + i18n("channels") + ` · ${root.latency}`
+                        text: {
+                            const rate = root.rate.toLocaleString(Qt.locale(), 'f', 1);
+                            const latency = root.latency.toLocaleString(Qt.locale(), 'f', 1);
+
+                            return `${root.state} · ` + `${root.format} · ${rate} kHz · ${root.nVolumeChannels} ` + i18n("channels") + ` · ${latency} ms`;
+                        }
                         color: Kirigami.Theme.disabledTextColor
                     }
                 }

--- a/src/contents/ui/PageStreamsEffects.qml
+++ b/src/contents/ui/PageStreamsEffects.qml
@@ -633,14 +633,22 @@ Kirigami.Page {
                             actionLevelSaturation.visible = true;
                         else if (actionLevelSaturation.visible !== false)
                             actionLevelSaturation.visible = false;
-                        const localeLeft = left.toLocaleString(Qt.locale(), 'f', 0).padStart(4, ' ');
-                        const localeRight = right.toLocaleString(Qt.locale(), 'f', 0).padStart(4, ' ');
-                        const latency = Number(pipelineInstance.getPipeLineLatency()).toLocaleString(Qt.locale(), 'f', 1);
+
+                        const localeLeft = left.toLocaleString(Qt.locale(), 'f', 0).padStart(3, ' ');
+                        const localeRight = right.toLocaleString(Qt.locale(), 'f', 0).padStart(3, ' ');
+
+                        const styledLocaleLeft = left > -10 ? `<b>${localeLeft}</b>` : localeLeft;
+                        const styledLocaleRight = right > -10 ? `<b>${localeRight}</b>` : localeRight;
+
+                        const pipelineLatency = Number(pipelineInstance.getPipeLineLatency());
+                        const latency = pipelineLatency.toLocaleString(Qt.locale(), 'f', 1);
+                        const styledLatency = pipelineLatency > 0 ? `<b>${latency}</b>` : latency;
+
                         const rate = Number(pipelineInstance.getPipeLineRate()).toLocaleString(Qt.locale(), 'f', 1);
 
-                        actionRateValue.text = `<pre> ${rate} kHz </pre>`;
-                        actionLatencyValue.text = `<pre> ${latency} ms </pre>`;
-                        actionLevelValue.text = `<pre>${localeLeft} ${localeRight} dB</pre>`;
+                        actionRateValue.text = `<pre> <b>${rate}</b> kHz </pre>`;
+                        actionLatencyValue.text = `<pre> ${styledLatency} ms </pre>`;
+                        actionLevelValue.text = `<pre> ${styledLocaleLeft} ${styledLocaleRight} dB</pre>`;
                     }
                 }
             }

--- a/src/pw_model_nodes.cpp
+++ b/src/pw_model_nodes.cpp
@@ -277,11 +277,11 @@ QVariant Nodes::data(const QModelIndex& index, int role) const {
     case Roles::NoutputPorts:
       return it->n_output_ports;
     case Roles::Rate:
-      return QString::fromStdString(std::format("{0:.1Lf} kHz", static_cast<float>(it->rate) / 1000.0F));
+      return static_cast<float>(it->rate) / 1000.0F;
     case Roles::NvolumeChannels:
       return it->n_volume_channels;
     case Roles::Latency:
-      return QString::fromStdString(std::format("{0:.0f} ms", 1000.0F * it->latency));
+      return it->latency * 1000.0F;
     case Roles::Volume:
       return it->volume;
     case Roles::IsBlocklisted:


### PR DESCRIPTION
Added bold styling to highlight values in bottom bar:

 <img width="337" height="36" alt="Screenshot From 2025-09-21 11-56-07" src="https://github.com/user-attachments/assets/a95ffb3f-deeb-4af0-912f-7f6dd6b2ebc4" />  .

 <img width="337" height="36" alt="Screenshot From 2025-09-21 11-57-04" src="https://github.com/user-attachments/assets/1f93ced6-14e7-4fe4-be7e-b4403c8fa5f7" />  .

Rate is always highlighted while the latency only if greater than 0 ms and the level meter only if greater than -10 db. @wwmm Is this okay for you?

Than I noticed that values in app info card are not localized. I moved the format in QML and added also decimal precision to latency:

<img width="523" height="146" alt="Screenshot From 2025-09-21 11-55-04" src="https://github.com/user-attachments/assets/26e98a09-e16d-409b-81c3-2e00126a8017" />
