### PR TITLE
XDG desktop entry: add StartupWMClass

### DIFF
--- a/src/contents/com.github.wwmm.easyeffects.desktop
+++ b/src/contents/com.github.wwmm.easyeffects.desktop
@@ -7,6 +7,7 @@ Keywords=limiter;compressor;reverberation;equalizer;autovolume;
 Categories=AudioVideo;Audio;
 Exec=easyeffects
 Icon=com.github.wwmm.easyeffects
+StartupWMClass=wwmm.easyeffects.github.com
 StartupNotify=true
 Terminal=false
 Type=Application

--- a/src/contents/com.github.wwmm.easyeffects.desktop.template
+++ b/src/contents/com.github.wwmm.easyeffects.desktop.template
@@ -7,6 +7,7 @@ Keywords=limiter;compressor;reverberation;equalizer;autovolume;
 Categories=AudioVideo;Audio;
 Exec=easyeffects
 Icon=com.github.wwmm.easyeffects
+StartupWMClass=wwmm.easyeffects.github.com
 StartupNotify=true
 Terminal=false
 Type=Application

--- a/util/easyeffects-dev.desktop
+++ b/util/easyeffects-dev.desktop
@@ -7,6 +7,7 @@ Keywords=limiter;compressor;reverberation;equalizer;autovolume;
 Categories=AudioVideo;Audio;
 Exec=build/src/easyeffects
 Icon=easyeffects
+StartupWMClass=wwmm.easyeffects.github.com
 StartupNotify=true
 Terminal=false
 Type=Application


### PR DESCRIPTION
Running Easy Effects I noticed a new default app icon is displayed in the Gnome dash. I remember this issue is fixed adding the `StartupWMClass` to the desktop entry. Indeed I copied the system desktop entry into `~/.local/share/applications` and added that line to avoid showing the additional icon.

Maybe this trick could also fix the missing icon in the development build on KDE.

@wwmm The desktop entry is automatically installed by cmake, right? So no need to change the PKGBUILD I suppose...   