### PR TITLE
Rewrite all util messages to use std::format

### DIFF
--- a/src/autogain.cpp
+++ b/src/autogain.cpp
@@ -77,7 +77,7 @@ Autogain::~Autogain() {
     ebur128_destroy(&ebur_state);
   }
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Autogain::reset() {

--- a/src/autostart.cpp
+++ b/src/autostart.cpp
@@ -70,7 +70,7 @@ void on_request_background_called([[maybe_unused]] GObject* source,
     util::warning(reason);
     util::warning(explanation);
 
-    util::warning("due to error, setting autostart state and switch to false");
+    util::warning("Due to error, setting autostart state and switch to false");
 
     db::Main::setAutostartOnLogin(false);
 

--- a/src/autostart.cpp
+++ b/src/autostart.cpp
@@ -66,7 +66,7 @@ void on_request_background_called([[maybe_unused]] GObject* source,
       explanation = "No explanation could be provided, error was null";
     }
 
-    util::debug("A background request failed: " + error_message);
+    util::debug(std::format("A background request failed: {}", error_message));
     util::warning(reason);
     util::warning(explanation);
 

--- a/src/bass_enhancer.cpp
+++ b/src/bass_enhancer.cpp
@@ -52,7 +52,7 @@ BassEnhancer::BassEnhancer(const std::string& tag,
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::BassEnhancer>(settings);
@@ -75,7 +75,7 @@ BassEnhancer::~BassEnhancer() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void BassEnhancer::reset() {

--- a/src/bass_loudness.cpp
+++ b/src/bass_loudness.cpp
@@ -53,7 +53,7 @@ BassLoudness::BassLoudness(const std::string& tag,
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::BassLoudness>(settings);
@@ -70,7 +70,7 @@ BassLoudness::~BassLoudness() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void BassLoudness::reset() {

--- a/src/bass_loudness.cpp
+++ b/src/bass_loudness.cpp
@@ -46,12 +46,14 @@ BassLoudness::BassLoudness(const std::string& tag,
       settings(db::Manager::self().get_plugin_db<db::BassLoudness>(
           pipe_type,
           tags::plugin_name::BaseName::bassLoudness + "#" + instance_id)) {
-  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://drobilla.net/plugins/mda/Loudness");
+  const auto lv2_plugin_uri = "http://drobilla.net/plugins/mda/Loudness";
+
+  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>(lv2_plugin_uri);
 
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + "http://drobilla.net/plugins/mda/Loudness is not installed");
+    util::debug(log_tag + lv2_plugin_uri + " is not installed");
   }
 
   init_common_controls<db::BassLoudness>(settings);

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -54,7 +54,7 @@ Compressor::Compressor(const std::string& tag, pw::Manager* pipe_manager, Pipeli
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::Compressor>(settings);
@@ -100,7 +100,7 @@ Compressor::~Compressor() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Compressor::reset() {

--- a/src/convolver.cpp
+++ b/src/convolver.cpp
@@ -148,7 +148,7 @@ Convolver::~Convolver() {
     delete conv;
   }
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Convolver::reset() {
@@ -345,14 +345,14 @@ auto Convolver::read_kernel_file(const std::string& kernel_path)
 
   auto file_path = std::filesystem::path{kernel_path};
 
-  util::debug("Reading the impulse file: " + file_path.string());
+  util::debug(std::format("Reading the impulse file: {}", file_path.string()));
 
   if (file_path.extension() != irs_ext) {
     file_path += irs_ext;
   }
 
   if (!std::filesystem::exists(file_path)) {
-    util::debug("File: " + file_path.string() + " does not exist");
+    util::debug(std::format("File: {} does not exist", file_path.string()));
 
     return std::make_tuple(rate, kernel_L, kernel_R);
   }
@@ -467,7 +467,7 @@ void Convolver::load_kernel_file() {
 
   kernel_is_initialized = true;
 
-  util::debug(log_tag + name.toStdString() + ": kernel correctly loaded");
+  util::debug(std::format("{}{}: kernel correctly loaded", log_tag, name.toStdString()));
 
   mythreads.emplace_back(  // Using emplace_back here makes sense
       [this, kernel_R, kernel_L, kernel_rate]() { chart_kernel_fft(kernel_L, kernel_R, kernel_rate); });
@@ -588,7 +588,7 @@ void Convolver::setup_zita() {
 
   zita_ready = true;
 
-  util::debug(log_tag + name.toStdString() + ": zita is ready");
+  util::debug(std::format("{}{}: zita is ready", log_tag, name.toStdString()));
 }
 
 auto Convolver::get_zita_buffer_size() -> uint {
@@ -747,7 +747,7 @@ void Convolver::combine_kernels(const std::string& kernel_1_name,
 
   sndfile.writef(buffer.data(), static_cast<sf_count_t>(kernel_L.size()));
 
-  util::debug("Combined kernel saved: " + output_file_path.string());
+  util::debug(std::format("Combined kernel saved: {}", output_file_path.string()));
 
   Q_EMIT kernelCombinationStopped();
 }
@@ -785,12 +785,12 @@ void Convolver::chart_kernel_fft(const std::vector<float>& kernel_L,
   std::scoped_lock<std::mutex> lock(data_mutex);
 
   if (kernel_L.empty() || kernel_R.empty() || kernel_L.size() != kernel_R.size()) {
-    util::debug(" aborting the impulse fft calculation...");
+    util::debug("Aborting the impulse fft calculation...");
 
     return;
   }
 
-  util::debug(" calculating the impulse fft...");
+  util::debug("Calculating the impulse fft...");
 
   std::vector<double> spectrum_L((kernel_L.size() / 2U) + 1U);
   std::vector<double> spectrum_R((kernel_R.size() / 2U) + 1U);

--- a/src/convolver.cpp
+++ b/src/convolver.cpp
@@ -345,14 +345,14 @@ auto Convolver::read_kernel_file(const std::string& kernel_path)
 
   auto file_path = std::filesystem::path{kernel_path};
 
-  util::debug("reading the impulse file: " + file_path.string());
+  util::debug("Reading the impulse file: " + file_path.string());
 
   if (file_path.extension() != irs_ext) {
     file_path += irs_ext;
   }
 
   if (!std::filesystem::exists(file_path)) {
-    util::debug("file: " + file_path.string() + " does not exist");
+    util::debug("File: " + file_path.string() + " does not exist");
 
     return std::make_tuple(rate, kernel_L, kernel_R);
   }
@@ -695,7 +695,7 @@ void Convolver::combine_kernels(const std::string& kernel_1_name,
   }
 
   if (rate1 > rate2) {
-    util::debug(std::format("resampling the kernel {} to {} Hz", kernel_2_name, rate1));
+    util::debug(std::format("Resampling the kernel {} to {} Hz", kernel_2_name, rate1));
 
     auto resampler = std::make_unique<Resampler>(rate2, rate1);
 
@@ -705,7 +705,7 @@ void Convolver::combine_kernels(const std::string& kernel_1_name,
 
     kernel_2_R = resampler->process(kernel_2_R, true);
   } else if (rate2 > rate1) {
-    util::debug(std::format("resampling the kernel {} to {} Hz", kernel_1_name, rate2));
+    util::debug(std::format("Resampling the kernel {} to {} Hz", kernel_1_name, rate2));
 
     auto resampler = std::make_unique<Resampler>(rate1, rate2);
 
@@ -747,7 +747,7 @@ void Convolver::combine_kernels(const std::string& kernel_1_name,
 
   sndfile.writef(buffer.data(), static_cast<sf_count_t>(kernel_L.size()));
 
-  util::debug("combined kernel saved: " + output_file_path.string());
+  util::debug("Combined kernel saved: " + output_file_path.string());
 
   Q_EMIT kernelCombinationStopped();
 }
@@ -883,8 +883,8 @@ void Convolver::chart_kernel_fft(const std::vector<float>& kernel_L,
   auto max_freq = std::ranges::max(freq_axis);
   auto min_freq = std::ranges::min(freq_axis);
 
-  util::debug(std::format("min fft frequency: {}", min_freq));
-  util::debug(std::format("max fft frequency: {}", max_freq));
+  util::debug(std::format("Min fft frequency: {}", min_freq));
+  util::debug(std::format("Max fft frequency: {}", max_freq));
 
   auto log_freq_axis = util::logspace(min_freq, max_freq, interpPoints);
 

--- a/src/convolver.cpp
+++ b/src/convolver.cpp
@@ -360,8 +360,8 @@ auto Convolver::read_kernel_file(const std::string& kernel_path)
   auto sndfile = SndfileHandle(file_path.string());
 
   if (sndfile.channels() != 2 || sndfile.frames() == 0) {
-    util::warning(" Only stereo impulse responses are supported.");
-    util::warning(" The impulse file was not loaded!");
+    util::warning(std::format("{}Only stereo impulse responses are supported.", log_tag));
+    util::warning(std::format("{}The impulse file was not loaded!", log_tag));
 
     return std::make_tuple(rate, kernel_L, kernel_R);
   }
@@ -393,7 +393,7 @@ void Convolver::load_kernel_file() {
   const auto name = settings->kernelName();
 
   if (name.isEmpty()) {
-    util::warning(log_tag + name.toStdString() + ": irs filename is null. Entering passthrough mode...");
+    util::warning(std::format("{}{}: irs filename is null. Entering passthrough mode...", log_tag, name.toStdString()));
 
     return;
   }
@@ -404,7 +404,7 @@ void Convolver::load_kernel_file() {
 
   // If the search fails, the path is empty
   if (rate == 0 || kernel_L.empty() || kernel_R.empty()) {
-    util::warning(log_tag + name.toStdString() + " is invalid. Entering passthrough mode...");
+    util::warning(std::format("{}{} is invalid. Entering passthrough mode...", log_tag, name.toStdString()));
 
     return;
   }
@@ -670,7 +670,7 @@ void Convolver::combine_kernels(const std::string& kernel_1_name,
 
   // If the search fails, the path is empty
   if (kernel_1_path.empty()) {
-    util::warning(log_tag + kernel_1_path + ": irs filename does not exist.");
+    util::warning(std::format("{}{}: irs filename does not exist.", log_tag, kernel_1_path));
 
     Q_EMIT kernelCombinationStopped();
 
@@ -678,7 +678,7 @@ void Convolver::combine_kernels(const std::string& kernel_1_name,
   }
 
   if (kernel_2_path.empty()) {
-    util::warning(log_tag + kernel_2_path + ": irs filename does not exist.");
+    util::warning(std::format("{}{}: irs filename does not exist.", log_tag, kernel_2_path));
 
     Q_EMIT kernelCombinationStopped();
 

--- a/src/convolver_preset.cpp
+++ b/src/convolver_preset.cpp
@@ -66,8 +66,9 @@ void ConvolverPreset::load(const nlohmann::json& json) {
     if (!kernel_path.empty()) {
       new_kernel_name = std::filesystem::path{kernel_path}.stem().string();
 
-      util::warning("using Convolver kernel-path is deprecated, please update your preset; fallback to kernel-name: " +
-                    new_kernel_name);
+      util::warning(std::format(
+          "Using Convolver kernel-path is deprecated, please update your preset; fallback to kernel-name: {}",
+          new_kernel_name));
     }
   }
 

--- a/src/crossfeed.cpp
+++ b/src/crossfeed.cpp
@@ -67,7 +67,7 @@ Crossfeed::~Crossfeed() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Crossfeed::reset() {

--- a/src/crystalizer.cpp
+++ b/src/crystalizer.cpp
@@ -116,7 +116,7 @@ Crystalizer::~Crystalizer() {
 
   data_mutex.unlock();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Crystalizer::reset() {

--- a/src/deepfilternet.cpp
+++ b/src/deepfilternet.cpp
@@ -55,7 +55,7 @@ DeepFilterNet::DeepFilterNet(const std::string& tag,
   package_installed = ladspa_wrapper->found_plugin();
 
   if (!package_installed) {
-    util::debug(log_tag + "libdeep_filter_ladspa is not installed");
+    util::debug(std::format("{}libdeep_filter_ladspa is not installed", log_tag));
   }
 
   init_common_controls<db::DeepFilterNet>(settings);
@@ -83,7 +83,7 @@ DeepFilterNet::~DeepFilterNet() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void DeepFilterNet::reset() {

--- a/src/deesser.cpp
+++ b/src/deesser.cpp
@@ -43,12 +43,14 @@ Deesser::Deesser(const std::string& tag, pw::Manager* pipe_manager, PipelineType
       settings(
           db::Manager::self().get_plugin_db<db::Deesser>(pipe_type,
                                                          tags::plugin_name::BaseName::deesser + "#" + instance_id)) {
-  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://calf.sourceforge.net/plugins/Deesser");
+  const auto lv2_plugin_uri = "http://calf.sourceforge.net/plugins/Deesser";
+
+  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>(lv2_plugin_uri);
 
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + "http://calf.sourceforge.net/plugins/Deesser is not installed");
+    util::debug(log_tag + lv2_plugin_uri + " is not installed");
   }
 
   init_common_controls<db::Deesser>(settings);

--- a/src/deesser.cpp
+++ b/src/deesser.cpp
@@ -50,7 +50,7 @@ Deesser::Deesser(const std::string& tag, pw::Manager* pipe_manager, PipelineType
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::Deesser>(settings);
@@ -76,7 +76,7 @@ Deesser::~Deesser() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 void Deesser::reset() {
   settings->setDefaults();

--- a/src/delay.cpp
+++ b/src/delay.cpp
@@ -44,12 +44,14 @@ Delay::Delay(const std::string& tag, pw::Manager* pipe_manager, PipelineType pip
                  pipe_type),
       settings(db::Manager::self().get_plugin_db<db::Delay>(pipe_type,
                                                             tags::plugin_name::BaseName::delay + "#" + instance_id)) {
-  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/comp_delay_x2_stereo");
+  const auto lv2_plugin_uri = "http://lsp-plug.in/plugins/lv2/comp_delay_x2_stereo";
+
+  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>(lv2_plugin_uri);
 
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/comp_delay_x2_stereo is not installed");
+    util::debug(log_tag + lv2_plugin_uri + " is not installed");
   }
 
   init_common_controls<db::Delay>(settings);

--- a/src/delay.cpp
+++ b/src/delay.cpp
@@ -51,7 +51,7 @@ Delay::Delay(const std::string& tag, pw::Manager* pipe_manager, PipelineType pip
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::Delay>(settings);
@@ -93,7 +93,7 @@ Delay::~Delay() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Delay::reset() {

--- a/src/echo_canceller.cpp
+++ b/src/echo_canceller.cpp
@@ -112,7 +112,7 @@ EchoCanceller::~EchoCanceller() {
 
   data_mutex.unlock();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void EchoCanceller::reset() {

--- a/src/echo_canceller.cpp
+++ b/src/echo_canceller.cpp
@@ -222,7 +222,7 @@ void EchoCanceller::init_speex() {
   echo_state_L = speex_echo_state_init(static_cast<int>(n_samples), static_cast<int>(filter_length));
 
   if (speex_echo_ctl(echo_state_L, SPEEX_ECHO_SET_SAMPLING_RATE, &rate) != 0) {
-    util::warning(log_tag + name.toStdString() + "SPEEX_ECHO_SET_SAMPLING_RATE: unknown request");
+    util::warning(std::format("{}{}SPEEX_ECHO_SET_SAMPLING_RATE: unknown request", log_tag, name.toStdString()));
   }
 
   if (echo_state_R != nullptr) {
@@ -232,7 +232,7 @@ void EchoCanceller::init_speex() {
   echo_state_R = speex_echo_state_init(static_cast<int>(n_samples), static_cast<int>(filter_length));
 
   if (speex_echo_ctl(echo_state_R, SPEEX_ECHO_SET_SAMPLING_RATE, &rate) != 0) {
-    util::warning(log_tag + name.toStdString() + "SPEEX_ECHO_SET_SAMPLING_RATE: unknown request");
+    util::warning(std::format("{}{}SPEEX_ECHO_SET_SAMPLING_RATE: unknown request", log_tag, name.toStdString()));
   }
 
   if (state_left != nullptr) {

--- a/src/equalizer.cpp
+++ b/src/equalizer.cpp
@@ -70,7 +70,7 @@ Equalizer::Equalizer(const std::string& tag, pw::Manager* pipe_manager, Pipeline
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::Equalizer>(settings);
@@ -116,7 +116,7 @@ Equalizer::~Equalizer() {
   settings_left->disconnect();
   settings_right->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Equalizer::reset() {

--- a/src/equalizer.cpp
+++ b/src/equalizer.cpp
@@ -63,12 +63,14 @@ Equalizer::Equalizer(const std::string& tag, pw::Manager* pipe_manager, Pipeline
       settings_right(db::Manager::self().get_plugin_db<db::EqualizerChannel>(
           pipe_type,
           tags::plugin_name::BaseName::equalizer + "#" + instance_id + "#right")) {
-  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/para_equalizer_x32_lr");
+  const auto lv2_plugin_uri = "http://lsp-plug.in/plugins/lv2/para_equalizer_x32_lr";
+
+  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>(lv2_plugin_uri);
 
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/para_equalizer_x32_lr is not installed");
+    util::debug(log_tag + lv2_plugin_uri + " is not installed");
   }
 
   init_common_controls<db::Equalizer>(settings);

--- a/src/exciter.cpp
+++ b/src/exciter.cpp
@@ -49,7 +49,7 @@ Exciter::Exciter(const std::string& tag, pw::Manager* pipe_manager, PipelineType
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::Exciter>(settings);
@@ -72,7 +72,7 @@ Exciter::~Exciter() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Exciter::reset() {

--- a/src/expander.cpp
+++ b/src/expander.cpp
@@ -47,12 +47,14 @@ Expander::Expander(const std::string& tag, pw::Manager* pipe_manager, PipelineTy
       settings(
           db::Manager::self().get_plugin_db<db::Expander>(pipe_type,
                                                           tags::plugin_name::BaseName::expander + "#" + instance_id)) {
-  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/sc_expander_stereo");
+  const auto lv2_plugin_uri = "http://lsp-plug.in/plugins/lv2/sc_expander_stereo";
+
+  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>(lv2_plugin_uri);
 
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/sc_expander_stereo is not installed");
+    util::debug(log_tag + lv2_plugin_uri + " is not installed");
   }
 
   init_common_controls<db::Expander>(settings);

--- a/src/expander.cpp
+++ b/src/expander.cpp
@@ -54,7 +54,7 @@ Expander::Expander(const std::string& tag, pw::Manager* pipe_manager, PipelineTy
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::Expander>(settings);
@@ -96,7 +96,7 @@ Expander::~Expander() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Expander::reset() {

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -50,7 +50,7 @@ Filter::Filter(const std::string& tag, pw::Manager* pipe_manager, PipelineType p
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::Filter>(settings);
@@ -75,7 +75,7 @@ Filter::~Filter() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Filter::reset() {

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -53,7 +53,7 @@ Gate::Gate(const std::string& tag, pw::Manager* pipe_manager, PipelineType pipe_
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::Gate>(settings);
@@ -98,7 +98,7 @@ Gate::~Gate() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Gate::reset() {

--- a/src/global_shortcuts.cpp
+++ b/src/global_shortcuts.cpp
@@ -67,8 +67,8 @@ GlobalShortcuts::GlobalShortcuts(QObject* parent) : QObject(parent) {
 
 void GlobalShortcuts::onSessionCreatedResponse(uint responseCode, const QVariantMap& results) {
   if (responseCode != 0) {
-    util::warning("D-Bus CreateSession for GlobalShortcuts was denied or failed. Response code: " +
-                  util::to_string(responseCode));
+    util::warning(std::format("D-Bus CreateSession for GlobalShortcuts was denied or failed. Response code: {}",
+                              util::to_string(responseCode)));
 
     return;
   }

--- a/src/global_shortcuts.cpp
+++ b/src/global_shortcuts.cpp
@@ -67,8 +67,8 @@ GlobalShortcuts::GlobalShortcuts(QObject* parent) : QObject(parent) {
 
 void GlobalShortcuts::onSessionCreatedResponse(uint responseCode, const QVariantMap& results) {
   if (responseCode != 0) {
-    util::warning(std::format("D-Bus CreateSession for GlobalShortcuts was denied or failed. Response code: {}",
-                              util::to_string(responseCode)));
+    util::warning(
+        std::format("D-Bus CreateSession for GlobalShortcuts was denied or failed. Response code: {}", responseCode));
 
     return;
   }

--- a/src/global_shortcuts.cpp
+++ b/src/global_shortcuts.cpp
@@ -110,6 +110,9 @@ void GlobalShortcuts::bind_shortcuts() {
   // For security reasons, it's better to show the session handle only in development/debug mode.
   // util::info("Session handle object response:" + session_obj_path.path().toStdString());
 
+  // TODO: temporary fix for a core dump, to be removed...
+  return;
+
   // a(sa{sv})
   QList<QPair<QString, QVariantMap>> shortcuts;
 

--- a/src/help_manager.cpp
+++ b/src/help_manager.cpp
@@ -42,7 +42,7 @@ QString HelpManager::copyResourceFolder(const QString& resourcePath, const QStri
       QStandardPaths::writableLocation(QStandardPaths::TempLocation) + QDir::separator() + tempFolderName;
 
   if (!QDir().mkpath(tempPath)) {
-    util::warning("Failed to create temp folder:" + tempPath.toStdString());
+    util::warning(std::format("Failed to create temp folder: {}", tempPath.toStdString()));
   }
 
   QDir resourceDir(resourcePath);
@@ -53,7 +53,7 @@ QString HelpManager::copyResourceFolder(const QString& resourcePath, const QStri
     QFile::remove(dst);  // remove if exists
 
     if (!QFile::copy(src, dst)) {
-      util::warning("Failed to copy" + src.toStdString() + "to" + dst.toStdString());
+      util::warning(std::format("Failed to copy {} to {}", src.toStdString(), dst.toStdString()));
     }
   }
 
@@ -66,7 +66,7 @@ void HelpManager::openManual() {
   QString indexPath = tempPath + "/index.html";
 
   if (!QFile::exists(indexPath)) {
-    util::warning("Index file missing:" + indexPath.toStdString());
+    util::warning(std::format("Index file missing: {}", indexPath.toStdString()));
 
     return;
   }

--- a/src/ladspa_wrapper.cpp
+++ b/src/ladspa_wrapper.cpp
@@ -762,7 +762,7 @@ auto LadspaWrapper::get_control_port_value(const std::string& symbol) const -> f
   auto iter = map_cp_name_to_idx.find(symbol);
 
   if (iter == map_cp_name_to_idx.end()) {
-    util::warning(plugin_name + " port symbol not found: " + symbol);
+    util::warning(std::format("{} port symbol not found: {}", plugin_name, symbol));
 
     return 0.0F;
   }
@@ -788,7 +788,7 @@ auto LadspaWrapper::set_control_port_value_clamp(const std::string& symbol, floa
   auto iter = map_cp_name_to_idx.find(symbol);
 
   if (iter == map_cp_name_to_idx.end()) {
-    util::warning(plugin_name + " port symbol not found: " + symbol);
+    util::warning(std::format("{} port symbol not found: {}", plugin_name, symbol));
 
     return value;
   }

--- a/src/level_meter.cpp
+++ b/src/level_meter.cpp
@@ -67,7 +67,7 @@ LevelMeter::~LevelMeter() {
     ebur128_destroy(&ebur_state);
   }
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void LevelMeter::reset() {

--- a/src/limiter.cpp
+++ b/src/limiter.cpp
@@ -53,7 +53,7 @@ Limiter::Limiter(const std::string& tag, pw::Manager* pipe_manager, PipelineType
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::Limiter>(settings);
@@ -95,7 +95,7 @@ Limiter::~Limiter() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Limiter::reset() {

--- a/src/local_client.cpp
+++ b/src/local_client.cpp
@@ -37,7 +37,7 @@ LocalClient::LocalClient(QObject* parent) : QObject(parent), client(std::make_un
   connect(client.get(), &QLocalSocket::readyRead, [&]() {
     QString message = client->readAll();
 
-    util::debug("Server message: " + message.toStdString());
+    util::debug(std::format("Server message: {}", message.toStdString()));
   });
 
   client->connectToServer(tags::local_server::server_name);

--- a/src/local_server.cpp
+++ b/src/local_server.cpp
@@ -49,7 +49,9 @@ void LocalServer::startServer() {
   QLocalServer::removeServer(tags::local_server::server_name);
 
   if (server->listen(tags::local_server::server_name)) {
-    util::debug("Local socket server started. Listening on the name: " + std::string(tags::local_server::server_name));
+    util::debug(std::format("Local socket server started. Listening on the name: {}",
+                            std::string(tags::local_server::server_name)));
+
   } else {
     util::debug("Failed to start the server");
   }

--- a/src/local_server.cpp
+++ b/src/local_server.cpp
@@ -49,8 +49,7 @@ void LocalServer::startServer() {
   QLocalServer::removeServer(tags::local_server::server_name);
 
   if (server->listen(tags::local_server::server_name)) {
-    util::debug(std::format("Local socket server started. Listening on the name: {}",
-                            std::string(tags::local_server::server_name)));
+    util::debug(std::format("Local socket server started. Listening on the name: {}", tags::local_server::server_name));
 
   } else {
     util::debug("Failed to start the server");

--- a/src/loudness.cpp
+++ b/src/loudness.cpp
@@ -45,12 +45,14 @@ Loudness::Loudness(const std::string& tag, pw::Manager* pipe_manager, PipelineTy
       settings(
           db::Manager::self().get_plugin_db<db::Loudness>(pipe_type,
                                                           tags::plugin_name::BaseName::loudness + "#" + instance_id)) {
-  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/loud_comp_stereo");
+  const auto lv2_plugin_uri = "http://lsp-plug.in/plugins/lv2/loud_comp_stereo";
+
+  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>(lv2_plugin_uri);
 
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/loud_comp_stereo is not installed");
+    util::debug(log_tag + lv2_plugin_uri + " is not installed");
   }
 
   init_common_controls<db::Loudness>(settings);

--- a/src/loudness.cpp
+++ b/src/loudness.cpp
@@ -52,7 +52,7 @@ Loudness::Loudness(const std::string& tag, pw::Manager* pipe_manager, PipelineTy
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::Loudness>(settings);
@@ -73,7 +73,7 @@ Loudness::~Loudness() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Loudness::reset() {

--- a/src/lv2_ui.cpp
+++ b/src/lv2_ui.cpp
@@ -201,7 +201,7 @@ void NativeUi::load() {
       lilv_free(bundle_path);
 
       if (ui_handle && show_iface && show_iface->show(ui_handle) != 0) {
-        util::warning("failed to show ui for " + ui_uri);
+        util::warning(std::format("Failed to show UI for {}", ui_uri));
       }
 
       break;

--- a/src/lv2_ui.cpp
+++ b/src/lv2_ui.cpp
@@ -83,7 +83,7 @@ void NativeUi::load() {
 
     std::string ui_uri = lilv_node_as_uri(lilv_ui_get_uri(ui));
 
-    util::debug(wrapper->get_plugin_uri() + " ui uri: " + ui_uri);
+    util::debug(std::format("{} UI uri: {}", wrapper->get_plugin_uri(), ui_uri));
 
     const LilvNode* binary_node = lilv_ui_get_binary_uri(ui);
     const LilvNode* bundle_node = lilv_ui_get_bundle_uri(ui);

--- a/src/lv2_wrapper.cpp
+++ b/src/lv2_wrapper.cpp
@@ -58,7 +58,7 @@ Lv2Wrapper::Lv2Wrapper(const std::string& plugin_uri)
   auto* const uri = lilv_new_uri(world, plugin_uri.c_str());
 
   if (uri == nullptr) {
-    util::warning("Invalid plugin URI: " + plugin_uri);
+    util::warning(std::format("Invalid plugin URI: {}", plugin_uri));
 
     return;
   }
@@ -72,7 +72,7 @@ Lv2Wrapper::Lv2Wrapper(const std::string& plugin_uri)
   lilv_node_free(uri);
 
   if (plugin == nullptr) {
-    util::warning("Could not find the plugin: " + plugin_uri);
+    util::warning(std::format("Could not find the plugin: {}", plugin_uri));
 
     return;
   }
@@ -183,7 +183,7 @@ void Lv2Wrapper::create_ports() {
     if (lilv_port_is_a(plugin, lilv_port, lv2_InputPort)) {
       port->is_input = true;
     } else if (!lilv_port_is_a(plugin, lilv_port, lv2_OutputPort) && !port->optional) {
-      util::warning("Port " + port->name + " is neither input nor output!");
+      util::warning(std::format("Port {} is neither input nor output!", port->name));
     }
 
     if (lilv_port_is_a(plugin, lilv_port, lv2_ControlPort)) {
@@ -217,7 +217,7 @@ void Lv2Wrapper::create_ports() {
         n_audio_out++;
       }
     } else if (!port->optional) {
-      util::warning("Port " + port->name + " has un unsupported type!");
+      util::warning(std::format("Port {} has un unsupported type!", port->name));
     }
 
     lilv_node_free(port_name);
@@ -302,7 +302,7 @@ auto Lv2Wrapper::create_instance(const uint& rate) -> bool {
   instance = lilv_plugin_instantiate(plugin, rate, features.data());
 
   if (instance == nullptr) {
-    util::warning("failed to instantiate " + plugin_uri);
+    util::warning(std::format("Failed to instantiate {}", plugin_uri));
 
     return false;
   }
@@ -410,7 +410,7 @@ void Lv2Wrapper::set_control_port_value(const std::string& symbol, const float& 
   for (auto& p : ports) {
     if (p.type == PortType::TYPE_CONTROL && p.symbol == symbol) {
       if (!p.is_input) {
-        util::warning(plugin_uri + " port " + symbol + " is not an input!");
+        util::warning(std::format("{} port {} is not an input!", plugin_uri, symbol));
 
         return;
       }
@@ -419,13 +419,13 @@ void Lv2Wrapper::set_control_port_value(const std::string& symbol, const float& 
 
       // Check port bounds
       if (value < p.min) {
-        // util::warning(plugin_uri + ": value " + util::to_string(value) + " is out of minimum limit for port " +
-        //               p.symbol + " (" + p.name + ")");
+        // util::warning(plugin_uri + ": value " + util::to_string(value) + "
+        // is out of minimum limit for port " + p.symbol + " (" + p.name + ")");
 
         p.value = p.min;
       } else if (value > p.max) {
-        // util::warning(plugin_uri + ": value " + util::to_string(value) + " is out of maximum limit for port " +
-        //               p.symbol + " (" + p.name + ")");
+        // util::warning(plugin_uri + ": value " + util::to_string(value) + "
+        // is out of maximum limit for port " + p.symbol + " (" + p.name + ")");
 
         p.value = p.max;
       } else {
@@ -439,7 +439,7 @@ void Lv2Wrapper::set_control_port_value(const std::string& symbol, const float& 
   }
 
   if (!found) {
-    util::warning(plugin_uri + " port symbol not found: " + symbol);
+    util::warning(std::format("{} port symbol not found: {}", plugin_uri, symbol));
   }
 }
 auto Lv2Wrapper::get_control_port_value(const std::string& symbol) -> float {
@@ -477,7 +477,7 @@ auto Lv2Wrapper::get_control_port_value(const std::string& symbol) -> float {
     }
   }
 
-  util::warning(plugin_uri + " port symbol not found: " + symbol);
+  util::warning(std::format("{} port symbol not found: {}", plugin_uri, symbol));
 
   return 0.0F;
 }

--- a/src/lv2_wrapper.cpp
+++ b/src/lv2_wrapper.cpp
@@ -122,7 +122,7 @@ void Lv2Wrapper::check_required_features() {
 
       const char* required_feature_uri = lilv_node_as_uri(required_feature);
 
-      util::debug(plugin_uri + " requires feature: " + required_feature_uri);
+      util::debug(std::format("{} requires feature: {}", plugin_uri, required_feature_uri));
     }
 
     lilv_nodes_free(required_features);

--- a/src/lv2_wrapper.cpp
+++ b/src/lv2_wrapper.cpp
@@ -50,7 +50,7 @@ namespace lv2 {
 Lv2Wrapper::Lv2Wrapper(const std::string& plugin_uri)
     : plugin_uri(plugin_uri), world(lilv_world_new()), native_ui(this) {
   if (world == nullptr) {
-    util::warning("failed to initialized the world");
+    util::warning("Failed to initialized the world");
 
     return;
   }
@@ -177,8 +177,8 @@ void Lv2Wrapper::create_ports() {
       port->max = maximum[n];
     }
 
-    // util::warning("port name: " + port->name);
-    // util::warning("port symbol: " + port->symbol);
+    // util::warning("Port name: " + port->name);
+    // util::warning("Port symbol: " + port->symbol);
 
     if (lilv_port_is_a(plugin, lilv_port, lv2_InputPort)) {
       port->is_input = true;
@@ -191,7 +191,7 @@ void Lv2Wrapper::create_ports() {
     } else if (lilv_port_is_a(plugin, lilv_port, lv2_AtomPort)) {
       port->type = TYPE_ATOM;
 
-      // util::warning("port name: " + port->name);
+      // util::warning("Port name: " + port->name);
     } else if (lilv_port_is_a(plugin, lilv_port, lv2_AudioPort)) {
       port->type = TYPE_AUDIO;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,7 +133,7 @@ static void initGlobalBypass(StreamInputEffects& sie, StreamOutputEffects& soe) 
     soe.set_bypass(db::Main::bypass());
     sie.set_bypass(db::Main::bypass());
 
-    util::info((db::Main::bypass() ? "enabling global bypass" : "disabling global bypass"));
+    util::info((db::Main::bypass() ? "Enabling global bypass" : "Disabling global bypass"));
   };
 
   update_bypass_state();

--- a/src/maximizer.cpp
+++ b/src/maximizer.cpp
@@ -51,7 +51,7 @@ Maximizer::Maximizer(const std::string& tag, pw::Manager* pipe_manager, Pipeline
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::Maximizer>(settings);
@@ -69,7 +69,7 @@ Maximizer::~Maximizer() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Maximizer::reset() {

--- a/src/multiband_compressor.cpp
+++ b/src/multiband_compressor.cpp
@@ -67,7 +67,7 @@ MultibandCompressor::MultibandCompressor(const std::string& tag,
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::MultibandCompressor>(settings);
@@ -103,7 +103,7 @@ MultibandCompressor::~MultibandCompressor() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void MultibandCompressor::reset() {

--- a/src/multiband_gate.cpp
+++ b/src/multiband_gate.cpp
@@ -67,7 +67,7 @@ MultibandGate::MultibandGate(const std::string& tag,
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::MultibandGate>(settings);
@@ -103,7 +103,7 @@ MultibandGate::~MultibandGate() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void MultibandGate::reset() {

--- a/src/output_level.cpp
+++ b/src/output_level.cpp
@@ -36,7 +36,7 @@ OutputLevel::~OutputLevel() {
     disconnect_from_pw();
   }
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void OutputLevel::reset() {}

--- a/src/pitch.cpp
+++ b/src/pitch.cpp
@@ -79,7 +79,7 @@ Pitch::~Pitch() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Pitch::reset() {

--- a/src/plugin_base.cpp
+++ b/src/plugin_base.cpp
@@ -409,7 +409,7 @@ auto PluginBase::connect_to_pw() -> bool {
   if (pw_filter_connect(filter, PW_FILTER_FLAG_RT_PROCESS, nullptr, 0) != 0) {
     pm->unlock();
 
-    util::warning(log_tag + name.toStdString() + " cannot connect the filter to PipeWire!");
+    util::warning(std::format("{}{} cannot connect the filter to PipeWire!", log_tag, name.toStdString()));
 
     return false;
   }
@@ -422,7 +422,7 @@ auto PluginBase::connect_to_pw() -> bool {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
     if (state == PW_FILTER_STATE_ERROR) {
-      util::warning(log_tag + name.toStdString() + " is in an error");
+      util::warning(std::format("{}{} is in an error", log_tag, name.toStdString()));
 
       return false;
     }

--- a/src/plugin_base.cpp
+++ b/src/plugin_base.cpp
@@ -93,7 +93,7 @@ void on_process(void* userdata, spa_io_position* position) {
     d->pb->setup();
   }
 
-  // util::warning("processing: " + util::to_string(n_samples));
+  // util::warning("Processing: " + util::to_string(n_samples));
 
   auto* in_left = static_cast<float*>(pw_filter_get_dsp_buffer(d->in_left, n_samples));
   auto* in_right = static_cast<float*>(pw_filter_get_dsp_buffer(d->in_right, n_samples));
@@ -110,7 +110,7 @@ void on_process(void* userdata, spa_io_position* position) {
     left_in = std::span(in_left, n_samples);
   } else {
     if (!d->pb->got_null_left_in) {
-      util::warning("processing: we received a null left_in pointer. Using the dummy array instead.");
+      util::warning("Processing: we received a null left_in pointer. Using the dummy array instead.");
 
       d->pb->got_null_left_in = true;
     }
@@ -122,7 +122,7 @@ void on_process(void* userdata, spa_io_position* position) {
     right_in = std::span(in_right, n_samples);
   } else {
     if (!d->pb->got_null_right_in) {
-      util::warning("processing: we received a null right_in pointer. Using the dummy array instead.");
+      util::warning("Processing: we received a null right_in pointer. Using the dummy array instead.");
 
       d->pb->got_null_right_in = true;
     }
@@ -134,7 +134,7 @@ void on_process(void* userdata, spa_io_position* position) {
     left_out = std::span(out_left, n_samples);
   } else {
     if (!d->pb->got_null_left_out) {
-      util::warning("processing: we received a null left_out pointer. Using the dummy array instead.");
+      util::warning("Processing: we received a null left_out pointer. Using the dummy array instead.");
 
       d->pb->got_null_left_out = true;
     }
@@ -146,7 +146,7 @@ void on_process(void* userdata, spa_io_position* position) {
     right_out = std::span(out_right, n_samples);
   } else {
     if (!d->pb->got_null_right_out) {
-      util::warning("processing: we received a null right_out pointer. Using the dummy array instead.");
+      util::warning("Processing: we received a null right_out pointer. Using the dummy array instead.");
 
       d->pb->got_null_right_out = true;
     }
@@ -162,7 +162,7 @@ void on_process(void* userdata, spa_io_position* position) {
 
     if (probe_left == nullptr || probe_right == nullptr) {
       if (!d->pb->got_null_probe) {
-        util::warning("processing: we received a null pointer for probe left/right. Using the dummy array instead.");
+        util::warning("Processing: we received a null pointer for probe left/right. Using the dummy array instead.");
 
         d->pb->got_null_probe = true;
       }

--- a/src/plugin_base.cpp
+++ b/src/plugin_base.cpp
@@ -446,7 +446,7 @@ auto PluginBase::connect_to_pw() -> bool {
 
   connected_to_pw = true;
 
-  util::debug(log_tag + name.toStdString() + " successfully connected to PipeWire graph");
+  util::debug(std::format("{}{} successfully connected to PipeWire graph", log_tag, name.toStdString()));
 
   return true;
 }

--- a/src/plugin_preset_base.hpp
+++ b/src/plugin_preset_base.hpp
@@ -42,7 +42,7 @@ class PluginPresetBase {
     auto instance = db::Manager::self().get_plugin_db<dbType>(pipeline_type, QString::fromStdString(instance_name));
 
     if (instance == nullptr) {
-      util::warning("Failed to get the database instance for: " + instance_name);
+      util::warning(std::format("Failed to get the database instance for: {}", instance_name));
     }
 
     return instance;

--- a/src/presets_autoload_manager.cpp
+++ b/src/presets_autoload_manager.cpp
@@ -108,7 +108,7 @@ void AutoloadManager::add(const PipelineType& pipeline_type,
 
   o << std::setw(4) << json << '\n';
 
-  util::debug(std::format("added autoload preset file: {}", path.string()));
+  util::debug(std::format("Added autoload preset file: {}", path.string()));
 
   o.close();
 
@@ -139,7 +139,7 @@ void AutoloadManager::remove(const PipelineType& pipeline_type,
       device_profile.toStdString() == json.value("device-profile", "")) {
     std::filesystem::remove(path);
 
-    util::debug(std::format("removed autoload: {}", path.string()));
+    util::debug(std::format("Removed autoload: {}", path.string()));
   }
 }
 
@@ -180,7 +180,7 @@ void AutoloadManager::load(const PipelineType& pipeline_type,
     }
 
     if (!fallback.isEmpty()) {
-      util::debug(std::format("autoloading fallback preset {} for device {}", name, device_name.toStdString()));
+      util::debug(std::format("Autoloading fallback preset {} for device {}", name, device_name.toStdString()));
 
       Q_EMIT loadFallbackPresetRequested(pipeline_type, fallback);
 
@@ -188,7 +188,7 @@ void AutoloadManager::load(const PipelineType& pipeline_type,
     }
   }
 
-  util::debug(std::format("autoloading local preset {} for device {}", name, device_name.toStdString()));
+  util::debug(std::format("Autoloading local preset {} for device {}", name, device_name.toStdString()));
 
   Q_EMIT loadPresetRequested(pipeline_type, QString::fromStdString(name));
 }

--- a/src/presets_community_manager.cpp
+++ b/src/presets_community_manager.cpp
@@ -268,9 +268,9 @@ bool CommunityManager::import_from_community_package(const PipelineType& pipelin
   }
 
   if (!preset_can_be_copied) {
-    util::warning(std::format("can't import the community preset: {}", p.string()));
+    util::warning(std::format("Can't import the community preset: {}", p.string()));
 
-    util::warning("exceeded the maximum copy attempts; please delete or rename your local preset");
+    util::warning("Exceeded the maximum copy attempts; please delete or rename your local preset");
 
     return false;
   }
@@ -278,18 +278,18 @@ bool CommunityManager::import_from_community_package(const PipelineType& pipelin
   // Now we know that the preset is OK to be copied, but we first check for addons.
   if (!import_addons_from_community_package(pipeline_type, p, package.toStdString())) {
     util::warning(
-        std::format("can't import addons for the community preset: {}; Import stage aborted, please reload the "
+        std::format("Can't import addons for the community preset: {}; Import stage aborted, please reload the "
                     "community preset list",
                     p.string()));
 
-    util::warning("if the issue goes on, contact the maintainer of the community package");
+    util::warning("If the issue goes on, contact the maintainer of the community package");
 
     return false;
   }
 
   std::filesystem::copy_file(p, out_path);
 
-  util::debug(std::format("successfully imported the community preset to: {}", out_path.string()));
+  util::debug(std::format("Successfully imported the community preset to: {}", out_path.string()));
 
   return true;
 }
@@ -316,7 +316,7 @@ auto CommunityManager::getAllCommunityPresetsPaths(PipelineType type) -> QList<s
       while (it != std::filesystem::directory_iterator{}) {
         if (auto package_path = it->path(); std::filesystem::is_directory(it->status())) {
           const auto package_path_name = package_path.string();
-          util::debug("scan directory for community presets: " + package_path_name);
+          util::debug("Scan directory for community presets: " + package_path_name);
 
           auto package_it = std::filesystem::directory_iterator{package_path};
           const auto sub_cp_vect =

--- a/src/presets_community_manager.cpp
+++ b/src/presets_community_manager.cpp
@@ -316,7 +316,7 @@ auto CommunityManager::getAllCommunityPresetsPaths(PipelineType type) -> QList<s
       while (it != std::filesystem::directory_iterator{}) {
         if (auto package_path = it->path(); std::filesystem::is_directory(it->status())) {
           const auto package_path_name = package_path.string();
-          util::debug("Scan directory for community presets: " + package_path_name);
+          util::debug(std::format("Scan directory for community presets: {}", package_path_name));
 
           auto package_it = std::filesystem::directory_iterator{package_path};
           const auto sub_cp_vect =

--- a/src/presets_community_manager.cpp
+++ b/src/presets_community_manager.cpp
@@ -156,7 +156,7 @@ auto CommunityManager::import_addons_from_community_package(const PipelineType& 
 
           std::filesystem::copy_file(path, out_path, std::filesystem::copy_options::overwrite_existing);
 
-          util::debug(std::format("successfully imported community preset addon {} locally", irs_name));
+          util::debug(std::format("Successfully imported community preset addon {} locally", irs_name));
 
           found = true;
 
@@ -165,7 +165,7 @@ auto CommunityManager::import_addons_from_community_package(const PipelineType& 
       }
 
       if (!found) {
-        util::warning(std::format("community preset addon {} not found!", irs_name));
+        util::warning(std::format("Community preset addon {} not found!", irs_name));
 
         return false;
       }
@@ -185,7 +185,7 @@ auto CommunityManager::import_addons_from_community_package(const PipelineType& 
 
           std::filesystem::copy_file(path, out_path, std::filesystem::copy_options::overwrite_existing);
 
-          util::debug(std::format("successfully imported community preset addon {} locally", model_name));
+          util::debug(std::format("Successfully imported community preset addon {} locally", model_name));
 
           found = true;
 
@@ -194,7 +194,7 @@ auto CommunityManager::import_addons_from_community_package(const PipelineType& 
       }
 
       if (!found) {
-        util::warning(std::format("community preset addon {} not found!", model_name));
+        util::warning(std::format("Community preset addon {} not found!", model_name));
 
         return false;
       }
@@ -260,7 +260,7 @@ bool CommunityManager::import_from_community_package(const PipelineType& pipelin
       }
     } while (++i < max_copy_attempts);
   } catch (const std::exception& e) {
-    util::warning(std::format("can't import the community preset: {}", p.string()));
+    util::warning(std::format("Can't import the community preset: {}", p.string()));
 
     util::warning(e.what());
 

--- a/src/presets_irs_manager.cpp
+++ b/src/presets_irs_manager.cpp
@@ -106,9 +106,9 @@ bool IrsManager::remove_impulse_file(const QString& filePath) {
   }
 
   if (result) {
-    util::debug(std::format("removed irs file: {}", filePath.toStdString()));
+    util::debug(std::format("Removed irs file: {}", filePath.toStdString()));
   } else {
-    util::warning(std::format("failed to removed the irs file: {}", filePath.toStdString()));
+    util::warning(std::format("Failed to removed the irs file: {}", filePath.toStdString()));
   }
 
   return result;

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -799,9 +799,10 @@ void Manager::notify_error(const PresetError& preset_error, const std::string& p
       break;
     }
     case PresetError::plugin_format: {
-      util::warning("A parsing error occurred while trying to load the " + plugin_name +
-                    " plugin from the preset. The file could be invalid or "
-                    "corrupted. Please check its content.");
+      util::warning(
+          std::format("A parsing error occurred while trying to load the {} plugin from the preset. The file could be "
+                      "invalid or corrupted. Please check its content.",
+                      plugin_name));
 
       Q_EMIT presetLoadError(i18n("Preset Not Loaded Correctly"),
                              plugin_translated + i18n("One or More Parameters Have a Wrong Format"));
@@ -809,7 +810,8 @@ void Manager::notify_error(const PresetError& preset_error, const std::string& p
       break;
     }
     case PresetError::plugin_generic: {
-      util::warning("A generic error occurred while trying to load the " + plugin_name + " plugin from the preset.");
+      util::warning(
+          std::format("A generic error occurred while trying to load the {} plugin from the preset.", plugin_name));
 
       Q_EMIT presetLoadError(i18n("Preset Not Loaded Correctly"),
                              plugin_translated + i18n("Generic Error While Loading The Effect"));

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -364,7 +364,7 @@ bool Manager::savePresetFile(const PipelineType& pipeline_type, const QString& n
 
   // std::cout << std::setw(4) << json << std::endl;
 
-  util::debug(std::format("saved preset: {}", output_file.string()));
+  util::debug(std::format("Saved preset: {}", output_file.string()));
 
   return true;
 }
@@ -394,7 +394,7 @@ bool Manager::remove(const PipelineType& pipeline_type, const QString& name) {
   if (std::filesystem::exists(preset_file)) {
     std::filesystem::remove(preset_file);
 
-    util::debug(std::format("removed preset: {}", preset_file.string()));
+    util::debug(std::format("Removed preset: {}", preset_file.string()));
 
     return true;
   }
@@ -418,7 +418,7 @@ bool Manager::renameLocalPresetFile(const PipelineType& pipeline_type, const QSt
   if (std::filesystem::exists(preset_file)) {
     std::filesystem::rename(preset_file, new_file);
 
-    util::debug(std::format("renamed preset: {} to {}", preset_file.string(), new_file.string()));
+    util::debug(std::format("Renamed preset: {} to {}", preset_file.string(), new_file.string()));
 
     return true;
   }
@@ -534,7 +534,7 @@ auto Manager::load_preset_file(const PipelineType& pipeline_type, const std::fil
   // After the plugin order list, load the blocklist and then
   // apply the parameters of the loaded plugins.
   if (load_blocklist(pipeline_type, json) && read_plugins_preset(pipeline_type, plugins, json)) {
-    util::debug(std::format("successfully loaded the preset: {}", input_file.string()));
+    util::debug(std::format("Successfully loaded the preset: {}", input_file.string()));
 
     return true;
   }
@@ -550,7 +550,7 @@ bool Manager::loadLocalPresetFile(const PipelineType& pipeline_type, const QStri
 
   // Check preset existence
   if (!std::filesystem::exists(input_file)) {
-    util::debug(std::format("can't find the local preset \"{}\" on the filesystem", name.toStdString()));
+    util::debug(std::format("Can't find the local preset \"{}\" on the filesystem", name.toStdString()));
 
     return false;
   }
@@ -575,7 +575,7 @@ bool Manager::loadCommunityPresetFile(const PipelineType& pipeline_type,
 
   // Check preset existence
   if (!std::filesystem::exists(input_file)) {
-    util::warning(std::format("the community preset \"{}\" does not exist on the filesystem", input_file.string()));
+    util::warning(std::format("The community preset \"{}\" does not exist on the filesystem", input_file.string()));
 
     return false;
   }
@@ -606,11 +606,11 @@ bool Manager::importPresets(const PipelineType& pipeline_type, const QList<QStri
       try {
         std::filesystem::copy_file(input_path, out_path, std::filesystem::copy_options::overwrite_existing);
 
-        util::debug(std::format("imported preset to: {}", out_path.string()));
+        util::debug(std::format("Imported preset to: {}", out_path.string()));
 
         return true;
       } catch (const std::exception& e) {
-        util::warning(std::format("can't import preset to: {}", out_path.string()));
+        util::warning(std::format("Can't import preset to: {}", out_path.string()));
         util::warning(e.what());
 
         return false;
@@ -650,7 +650,7 @@ bool Manager::exportPresets(const PipelineType& pipeline_type, const QString& di
       }
     }
 
-    util::debug(std::format("exported presets to: {}", output_path.string()));
+    util::debug(std::format("Exported presets to: {}", output_path.string()));
 
     return true;
   }

--- a/src/presets_rnnoise_manager.cpp
+++ b/src/presets_rnnoise_manager.cpp
@@ -90,9 +90,9 @@ bool RnnoiseManager::remove_model(const QString& filePath) {
   }
 
   if (result) {
-    util::debug(std::format("removed the rnnoise model: {}", filePath.toStdString()));
+    util::debug(std::format("Removed the rnnoise model: {}", filePath.toStdString()));
   } else {
-    util::warning(std::format("failed to remove the rnnoise model: {}", filePath.toStdString()));
+    util::warning(std::format("Failed to remove the rnnoise model: {}", filePath.toStdString()));
   }
 
   return result;

--- a/src/pw_manager.cpp
+++ b/src/pw_manager.cpp
@@ -625,11 +625,11 @@ Manager::Manager()
 
   // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
   if (thread_loop == nullptr) {
-    util::fatal("could not create PipeWire loop");
+    util::fatal("Could not create PipeWire loop");
   }
 
   if (pw_thread_loop_start(thread_loop) != 0) {
-    util::fatal("could not start the loop");
+    util::fatal("Could not start the loop");
   }
 
   lock();
@@ -649,19 +649,19 @@ Manager::Manager()
   context = pw_context_new(pw_thread_loop_get_loop(thread_loop), props_context, 0);
 
   if (context == nullptr) {
-    util::fatal("could not create PipeWire context");
+    util::fatal("Could not create PipeWire context");
   }
 
   core = pw_context_connect(context, nullptr, 0);
 
   if (core == nullptr) {
-    util::fatal("context connection failed");
+    util::fatal("Context connection failed");
   }
 
   registry = pw_core_get_registry(core, PW_VERSION_REGISTRY, 0);
 
   if (registry == nullptr) {
-    util::fatal("could not get the registry");
+    util::fatal("Could not get the registry");
   }
 
   pw_core_add_listener(core, &core_listener, &core_events, this);  // NOLINT

--- a/src/pw_manager.cpp
+++ b/src/pw_manager.cpp
@@ -273,7 +273,7 @@ auto on_metadata_property(void* data, uint32_t id, const char* key, const char* 
   const std::string str_key = (key != nullptr) ? key : "";
   const std::string str_value = (value != nullptr) ? value : "";
 
-  util::debug(std::format("new metadata property: {}, {}, {}, {}", id, str_key, type ? type : "", str_value));
+  util::debug(std::format("New metadata property: {}, {}, {}, {}", id, str_key, type ? type : "", str_value));
 
   if (str_value.empty()) {
     return 0;
@@ -286,7 +286,7 @@ auto on_metadata_property(void* data, uint32_t id, const char* key, const char* 
       return 0;
     }
 
-    util::debug(std::format("new default output device: {}", v));
+    util::debug(std::format("New default output device: {}", v));
 
     pm->defaultOutputDeviceName = QString::fromStdString(v);
 
@@ -300,7 +300,7 @@ auto on_metadata_property(void* data, uint32_t id, const char* key, const char* 
       return 0;
     }
 
-    util::debug(std::format("new default input device: {}", v));
+    util::debug(std::format("New default input device: {}", v));
 
     pm->defaultInputDeviceName = QString::fromStdString(v);
 
@@ -513,7 +513,7 @@ void on_registry_global(void* data,
 
   if (std::strcmp(type, PW_TYPE_INTERFACE_Metadata) == 0) {
     if (const auto* name = spa_dict_lookup(props, PW_KEY_METADATA_NAME)) {
-      util::debug(std::format("found metadata: {}", name));
+      util::debug(std::format("Found metadata: {}", name));
 
       if (std::strcmp(name, "default") == 0) {
         if (pm->metadata != nullptr) {
@@ -564,8 +564,8 @@ void on_core_info(void* data, const struct pw_core_info* info) {
 
   util::spa_dict_get_string(info->props, "default.clock.quantum", pm->defaultQuantum);
 
-  util::warning(std::format("core version: {}", info->version));
-  util::warning(std::format("core name: {}", info->name));
+  util::warning(std::format("Core version: {}", info->version));
+  util::warning(std::format("Core name: {}", info->name));
 }
 
 void on_core_done(void* data, uint32_t id, [[maybe_unused]] int seq) {
@@ -616,8 +616,8 @@ Manager::Manager()
   spa_zero(core_listener);
   spa_zero(registry_listener);
 
-  util::debug(std::format("compiled with PipeWire: {}", headerVersion.toStdString()));
-  util::debug(std::format("linked to PipeWire: {}", libraryVersion.toStdString()));
+  util::debug(std::format("Compiled with PipeWire: {}", headerVersion.toStdString()));
+  util::debug(std::format("Linked to PipeWire: {}", libraryVersion.toStdString()));
 
   // this needs to occur after pw_init(), so putting it before pw_init() in the initializer breaks this
   // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
@@ -866,13 +866,13 @@ auto Manager::link_nodes(const uint& output_node_id,
   }
 
   if (list_input_ports.empty()) {
-    util::debug(std::format("node {} has no input ports yet. Aborting the link", input_node_id));
+    util::debug(std::format("Node {} has no input ports yet. Aborting the link", input_node_id));
 
     return list;
   }
 
   if (list_output_ports.empty()) {
-    util::debug(std::format("node {} has no output ports yet. Aborting the link", output_node_id));
+    util::debug(std::format("Node {} has no output ports yet. Aborting the link", output_node_id));
 
     return list;
   }
@@ -915,7 +915,7 @@ auto Manager::link_nodes(const uint& output_node_id,
         pw_properties_free(props);
 
         if (proxy == nullptr) {
-          util::warning(std::format("failed to link the node {} to {}", output_node_id, input_node_id));
+          util::warning(std::format("Failed to link the node {} to {}", output_node_id, input_node_id));
 
           unlock();
 

--- a/src/pw_model_nodes.cpp
+++ b/src/pw_model_nodes.cpp
@@ -228,7 +228,7 @@ QVariant Nodes::data(const QModelIndex& index, int role) const {
   const auto it = std::next(list.begin(), index.row());
 
   if (it == list.end()) {
-    util::warning(std::format("invalid model index.row(): {}", index.row()));
+    util::warning(std::format("Invalid model index.row(): {}", index.row()));
 
     return {};
   }

--- a/src/reverb.cpp
+++ b/src/reverb.cpp
@@ -49,7 +49,7 @@ Reverb::Reverb(const std::string& tag, pw::Manager* pipe_manager, PipelineType p
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::Reverb>(settings);
@@ -75,7 +75,7 @@ Reverb::~Reverb() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Reverb::reset() {

--- a/src/reverb.cpp
+++ b/src/reverb.cpp
@@ -42,12 +42,14 @@ Reverb::Reverb(const std::string& tag, pw::Manager* pipe_manager, PipelineType p
                  pipe_type),
       settings(db::Manager::self().get_plugin_db<db::Reverb>(pipe_type,
                                                              tags::plugin_name::BaseName::reverb + "#" + instance_id)) {
-  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://calf.sourceforge.net/plugins/Reverb");
+  const auto lv2_plugin_uri = "http://calf.sourceforge.net/plugins/Reverb";
+
+  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>(lv2_plugin_uri);
 
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + "http://calf.sourceforge.net/plugins/Reverb is not installed");
+    util::debug(log_tag + lv2_plugin_uri + " is not installed");
   }
 
   init_common_controls<db::Reverb>(settings);

--- a/src/rnnoise.cpp
+++ b/src/rnnoise.cpp
@@ -130,7 +130,7 @@ RNNoise::~RNNoise() {
   free_rnnoise();
 #endif
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void RNNoise::reset() {
@@ -325,13 +325,13 @@ auto RNNoise::get_model_from_name() -> RNNModel* {
   if (path.empty()) {
     standard_model = true;
 
-    util::debug(log_tag + name + " model does not exist on the filesystem, using the standard model.");
+    util::debug(std::format("{}{} model does not exist on the filesystem, using the standard model.", log_tag, name));
 
     return m;
   }
 
   // Custom Model
-  util::debug(log_tag + name + " loading custom model from path: " + path);
+  util::debug(std::format("{}{} loading custom model from path: {}", log_tag, name, path));
 
   if (FILE* f = fopen(path.c_str(), "r"); f != nullptr) {
     m = rnnoise_model_from_file(f);

--- a/src/rnnoise.cpp
+++ b/src/rnnoise.cpp
@@ -314,7 +314,7 @@ auto RNNoise::get_model_from_name() -> RNNModel* {
   if (settings->useStandardModel()) {
     standard_model = true;
 
-    util::warning(log_tag + " using the standard model");
+    util::warning(std::format("{} using the standard model", log_tag));
 
     return m;
   }
@@ -342,7 +342,7 @@ auto RNNoise::get_model_from_name() -> RNNModel* {
   standard_model = (m == nullptr);
 
   if (standard_model) {
-    util::warning(log_tag + name + " failed to load the custom model. Using the standard one.");
+    util::warning(std::format("{}{} failed to load the custom model. Using the standard one.", log_tag, name));
   }
 
   return m;

--- a/src/rnnoise_preset.cpp
+++ b/src/rnnoise_preset.cpp
@@ -72,8 +72,9 @@ void RNNoisePreset::load(const nlohmann::json& json) {
     if (!model_path.empty()) {
       new_model_name = std::filesystem::path{model_path}.stem().string();
 
-      util::warning("using RNNoise model-path is deprecated, please update your preset; fallback to model-name: " +
-                    new_model_name);
+      util::warning(
+          std::format("Using RNNoise model-path is deprecated, please update your preset; fallback to model-name: {}",
+                      new_model_name));
     }
   }
 

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -65,7 +65,8 @@ Spectrum::Spectrum(const std::string& tag, pw::Manager* pipe_manager, PipelineTy
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed, spectrum will not have A/V sync compensation");
+    util::debug(
+        std::format("{}{} is not installed, spectrum will not have A/V sync compensation", log_tag, lv2_plugin_uri));
   }
 
   lv2_wrapper->set_control_port_value("mode_l", 2);
@@ -98,7 +99,7 @@ Spectrum::~Spectrum() {
 
   fftwf_destroy_plan(plan);
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Spectrum::reset() {}
@@ -120,7 +121,7 @@ void Spectrum::setup() {
   }
 
   if (lv2_wrapper->get_rate() != rate) {
-    util::debug(log_tag + " creating instance of comp delay x2 stereo for spectrum A/V sync");
+    util::debug(std::format("{} creating instance of comp delay x2 stereo for spectrum A/V sync", log_tag));
     lv2_wrapper->create_instance(rate);
   }
 }

--- a/src/speex.cpp
+++ b/src/speex.cpp
@@ -164,7 +164,7 @@ Speex::~Speex() {
 
   free_speex();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void Speex::reset() {

--- a/src/stereo_tools.cpp
+++ b/src/stereo_tools.cpp
@@ -50,7 +50,7 @@ StereoTools::StereoTools(const std::string& tag, pw::Manager* pipe_manager, Pipe
   package_installed = lv2_wrapper->found_plugin;
 
   if (!package_installed) {
-    util::debug(log_tag + lv2_plugin_uri + " is not installed");
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
   }
 
   init_common_controls<db::StereoTools>(settings);
@@ -96,7 +96,7 @@ StereoTools::~StereoTools() {
 
   settings->disconnect();
 
-  util::debug(log_tag + name.toStdString() + " destroyed");
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
 }
 
 void StereoTools::reset() {

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -221,8 +221,8 @@ void StreamInputEffects::connect_filters(const bool& bypass) {
   auto input_device = pm->model_nodes.get_node_by_name(db::StreamInputs::inputDevice());
 
   if (input_device.serial == SPA_ID_INVALID) {
-    util::debug("The input device " + db::StreamInputs::inputDevice().toStdString() +
-                " is not available. Aborting the link");
+    util::debug(std::format("The input device {} is not available. Aborting the link...",
+                            db::StreamInputs::inputDevice().toStdString()));
 
     return;
   }
@@ -344,7 +344,7 @@ void StreamInputEffects::disconnect_filters() {
 
     if (plugin->connected_to_pw) {
       if (std::ranges::find(selected_plugins_list, plugin->name) == selected_plugins_list.end()) {
-        util::debug("Disconnecting the " + plugin->name.toStdString() + " filter from PipeWire");
+        util::debug(std::format("Disconnecting the {} filter from PipeWire", plugin->name.toStdString()));
 
         plugin->disconnect_from_pw();
       }

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -235,7 +235,7 @@ void StreamInputEffects::connect_filters(const bool& bypass) {
 
   int timeout = 0;
 
-  util::warning(std::format("before: {} -> {}", input_device.id, input_device.name.toStdString()));
+  util::warning(std::format("Before: {} -> {}", input_device.id, input_device.name.toStdString()));
 
   while (pm->count_node_ports(input_device.id) < 1) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -278,7 +278,7 @@ void StreamInputEffects::connect_filters(const bool& bypass) {
           prev_node_id = next_node_id;
           mic_linked = true;
         } else {
-          util::warning(std::format("link from node {} to node {} failed", prev_node_id, next_node_id));
+          util::warning(std::format("Link from node {} to node {} failed", prev_node_id, next_node_id));
         }
       }
     }
@@ -321,7 +321,7 @@ void StreamInputEffects::connect_filters(const bool& bypass) {
       prev_node_id = next_node_id;
       mic_linked = true;
     } else {
-      util::warning(std::format("link from node {} to node {} failed", prev_node_id, next_node_id));
+      util::warning(std::format("Link from node {} to node {} failed", prev_node_id, next_node_id));
     }
   }
 }
@@ -344,7 +344,7 @@ void StreamInputEffects::disconnect_filters() {
 
     if (plugin->connected_to_pw) {
       if (std::ranges::find(selected_plugins_list, plugin->name) == selected_plugins_list.end()) {
-        util::debug("disconnecting the " + plugin->name.toStdString() + " filter from PipeWire");
+        util::debug("Disconnecting the " + plugin->name.toStdString() + " filter from PipeWire");
 
         plugin->disconnect_from_pw();
       }

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -230,9 +230,10 @@ void StreamOutputEffects::connect_filters(const bool& bypass) {
     timeout++;
 
     if (timeout > 5000) {  // 5 seconds
-      util::warning("Information about the ports of the output device " + output_device.name.toStdString() +
-                    " with id " + util::to_string(output_device.id) +
-                    " are taking to long to be available. Aborting the link");
+      util::warning(
+          std::format("Information about the ports of the output device {} with id {} are taking to long to be "
+                      "available. Aborting the link",
+                      output_device.name.toStdString(), util::to_string(output_device.id)));
 
       return;
     }

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -203,6 +203,22 @@ void StreamOutputEffects::on_link_changed(const pw::LinkInfo link_info) {
 }
 
 void StreamOutputEffects::connect_filters(const bool& bypass) {
+  /**
+   * In the past we were connecting the filters from EE sink to the output
+   * device:
+   * - ee_sink -> plugins -> spectrum -> level meter -> speakers
+   *
+   * This went good until we started to see more crackling and null pointers
+   * provided by Pipewire.
+   *
+   * Then we started making the connection in the reverse way (preserving the
+   * direction from ee_sink to output device):
+   * - speakers <- level meter <- spectrum <- plugins <- ee_sink
+   *
+   * And we got less crackling and null pointers from Pipewire. Don't know why,
+   * but we'll keep this process until it works...
+   */
+
   // Checking if the output device exists.
 
   if (db::StreamOutputs::outputDevice().isEmpty()) {

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -252,7 +252,7 @@ void StreamOutputEffects::connect_filters(const bool& bypass) {
 
   if (links.size() < 2U) {
     util::warning(
-        std::format("link from global level meter {} to output device {} failed", prev_node_id, next_node_id));
+        std::format("Link from global level meter {} to output device {} failed", prev_node_id, next_node_id));
   }
 
   // Link spectrum to global level meter.
@@ -267,7 +267,7 @@ void StreamOutputEffects::connect_filters(const bool& bypass) {
   }
 
   if (links.size() < 2U) {
-    util::warning(std::format("link from spectrum {} to global level meter {} failed", prev_node_id, next_node_id));
+    util::warning(std::format("Link from spectrum {} to global level meter {} failed", prev_node_id, next_node_id));
   }
 
   // Link plugins in reverse order.
@@ -294,7 +294,7 @@ void StreamOutputEffects::connect_filters(const bool& bypass) {
         if (links.size() == 2U) {
           next_node_id = prev_node_id;
         } else {
-          util::warning(std::format("link from node {} to node {} failed", prev_node_id, next_node_id));
+          util::warning(std::format("Link from node {} to node {} failed", prev_node_id, next_node_id));
         }
       }
     }
@@ -331,7 +331,7 @@ void StreamOutputEffects::connect_filters(const bool& bypass) {
   }
 
   if (links.size() < 2U) {
-    util::warning(std::format("link from easyeffecst sink {} to node {} failed", prev_node_id, next_node_id));
+    util::warning(std::format("Link from easyeffecst sink {} to node {} failed", prev_node_id, next_node_id));
   }
 }
 
@@ -353,7 +353,7 @@ void StreamOutputEffects::disconnect_filters() {
 
     if (plugin->connected_to_pw) {
       if (std::ranges::find(selected_plugins_list, plugin->name) == selected_plugins_list.end()) {
-        util::debug("disconnecting the " + plugin->name.toStdString() + " filter from PipeWire");
+        util::debug("Disconnecting the " + plugin->name.toStdString() + " filter from PipeWire");
 
         plugin->disconnect_from_pw();
       }

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -249,7 +249,7 @@ void StreamOutputEffects::connect_filters(const bool& bypass) {
       util::warning(
           std::format("Information about the ports of the output device {} with id {} are taking to long to be "
                       "available. Aborting the link",
-                      output_device.name.toStdString(), util::to_string(output_device.id)));
+                      output_device.name.toStdString(), output_device.id));
 
       return;
     }

--- a/src/stream_output_effects.cpp
+++ b/src/stream_output_effects.cpp
@@ -230,8 +230,8 @@ void StreamOutputEffects::connect_filters(const bool& bypass) {
   auto output_device = pm->model_nodes.get_node_by_name(db::StreamOutputs::outputDevice());
 
   if (output_device.serial == SPA_ID_INVALID) {
-    util::debug("The output device " + db::StreamOutputs::outputDevice().toStdString() +
-                " is not available. Aborting the link");
+    util::debug(std::format("The output device {} is not available. Aborting the link...",
+                            db::StreamOutputs::outputDevice().toStdString()));
 
     return;
   }
@@ -369,7 +369,7 @@ void StreamOutputEffects::disconnect_filters() {
 
     if (plugin->connected_to_pw) {
       if (std::ranges::find(selected_plugins_list, plugin->name) == selected_plugins_list.end()) {
-        util::debug("Disconnecting the " + plugin->name.toStdString() + " filter from PipeWire");
+        util::debug(std::format("Disconnecting the {} filter from PipeWire", plugin->name.toStdString()));
 
         plugin->disconnect_from_pw();
       }

--- a/src/test_signals.cpp
+++ b/src/test_signals.cpp
@@ -58,7 +58,7 @@ void on_process(void* userdata, spa_io_position* position) {
     d->ts->sine_phase = 0.0F;
   }
 
-  // util::warning("processing: " + util::to_string(n_samples));
+  // util::warning("Processing: " + util::to_string(n_samples));
 
   auto* out_left = static_cast<float*>(pw_filter_get_dsp_buffer(d->out_left, n_samples));
   auto* out_right = static_cast<float*>(pw_filter_get_dsp_buffer(d->out_right, n_samples));
@@ -244,7 +244,7 @@ TestSignals::TestSignals(pw::Manager* pipe_manager) : pm(pipe_manager), random_g
 }
 
 TestSignals::~TestSignals() {
-  util::debug("destroyed");
+  util::debug("TestSignals destroyed");
 
   pm->lock();
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -285,7 +285,7 @@ auto get_lock_file() -> std::unique_ptr<QLockFile> {
   bool status = lockFile->tryLock(100);
 
   if (!status) {
-    util::debug("Could not lock the file: " + lockFile->fileName().toStdString());
+    util::debug(std::format("Could not lock the file: {}", lockFile->fileName().toStdString()));
 
     switch (lockFile->error()) {
       case QLockFile::NoError:

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -85,7 +85,7 @@ void create_user_directory(const std::filesystem::path& path) {
     return;
   }
 
-  util::warning(std::format("failed to create directory: {}", path.string()));
+  util::warning(std::format("Failed to create directory: {}", path.string()));
 }
 
 auto normalize(const double& x, const double& max, const double& min) -> double {


### PR DESCRIPTION
All the remaining util messages that uses variables are now converted to get the output of `std::format`. This has been done with ChatGPT to speedup the conversion and ensure correctness. 

In some plugin constructors the uri string has been used as constant like done in other plugins.

Unfortunately this introduced a weird core dump in a place that has nothing to do with the util messages and I can't understand why. Basically the application seems to block in `GlobalShortcuts::bind_shortcuts`:

<details>
<summary> Core dump </summary>

```
#0  0x00007f5040585f34 in ?? () from /usr/lib/libQt6DBus.so.6
#1  0x00007f5042bee3a3 in QVariant::fromMetaType(QMetaType, void const*) () from /usr/lib/libQt6Core.so.6
#2  0x00007f5042be2d7f in QVariant::QVariant(QMetaType, void const*) () from /usr/lib/libQt6Core.so.6
#3  0x00007f50405a2550 in QDBusObjectPath::operator QVariant() const () from /usr/lib/libQt6DBus.so.6
#4  0x000056347c52c5f3 in GlobalShortcuts::bind_shortcuts (this=0x1) at /home/username/pkgbuild/EasyEffects/git/easyeffects/src/global_shortcuts.cpp:140
#5  0x000056347c572a64 in operator() (__closure=0x7ffff2339280) at /home/username/pkgbuild/EasyEffects/git/easyeffects/src/main.cpp:157
#6  0x000056347c572b2e in operator() (__closure=0x5634bc0d0170) at /home/username/pkgbuild/EasyEffects/git/easyeffects/src/main.cpp:163
#7  0x000056347c576901 in operator() (__closure=0x7ffff2338730) at /usr/include/qt6/QtCore/qobjectdefs_impl.h:116
#8  0x000056347c576f98 in QtPrivate::FunctorCallBase::call_internal<void, QtPrivate::FunctorCall<std::integer_sequence<long unsigned int>, QtPrivate::List<>, void, initGlobalShortcuts(GlobalShortcuts&)::<lambda()> >::call(initGlobalShortcuts(GlobalShortcuts&)::<lambda()>&, void**)::<lambda()> >(void **, struct {...} &&) (
    args=0x7ffff2338868, fn=...) at /usr/include/qt6/QtCore/qobjectdefs_impl.h:65
#9  0x000056347c576946 in QtPrivate::FunctorCall<std::integer_sequence<long unsigned int>, QtPrivate::List<>, void, initGlobalShortcuts(GlobalShortcuts&)::<lambda()> >::call(struct {...} &, void **) (f=..., arg=0x7ffff2338868) at /usr/include/qt6/QtCore/qobjectdefs_impl.h:115
#10 0x000056347c576603 in QtPrivate::FunctorCallable<initGlobalShortcuts(GlobalShortcuts&)::<lambda()> >::call<QtPrivate::List<>, void>(struct {...} &, void *, void **)
    (f=..., arg=0x7ffff2338868) at /usr/include/qt6/QtCore/qobjectdefs_impl.h:337
#11 0x000056347c575e85 in QtPrivate::QCallableObject<initGlobalShortcuts(GlobalShortcuts&)::<lambda()>, QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase *, QObject *, void **, bool *) (which=1, this_=0x5634bc0d0160, r=0x5634bc051360, a=0x7ffff2338868, ret=0x0) at /usr/include/qt6/QtCore/qobjectdefs_impl.h:547
#12 0x00007f5042bd466f in ?? () from /usr/lib/libQt6Core.so.6
#13 0x000056347bf3bf25 in GlobalShortcuts::onBindShortcuts (this=0x5634bc051360)
    at /home/username/pkgbuild/EasyEffects/git/easyeffects/build/src/easyeffects_autogen/EWIEGA46WW/moc_global_shortcuts.cpp:148
#14 0x000056347c52bee0 in GlobalShortcuts::onSessionCreatedResponse (this=0x5634bc051360, responseCode=0, results=...)
    at /home/username/pkgbuild/EasyEffects/git/easyeffects/src/global_shortcuts.cpp:90
#15 0x000056347bf3bcd8 in GlobalShortcuts::qt_static_metacall (_o=0x5634bc051360, _c=QMetaObject::InvokeMetaMethod, _id=1, _a=0x7ffff2338bf8)
    at /home/username/pkgbuild/EasyEffects/git/easyeffects/build/src/easyeffects_autogen/EWIEGA46WW/moc_global_shortcuts.cpp:91
#16 0x000056347bf3becc in GlobalShortcuts::qt_metacall (this=0x5634bc051360, _c=QMetaObject::InvokeMetaMethod, _id=1, _a=0x7ffff2338bf8)
    at /home/username/pkgbuild/EasyEffects/git/easyeffects/build/src/easyeffects_autogen/EWIEGA46WW/moc_global_shortcuts.cpp:134
#17 0x00007f50405aa9f9 in ?? () from /usr/lib/libQt6DBus.so.6
#18 0x00007f5042bc1a74 in QObject::event(QEvent*) () from /usr/lib/libQt6Core.so.6
#19 0x00007f5044101dd0 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () from /usr/lib/libQt6Widgets.so.6
#20 0x00007f5042b68678 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () from /usr/lib/libQt6Core.so.6
#21 0x00007f5042b68a5b in QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) () from /usr/lib/libQt6Core.so.6
#22 0x00007f5042e437f8 in ?? () from /usr/lib/libQt6Core.so.6
#23 0x00007f5043134f4d in ?? () from /usr/lib/libglib-2.0.so.0
#24 0x00007f5043136617 in ?? () from /usr/lib/libglib-2.0.so.0
#25 0x00007f5043136825 in g_main_context_iteration () from /usr/lib/libglib-2.0.so.0
#26 0x00007f5042e3ffe2 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () from /usr/lib/libQt6Core.so.6
#27 0x00007f5042b74ca6 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () from /usr/lib/libQt6Core.so.6
#28 0x00007f5042b6cd21 in QCoreApplication::exec() () from /usr/lib/libQt6Core.so.6
```

</details>

I'm not able to figure out why. To test the changes I had to add a `return` to the top of that function and every thing works fine.

@wwmm Can you remove that line and look into it on your system?

Besides, testing all the plugins I saw the following warnings on the command line:

**Delay**

```
easyeffects: lv2_wrapper.cpp:442	http://lsp-plug.in/plugins/lv2/comp_delay_x2_stereo port symbol not found: sample_l
easyeffects: lv2_wrapper.cpp:442	http://lsp-plug.in/plugins/lv2/comp_delay_x2_stereo port symbol not found: sample_r
easyeffects: lv2_wrapper.cpp:442	http://lsp-plug.in/plugins/lv2/comp_delay_x2_stereo port symbol not found: sample_l
easyeffects: lv2_wrapper.cpp:442	http://lsp-plug.in/plugins/lv2/comp_delay_x2_stereo port symbol not found: sample_r
```

**Speech Processor**

``warning: The VAD has been replaced by a hack pending a complete rewrite``

@wwmm Please, take a look at these ones too.