### PR TITLE
use max of absolute samples for `get_peaks`

### DIFF
--- a/src/plugin_base.cpp
+++ b/src/plugin_base.cpp
@@ -541,15 +541,19 @@ void PluginBase::get_peaks(const std::span<float>& left_in,
                            const std::span<float>& right_in,
                            std::span<float>& left_out,
                            std::span<float>& right_out) {
+  auto abs_max = [](const std::span<float>& span) {
+    return std::ranges::max(span | std::views::transform([](float x) { return std::fabs(x); }));
+  };
+
   // input level
 
-  input_peak_left = util::linear_to_db(std::ranges::max(left_in));
-  input_peak_right = util::linear_to_db(std::ranges::max(right_in));
+  input_peak_left = util::linear_to_db(abs_max(left_in));
+  input_peak_right = util::linear_to_db(abs_max(right_in));
 
   // output level
 
-  output_peak_left = util::linear_to_db(std::ranges::max(left_out));
-  output_peak_right = util::linear_to_db(std::ranges::max(right_out));
+  output_peak_left = util::linear_to_db(abs_max(left_out));
+  output_peak_right = util::linear_to_db(abs_max(right_out));
 }
 
 void PluginBase::apply_gain(std::span<float>& left, std::span<float>& right, const float& gain) {


### PR DESCRIPTION
The peak meter was able to show lower peak values than were actually present if the audio was asymmetrical towards the negative side. Since clipping can happen below -1.0 as well, use the max of the absolute samples to determine the peaks.

This matches the behavior of:
- Audacity: https://github.com/audacity/audacity/blob/master/au3/libraries/lib-audio-io/AudioIO.cpp#L123
- LMMS: https://github.com/LMMS/lmms/blob/master/include/SampleFrame.h#L200