### PR TITLE
Convolver: inform the user about the Passthrough Mode

### DIFF
--- a/src/contents/ui/Convolver.qml
+++ b/src/contents/ui/Convolver.qml
@@ -42,6 +42,23 @@ Kirigami.ScrollablePage {
     }
 
     Connections {
+        function onNewKernelLoaded(name, success) {
+            if (success) {
+                convolverChartContainer.banner.title = name;
+
+                appWindow.showStatus(i18n("Loaded the %1 Convolver Impulse.", `<strong>${name}</strong>`), Kirigami.MessageType.Positive); // qmllint disable
+            } else {
+                convolverChartContainer.banner.title = i18n("Convolver Impulse Is Not Set");
+
+                if (name.length === 0 || name === '""') {
+                    // This is likely to happen after a config reset.
+                    appWindow.showStatus(i18n("The Convolver is in Passthrough Mode.")); // qmllint disable
+                } else {
+                    appWindow.showStatus(i18n("Failed to Load the %1 Impulse. The Convolver is in Passthrough Mode.", `<strong>${name}</strong>`), Kirigami.MessageType.Error, false); // qmllint disable
+                }
+            }
+        }
+
         function onKernelCombinationStopped() {
             progressBar.visible = false;
         }
@@ -164,6 +181,8 @@ Kirigami.ScrollablePage {
         }
 
         Kirigami.Card {
+            id: convolverChartContainer
+
             Layout.minimumWidth: Kirigami.Units.gridUnit * 16
             Layout.fillHeight: true
 
@@ -287,7 +306,7 @@ Kirigami.ScrollablePage {
             banner {
                 title: {
                     const name = convolverPage.pluginDB.kernelName;
-                    return (name.length === 0 || name === '""') ? i18n("Convolver Impulse Is Not Set") : name; // qmllint disable
+                    return (!convolverPage.pluginBackend.kernelIsInitialized || name.length === 0 || name === '""') ? i18n("Convolver Impulse Is Not Set") : name; // qmllint disable
                 }
                 titleAlignment: Qt.AlignHCenter | Qt.AlignBottom
                 titleLevel: 2

--- a/src/contents/ui/ConvolverImpulseSheet.qml
+++ b/src/contents/ui/ConvolverImpulseSheet.qml
@@ -75,8 +75,6 @@ Kirigami.OverlaySheet {
                 width: listView.width
                 onClicked: {
                     control.pluginDB.kernelName = name;
-
-                    appWindow.showStatus(i18n("Loaded the %1 Convolver Impulse.", `<strong>${name}</strong>`), Kirigami.MessageType.Positive); // qmllint disable
                 }
 
                 Kirigami.PromptDialog {

--- a/src/convolver.cpp
+++ b/src/convolver.cpp
@@ -398,7 +398,10 @@ void Convolver::load_kernel_file() {
   const auto name = settings->kernelName();
 
   if (name.isEmpty()) {
-    util::warning(std::format("{}{}: irs filename is null. Entering passthrough mode...", log_tag, name.toStdString()));
+    Q_EMIT newKernelLoaded(name, false);
+
+    util::warning(
+        std::format("{}{}: irs filename is invalid. Entering passthrough mode...", log_tag, name.toStdString()));
 
     return;
   }
@@ -409,13 +412,17 @@ void Convolver::load_kernel_file() {
 
   // If the search fails, the path is empty
   if (rate == 0 || kernel_L.empty() || kernel_R.empty()) {
-    util::warning(std::format("{}{} is invalid. Entering passthrough mode...", log_tag, name.toStdString()));
+    Q_EMIT newKernelLoaded(name, false);
+
+    util::warning(
+        std::format("{}{} irs has an invalid format. Entering passthrough mode...", log_tag, name.toStdString()));
 
     return;
   }
 
   if (kernel_rate != static_cast<int>(rate)) {
-    util::debug(std::format("{}{} resampling the kernel to {}", log_tag, name.toStdString(), rate));
+    util::debug(
+        std::format("{}{} kernel has {} rate. Resampling it to {}", log_tag, name.toStdString(), kernel_rate, rate));
 
     auto resampler = std::make_unique<Resampler>(kernel_rate, rate);
 
@@ -463,14 +470,16 @@ void Convolver::load_kernel_file() {
     chartMagR[n] = QPointF(x_linear[n], magR[n]);
   }
 
+  kernel_is_initialized = true;
+
+  Q_EMIT newKernelLoaded(name, true);
+
   Q_EMIT kernelRateChanged();
   Q_EMIT kernelDurationChanged();
   Q_EMIT kernelSamplesChanged();
 
   Q_EMIT chartMagLChanged();
   Q_EMIT chartMagRChanged();
-
-  kernel_is_initialized = true;
 
   util::debug(std::format("{}{}: kernel correctly loaded", log_tag, name.toStdString()));
 

--- a/src/convolver.hpp
+++ b/src/convolver.hpp
@@ -40,6 +40,8 @@
 class Convolver : public PluginBase {
   Q_OBJECT
 
+  Q_PROPERTY(bool kernelIsInitialized MEMBER kernel_is_initialized NOTIFY kernelInitializedChanged)
+
   Q_PROPERTY(QString kernelRate MEMBER kernelRate NOTIFY kernelRateChanged)
   Q_PROPERTY(QString kernelSamples MEMBER kernelSamples NOTIFY kernelSamplesChanged)
   Q_PROPERTY(QString kernelDuration MEMBER kernelDuration NOTIFY kernelDurationChanged)
@@ -87,7 +89,9 @@ class Convolver : public PluginBase {
   Q_INVOKABLE void combineKernels(const QString& kernel1, const QString& kernel2, const QString& outputName);
 
  Q_SIGNALS:
+  void newKernelLoaded(QString name, bool success);
 
+  void kernelInitializedChanged();
   void kernelRateChanged();
   void kernelSamplesChanged();
   void kernelDurationChanged();


### PR DESCRIPTION
When the Convolver plugin backed was failing to load a kernel, the user got a positive inline message on the correct loading.

Now the user gets a negative message on failing loadings and an informative message when the plugin is reset (entering in pass-through mode).

Besides, the chart banner is now properly updated to reflect these states.

The only remaining thing (which I'm not sure how to do it), is to reset the graph at the initial state when the pass-through mode is signaled. @wwmm What do you suggest? To give en empty array to the `updateData`? Or maybe you could implement a reset method which could be more straightforward to understand? 