### PR TITLE
Convolver: clear chart data on both load failings

### DIFF
--- a/src/convolver.cpp
+++ b/src/convolver.cpp
@@ -398,14 +398,7 @@ void Convolver::load_kernel_file() {
   const auto name = settings->kernelName();
 
   if (name.isEmpty()) {
-    // clearing the chart data
-
-    chartMagL.clear();
-    chartMagR.clear();
-    chartMagLfftLinear.clear();
-    chartMagRfftLinear.clear();
-    chartMagLfftLog.clear();
-    chartMagRfftLog.clear();
+    clear_chart_data();
 
     Q_EMIT newKernelLoaded(name, false);
 
@@ -421,6 +414,8 @@ void Convolver::load_kernel_file() {
 
   // If the search fails, the path is empty
   if (rate == 0 || kernel_L.empty() || kernel_R.empty()) {
+    clear_chart_data();
+
     Q_EMIT newKernelLoaded(name, false);
 
     util::warning(
@@ -955,4 +950,13 @@ void Convolver::chart_kernel_fft(const std::vector<float>& kernel_L,
   Q_EMIT chartMagRfftLinearChanged();
   Q_EMIT chartMagLfftLogChanged();
   Q_EMIT chartMagRfftLogChanged();
+}
+
+void Convolver::clear_chart_data() {
+  chartMagL.clear();
+  chartMagR.clear();
+  chartMagLfftLinear.clear();
+  chartMagRfftLinear.clear();
+  chartMagLfftLog.clear();
+  chartMagRfftLog.clear();
 }

--- a/src/convolver.hpp
+++ b/src/convolver.hpp
@@ -173,6 +173,8 @@ class Convolver : public PluginBase {
                         const std::vector<float>& kernel_R,
                         const float& kernel_rate);
 
+  void clear_chart_data();
+
   template <typename T1>
   void do_convolution(T1& data_left, T1& data_right) {
     std::span conv_left_in(conv->inpdata(0), get_zita_buffer_size());


### PR DESCRIPTION
The Convolver chart data was cleared only on the first error. Clear it also on the second.