### PR TITLE
Don't depend on deprecated appstream-util

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -35,7 +35,7 @@ depends=(
   'libportal-qt6'
   'webrtc-audio-processing'
 )
-makedepends=('cmake' 'extra-cmake-modules' 'git' 'ninja' 'intltool' 'appstream-glib' 'mold' 'ladspa')
+makedepends=('cmake' 'extra-cmake-modules' 'git' 'ninja' 'intltool' 'appstream' 'mold' 'ladspa')
 optdepends=('calf: limiter, exciter, bass enhancer and others'
             'lsp-plugins: equalizer, compressor, delay, loudness'
             'zam-plugins: maximizer'

--- a/PKGBUILD_AUR
+++ b/PKGBUILD_AUR
@@ -35,7 +35,7 @@ depends=(
   'libportal-qt6'
   'webrtc-audio-processing'
 )
-makedepends=('cmake' 'extra-cmake-modules' 'git' 'ninja' 'intltool' 'appstream-glib' 'ladspa')
+makedepends=('cmake' 'extra-cmake-modules' 'git' 'ninja' 'intltool' 'appstream' 'ladspa')
 optdepends=('calf: limiter, exciter, bass enhancer and others'
             'lsp-plugins: equalizer, compressor, delay, loudness'
             'zam-plugins: maximizer'

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: sound
 Priority: optional
 Maintainer: Boyuan Yang <byang@debian.org>
 Build-Depends:
- appstream-util,
+ appstream,
  debhelper-compat (= 13),
  gettext,
  itstool,


### PR DESCRIPTION
Hi!

This change drops the unneeded dependency on appstream-util, which we are trying to remove from Debian. The utility is deprecated and should no longer be used for modern metadata.

I did not touch the `util/update-release-files.sh` script, which still uses it. But it may make sense to sort that out too (you can pass `--strict` to `appstreamcli` to get strict validation behavior like with `appstream-util`).

Also, it looks like the cmake config doesn't install the metadata into `KDE_INSTALL_METAINFODIR` yet...

Thanks for considering the patch!
Best,
    Matthias
