### PR TITLE
Improve formatting in delete dialog

### DIFF
--- a/src/contents/ui/PresetsLocalPage.qml
+++ b/src/contents/ui/PresetsLocalPage.qml
@@ -199,7 +199,7 @@ ColumnLayout {
                     id: deleteDialog
 
                     title: i18n("Remove Preset") // qmllint disable
-                    subtitle: i18n("Are you sure you want to remove the preset\n%1\nfrom the list?", listItemDelegate.name) // qmllint disable
+                    subtitle: i18n("Are you sure you want to remove the preset %1 from the list?", `\n${listItemDelegate.name}\n`) // qmllint disable
                     standardButtons: Kirigami.Dialog.Ok | Kirigami.Dialog.Cancel
                     onAccepted: {
                         if (Presets.Manager.remove(columnLayout.pipeline, listItemDelegate.name) === true) {


### PR DESCRIPTION
It's better we don't show the new lines for translators.

@wwmm I edited this on Github. Please format it and test on your system, thanks.