### PR TITLE
Reinstate literal new lines in locale strings

### DIFF
--- a/src/contents/ui/PresetsLocalPage.qml
+++ b/src/contents/ui/PresetsLocalPage.qml
@@ -184,7 +184,7 @@ ColumnLayout {
                     id: saveDialog
 
                     title: i18n("Save Preset") // qmllint disable
-                    subtitle: i18n("Save current settings to the preset:%1", `\n${listItemDelegate.name}`) // qmllint disable
+                    subtitle: i18n("Save Current Settings to the Preset:\n%1", listItemDelegate.name) // qmllint disable
                     standardButtons: Kirigami.Dialog.Ok | Kirigami.Dialog.Cancel
                     onAccepted: {
                         if (Presets.Manager.savePresetFile(columnLayout.pipeline, listItemDelegate.name) === true) {
@@ -199,7 +199,7 @@ ColumnLayout {
                     id: deleteDialog
 
                     title: i18n("Remove Preset") // qmllint disable
-                    subtitle: i18n("Are you sure you want to remove the preset %1from the list?", `\n${listItemDelegate.name}\n`) // qmllint disable
+                    subtitle: i18n("Are You Sure You Want to Remove the Preset\n%1\nFrom the List?", listItemDelegate.name) // qmllint disable
                     standardButtons: Kirigami.Dialog.Ok | Kirigami.Dialog.Cancel
                     onAccepted: {
                         if (Presets.Manager.remove(columnLayout.pipeline, listItemDelegate.name) === true) {


### PR DESCRIPTION
I though new lines "`\n`" could be confusing for translators, but in reality they are rendered in a user friendly way in weblate, so we can reinstate them. The only things to hide from translators should be the HTML code, if possible. 