### PR TITLE
Improve margins of plugin credits

### DIFF
--- a/src/contents/ui/Autogain.qml
+++ b/src/contents/ui/Autogain.qml
@@ -228,7 +228,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/BassEnhancer.qml
+++ b/src/contents/ui/BassEnhancer.qml
@@ -194,7 +194,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/BassLoudness.qml
+++ b/src/contents/ui/BassLoudness.qml
@@ -107,7 +107,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/Compressor.qml
+++ b/src/contents/ui/Compressor.qml
@@ -899,7 +899,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/Convolver.qml
+++ b/src/contents/ui/Convolver.qml
@@ -463,7 +463,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/Crossfeed.qml
+++ b/src/contents/ui/Crossfeed.qml
@@ -137,7 +137,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/Crystalizer.qml
+++ b/src/contents/ui/Crystalizer.qml
@@ -93,7 +93,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/DeepFilterNet.qml
+++ b/src/contents/ui/DeepFilterNet.qml
@@ -171,7 +171,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/Deesser.qml
+++ b/src/contents/ui/Deesser.qml
@@ -304,7 +304,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/Delay.qml
+++ b/src/contents/ui/Delay.qml
@@ -368,7 +368,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/EchoCanceller.qml
+++ b/src/contents/ui/EchoCanceller.qml
@@ -155,7 +155,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/Equalizer.qml
+++ b/src/contents/ui/Equalizer.qml
@@ -268,7 +268,8 @@ Kirigami.ScrollablePage {
                 horizontalAlignment: Qt.AlignLeft
                 verticalAlignment: Qt.AlignVCenter
                 Layout.fillWidth: false
-                Layout.leftMargin: Kirigami.Units.smallSpacing
+                Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+                Layout.rightMargin: Kirigami.Units.largeSpacing * 8
                 color: Kirigami.Theme.disabledTextColor
             }
 

--- a/src/contents/ui/Exciter.qml
+++ b/src/contents/ui/Exciter.qml
@@ -194,7 +194,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/Expander.qml
+++ b/src/contents/ui/Expander.qml
@@ -856,7 +856,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/Filter.qml
+++ b/src/contents/ui/Filter.qml
@@ -202,7 +202,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/Gate.qml
+++ b/src/contents/ui/Gate.qml
@@ -990,7 +990,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/LevelMeter.qml
+++ b/src/contents/ui/LevelMeter.qml
@@ -193,7 +193,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/Limiter.qml
+++ b/src/contents/ui/Limiter.qml
@@ -578,7 +578,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/Loudness.qml
+++ b/src/contents/ui/Loudness.qml
@@ -158,7 +158,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/Maximizer.qml
+++ b/src/contents/ui/Maximizer.qml
@@ -105,7 +105,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/MultibandCompressor.qml
+++ b/src/contents/ui/MultibandCompressor.qml
@@ -933,7 +933,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/MultibandGate.qml
+++ b/src/contents/ui/MultibandGate.qml
@@ -906,7 +906,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/Pitch.qml
+++ b/src/contents/ui/Pitch.qml
@@ -213,7 +213,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/RNNoise.qml
+++ b/src/contents/ui/RNNoise.qml
@@ -300,7 +300,8 @@ Kirigami.ScrollablePage {
                 horizontalAlignment: Qt.AlignLeft
                 verticalAlignment: Qt.AlignVCenter
                 Layout.fillWidth: false
-                Layout.leftMargin: Kirigami.Units.smallSpacing
+                Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+                Layout.rightMargin: Kirigami.Units.largeSpacing * 8
                 color: Kirigami.Theme.disabledTextColor
             }
 

--- a/src/contents/ui/Reverb.qml
+++ b/src/contents/ui/Reverb.qml
@@ -312,7 +312,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/Speex.qml
+++ b/src/contents/ui/Speex.qml
@@ -169,7 +169,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 

--- a/src/contents/ui/StereoTools.qml
+++ b/src/contents/ui/StereoTools.qml
@@ -397,7 +397,8 @@ Kirigami.ScrollablePage {
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
             color: Kirigami.Theme.disabledTextColor
         }
 


### PR DESCRIPTION
@wwmm Since you said it's not good that footer action buttons are too close to the plugin credits, I added an amount of right margin to it.

I also improved a label for the Deesser which was misleading for the translators.