### PR TITLE
Flatpak build QT 6.10 update

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -49,7 +49,7 @@ jobs:
       FLATPAK_BUILD_PATH: flatpak_app/files/share
     needs: prepare
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.9
+      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.10
       options: --privileged
     strategy:
       matrix:

--- a/util/flatpak/com.github.wwmm.easyeffects.Devel.json
+++ b/util/flatpak/com.github.wwmm.easyeffects.Devel.json
@@ -1,7 +1,7 @@
 {
     "id": "com.github.wwmm.easyeffects.Devel",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.9",
+    "runtime-version": "6.10",
     "sdk": "org.kde.Sdk",
     "branch": "stable",
     "command": "easyeffects",

--- a/util/flatpak/easyeffects-modules.json
+++ b/util/flatpak/easyeffects-modules.json
@@ -8,8 +8,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/qt/qtgraphs.git",
-                    "tag": "v6.9.0",
-                    "commit": "ba29aa033b1878429dd1f12d783c57e516f6f32a",
+                    "tag": "v6.10.0",
+                    "commit": "4e18609678b777f7e7ce47c17764e46c20bfb608",
                     "//": "We cannot use x-checker-data here as this version has to match the qt/kde runtime"
                 }
             ],
@@ -45,7 +45,8 @@
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DBUILD_STATIC_LIBS=OFF",
-                "-DCMAKE_INSTALL_LIBDIR=lib"
+                "-DCMAKE_INSTALL_LIBDIR=lib",
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
             ],
             "sources": [
                 {
@@ -365,12 +366,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing.git",
-                    "tag": "v2.1",
-                    "commit": "846fe90a289f58b7c9303a635142aa2c7caa93e5",
-                    "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^v([\\d.]+)$"
-                    }
+                    "commit": "bc838790eeb6066d30f019c2a3516bd2b824a5c8",
+                    "//": "use latest commit for gcc 15 support"
                 }
             ]
         }


### PR DESCRIPTION
Some minor fixes for the build to work for QT 6.10.

Worth noting this also brings a runtime pipewire version upgrade to pipewire 1.4.8.

I did notice the desktop file may not be correct for the "devel" build that flatpak uses. The desktop file does not get exported properly by flatpak and I cannot find the application on the gnome launcher. It may just be a problem with how I'm installing the built `.flatpak` file, I will try some more to investigate when I have time.

The manual also does not open in the flatpak build, except there is not even an error message. Simply nothing happens when clicking the manual button.