### PR TITLE
Add some vertical margin to the segmented button in the footer

### DIFF
--- a/src/contents/ui/PageStreamsEffects.qml
+++ b/src/contents/ui/PageStreamsEffects.qml
@@ -489,6 +489,8 @@ Kirigami.Page {
         position: Controls.ToolBar.Footer
 
         contentItem: RowLayout {
+            spacing: Kirigami.Units.smallSpacing
+
             anchors {
                 left: parent.left
                 leftMargin: Kirigami.Units.smallSpacing
@@ -599,6 +601,8 @@ Kirigami.Page {
                 id: segmentedButton
 
                 Layout.alignment: Qt.AlignHCenter
+                Layout.topMargin: Math.round(Kirigami.Units.smallSpacing / 2)
+                Layout.bottomMargin: Math.round(Kirigami.Units.smallSpacing / 2)
 
                 readonly property bool hasEnoughWidth: appWindow.width >= Kirigami.Units.gridUnit * 40
 


### PR DESCRIPTION
Before:

<img width="432" height="187" alt="image" src="https://github.com/user-attachments/assets/e5b0cdc4-67a8-45b2-82e9-7ca850900690" />

After:

<img width="432" height="187" alt="Screenshot_20251110_143844" src="https://github.com/user-attachments/assets/b4da8b77-6ad2-4c1a-b9c8-8b6c4469f529" />

Spacing could be increased a bit more but not 100% sure

Btw if you have any opinion on the design of the segmented button or how to evolve then a bit, I'm taking them. I originally designed then for the date picker with the hope to use them in more places but atm it's only used there and now in Easy Effects.
