### PR TITLE
Remove ci flatpak build lint extra attempt

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -102,13 +102,6 @@ jobs:
       with:
         args: --exceptions --user-exceptions exceptions.json manifest util/flatpak/com.github.wwmm.easyeffects.Devel.json
 
-    # run command twice as they can fail intermittently due to network errors
-    - name: Verify flatpak builder lint (extra attempt)
-      uses: docker://ghcr.io/flathub/flatpak-builder-lint:latest
-      if: failure()
-      with:
-        args: --exceptions --user-exceptions exceptions.json manifest util/flatpak/com.github.wwmm.easyeffects.Devel.json
-
   arch-linux:
     name: Arch Linux
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This not only doesn't work, it isn't even running an extra attempt on the right step. So just remove this.