### PR TITLE
DisplayHint enum is included in Kirigami

### DIFF
--- a/src/contents/ui/Autogain.qml
+++ b/src/contents/ui/Autogain.qml
@@ -4,7 +4,6 @@ import QtQuick.Layouts
 import "Common.js" as Common
 import ee.tags.plugin.name as TagsPluginName // qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 import org.kde.kirigamiaddons.formcard as FormCard
 
 Kirigami.ScrollablePage {
@@ -112,9 +111,9 @@ Kirigami.ScrollablePage {
                     }
                 }
 
-		Item {
-		    Layout.fillHeight: true
-		}
+                Item {
+                    Layout.fillHeight: true
+                }
             }
 
             EeCard {
@@ -202,9 +201,9 @@ Kirigami.ScrollablePage {
                     convertDecibelToLinear: true
                 }
 
-		Item {
-		    Layout.fillHeight: true
-		}
+                Item {
+                    Layout.fillHeight: true
+                }
             }
         }
     }
@@ -253,7 +252,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset settings")// qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/BassEnhancer.qml
+++ b/src/contents/ui/BassEnhancer.qml
@@ -5,7 +5,6 @@ import "Common.js" as Common
 import ee.database as DB
 import ee.tags.plugin.name as TagsPluginName // qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 
 Kirigami.ScrollablePage {
     id: bassEnchancerPage
@@ -206,7 +205,7 @@ Kirigami.ScrollablePage {
             flat: true
             actions: [
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Show native window")// qmllint disable
                     icon.name: "window-duplicate-symbolic"
                     enabled: DB.Manager.main.showNativePluginUi
@@ -230,7 +229,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset")// qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/BassLoudness.qml
+++ b/src/contents/ui/BassLoudness.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls as Controls
 import QtQuick.Layouts
 import ee.tags.plugin.name as TagsPluginName// qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 
 Kirigami.ScrollablePage {
     id: bassLoudnessPage
@@ -119,7 +118,7 @@ Kirigami.ScrollablePage {
             flat: true
             actions: [
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/Compressor.qml
+++ b/src/contents/ui/Compressor.qml
@@ -6,7 +6,6 @@ import ee.database as DB
 import ee.pipewire as PW
 import ee.tags.plugin.name as TagsPluginName // qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 import org.kde.kirigamiaddons.formcard as FormCard
 
 Kirigami.ScrollablePage {
@@ -911,7 +910,7 @@ Kirigami.ScrollablePage {
             flat: true
             actions: [
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Show native window") // qmllint disable
                     icon.name: "window-duplicate-symbolic"
                     enabled: DB.Manager.main.showNativePluginUi
@@ -945,7 +944,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/Convolver.qml
+++ b/src/contents/ui/Convolver.qml
@@ -6,7 +6,6 @@ import ee.database as DB
 import ee.presets as Presets
 import ee.tags.plugin.name as TagsPluginName // qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 import org.kde.kirigamiaddons.formcard as FormCard
 
 Kirigami.ScrollablePage {
@@ -483,7 +482,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/Crossfeed.qml
+++ b/src/contents/ui/Crossfeed.qml
@@ -4,7 +4,6 @@ import QtQuick.Layouts
 import ee.database as DB
 import ee.tags.plugin.name as TagsPluginName // qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 
 Kirigami.ScrollablePage {
     id: crossfeedPage
@@ -164,7 +163,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/Crystalizer.qml
+++ b/src/contents/ui/Crystalizer.qml
@@ -5,7 +5,6 @@ import QtQuick.Controls as Controls
 import QtQuick.Layouts
 import ee.tags.plugin.name as TagsPluginName // qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 
 Kirigami.ScrollablePage {
     id: crystalizerPage
@@ -115,7 +114,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/DeepFilterNet.qml
+++ b/src/contents/ui/DeepFilterNet.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls as Controls
 import QtQuick.Layouts
 import ee.tags.plugin.name as TagsPluginName// qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 
 Kirigami.ScrollablePage {
     id: deepfilternetPage
@@ -197,7 +196,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset settings") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/Deesser.qml
+++ b/src/contents/ui/Deesser.qml
@@ -5,7 +5,6 @@ import "Common.js" as Common
 import ee.database as DB
 import ee.tags.plugin.name as TagsPluginName// qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 import org.kde.kirigamiaddons.formcard as FormCard
 
 Kirigami.ScrollablePage {
@@ -316,7 +315,7 @@ Kirigami.ScrollablePage {
             flat: true
             actions: [
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Show native window") // qmllint disable
                     icon.name: "window-duplicate-symbolic"
                     enabled: DB.Manager.main.showNativePluginUi
@@ -340,7 +339,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/Delay.qml
+++ b/src/contents/ui/Delay.qml
@@ -4,7 +4,6 @@ import QtQuick.Layouts
 import ee.database as DB
 import ee.tags.plugin.name as TagsPluginName// qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 import org.kde.kirigamiaddons.formcard as FormCard
 
 Kirigami.ScrollablePage {
@@ -400,7 +399,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Show native window") // qmllint disable
                     icon.name: "window-duplicate-symbolic"
                     enabled: DB.Manager.main.showNativePluginUi
@@ -414,7 +413,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/EchoCanceller.qml
+++ b/src/contents/ui/EchoCanceller.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls as Controls
 import QtQuick.Layouts
 import ee.tags.plugin.name as TagsPluginName// qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 import org.kde.kirigamiaddons.formcard as FormCard
 
 Kirigami.ScrollablePage {
@@ -177,7 +176,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/Equalizer.qml
+++ b/src/contents/ui/Equalizer.qml
@@ -8,7 +8,6 @@ import QtQuick.Layouts
 import ee.database as DB
 import ee.tags.plugin.name as TagsPluginName// qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 import org.kde.kirigamiaddons.formcard as FormCard
 
 Kirigami.ScrollablePage {
@@ -280,7 +279,7 @@ Kirigami.ScrollablePage {
                 flat: true
                 actions: [
                     Kirigami.Action {
-                        displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                        displayHint: Kirigami.DisplayHint.KeepVisible
                         text: i18n("Show native window") // qmllint disable
                         icon.name: "window-duplicate-symbolic"
                         enabled: DB.Manager.main.showNativePluginUi
@@ -346,7 +345,7 @@ Kirigami.ScrollablePage {
                         }
                     },
                     Kirigami.Action {
-                        displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                        displayHint: Kirigami.DisplayHint.KeepVisible
                         text: i18n("Reset") // qmllint disable
                         icon.name: "edit-reset-symbolic"
                         onTriggered: {

--- a/src/contents/ui/Exciter.qml
+++ b/src/contents/ui/Exciter.qml
@@ -5,7 +5,6 @@ import "Common.js" as Common
 import ee.database as DB
 import ee.tags.plugin.name as TagsPluginName// qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 
 Kirigami.ScrollablePage {
     id: exciterPage
@@ -206,7 +205,7 @@ Kirigami.ScrollablePage {
             flat: true
             actions: [
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Show native window") // qmllint disable
                     icon.name: "window-duplicate-symbolic"
                     enabled: DB.Manager.main.showNativePluginUi
@@ -230,7 +229,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/Expander.qml
+++ b/src/contents/ui/Expander.qml
@@ -6,7 +6,6 @@ import ee.database as DB
 import ee.pipewire as PW
 import ee.tags.plugin.name as TagsPluginName // qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 import org.kde.kirigamiaddons.formcard as FormCard
 
 Kirigami.ScrollablePage {
@@ -868,7 +867,7 @@ Kirigami.ScrollablePage {
             flat: true
             actions: [
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Show native window") // qmllint disable
                     icon.name: "window-duplicate-symbolic"
                     enabled: DB.Manager.main.showNativePluginUi
@@ -902,7 +901,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/Filter.qml
+++ b/src/contents/ui/Filter.qml
@@ -4,7 +4,6 @@ import QtQuick.Layouts
 import ee.database as DB
 import ee.tags.plugin.name as TagsPluginName// qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 import org.kde.kirigamiaddons.formcard as FormCard
 
 Kirigami.ScrollablePage {
@@ -223,7 +222,7 @@ Kirigami.ScrollablePage {
             flat: true
             actions: [
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Show native window") // qmllint disable
                     icon.name: "window-duplicate-symbolic"
                     enabled: DB.Manager.main.showNativePluginUi
@@ -237,7 +236,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/Gate.qml
+++ b/src/contents/ui/Gate.qml
@@ -6,7 +6,6 @@ import ee.database as DB
 import ee.pipewire as PW
 import ee.tags.plugin.name as TagsPluginName// qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 import org.kde.kirigamiaddons.formcard as FormCard
 
 Kirigami.ScrollablePage {
@@ -972,7 +971,7 @@ Kirigami.ScrollablePage {
             flat: true
             actions: [
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Show native window") // qmllint disable
                     icon.name: "window-duplicate-symbolic"
                     enabled: DB.Manager.main.showNativePluginUi
@@ -1006,7 +1005,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/LevelMeter.qml
+++ b/src/contents/ui/LevelMeter.qml
@@ -4,7 +4,6 @@ import QtQuick.Layouts
 import "Common.js" as Common
 import ee.tags.plugin.name as TagsPluginName// qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 
 Kirigami.ScrollablePage {
     id: levelMeterPage
@@ -227,7 +226,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset settings") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/Limiter.qml
+++ b/src/contents/ui/Limiter.qml
@@ -6,7 +6,6 @@ import ee.database as DB
 import ee.pipewire as PW
 import ee.tags.plugin.name as TagsPluginName// qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 import org.kde.kirigamiaddons.formcard as FormCard
 
 Kirigami.ScrollablePage {
@@ -590,7 +589,7 @@ Kirigami.ScrollablePage {
             flat: true
             actions: [
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Show native window") // qmllint disable
                     icon.name: "window-duplicate-symbolic"
                     enabled: DB.Manager.main.showNativePluginUi
@@ -624,7 +623,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/Loudness.qml
+++ b/src/contents/ui/Loudness.qml
@@ -4,7 +4,6 @@ import QtQuick.Layouts
 import ee.database as DB
 import ee.tags.plugin.name as TagsPluginName// qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 import org.kde.kirigamiaddons.formcard as FormCard
 
 Kirigami.ScrollablePage {
@@ -175,7 +174,7 @@ Kirigami.ScrollablePage {
             flat: true
             actions: [
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Show native window") // qmllint disable
                     icon.name: "window-duplicate-symbolic"
                     enabled: DB.Manager.main.showNativePluginUi
@@ -199,7 +198,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/Maximizer.qml
+++ b/src/contents/ui/Maximizer.qml
@@ -4,7 +4,6 @@ import QtQuick.Layouts
 import ee.database as DB
 import ee.tags.plugin.name as TagsPluginName // qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 
 Kirigami.ScrollablePage {
     id: maximizerPage
@@ -117,7 +116,7 @@ Kirigami.ScrollablePage {
             flat: true
             actions: [
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Show native window") // qmllint disable
                     icon.name: "window-duplicate-symbolic"
                     enabled: DB.Manager.main.showNativePluginUi
@@ -131,7 +130,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/MultibandCompressor.qml
+++ b/src/contents/ui/MultibandCompressor.qml
@@ -7,7 +7,6 @@ import ee.database as DB
 import ee.pipewire as PW
 import ee.tags.plugin.name as TagsPluginName// qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 import org.kde.kirigamiaddons.formcard as FormCard
 
 Kirigami.ScrollablePage {
@@ -951,7 +950,7 @@ Kirigami.ScrollablePage {
             flat: true
             actions: [
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Show native window") // qmllint disable
                     icon.name: "window-duplicate-symbolic"
                     enabled: DB.Manager.main.showNativePluginUi
@@ -982,7 +981,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/MultibandGate.qml
+++ b/src/contents/ui/MultibandGate.qml
@@ -7,7 +7,6 @@ import ee.database as DB
 import ee.pipewire as PW
 import ee.tags.plugin.name as TagsPluginName// qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 import org.kde.kirigamiaddons.formcard as FormCard
 
 Kirigami.ScrollablePage {
@@ -924,7 +923,7 @@ Kirigami.ScrollablePage {
             flat: true
             actions: [
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Show native window") // qmllint disable
                     icon.name: "window-duplicate-symbolic"
                     enabled: DB.Manager.main.showNativePluginUi
@@ -955,7 +954,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/Pitch.qml
+++ b/src/contents/ui/Pitch.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls as Controls
 import QtQuick.Layouts
 import ee.tags.plugin.name as TagsPluginName// qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 
 Kirigami.ScrollablePage {
     id: pitchPage
@@ -306,7 +305,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset settings") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/RNNoise.qml
+++ b/src/contents/ui/RNNoise.qml
@@ -9,7 +9,6 @@ import ee.presets as Presets
 import ee.tags.plugin.name as TagsPluginName // qmllint disable
 import ee.type.presets as TypePresets
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 
 Kirigami.ScrollablePage {
     id: rnnoisePage
@@ -319,7 +318,7 @@ Kirigami.ScrollablePage {
                         }
                     },
                     Kirigami.Action {
-                        displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                        displayHint: Kirigami.DisplayHint.KeepVisible
                         text: i18n("Reset") // qmllint disable
                         icon.name: "edit-reset-symbolic"
                         onTriggered: {

--- a/src/contents/ui/Reverb.qml
+++ b/src/contents/ui/Reverb.qml
@@ -5,7 +5,6 @@ import "Common.js" as Common
 import ee.database as DB
 import ee.tags.plugin.name as TagsPluginName // qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 import org.kde.kirigamiaddons.formcard as FormCard
 
 Kirigami.ScrollablePage {
@@ -332,7 +331,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Show native window") // qmllint disable
                     icon.name: "window-duplicate-symbolic"
                     enabled: DB.Manager.main.showNativePluginUi
@@ -346,7 +345,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/Speex.qml
+++ b/src/contents/ui/Speex.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls as Controls
 import QtQuick.Layouts
 import ee.tags.plugin.name as TagsPluginName // qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 
 Kirigami.ScrollablePage {
     id: speexPage
@@ -181,7 +180,7 @@ Kirigami.ScrollablePage {
             flat: true
             actions: [
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {

--- a/src/contents/ui/StereoTools.qml
+++ b/src/contents/ui/StereoTools.qml
@@ -4,7 +4,6 @@ import QtQuick.Layouts
 import ee.database as DB
 import ee.tags.plugin.name as TagsPluginName// qmllint disable
 import org.kde.kirigami as Kirigami
-import org.kde.kirigami.layouts as KirigamiLayouts
 import org.kde.kirigamiaddons.formcard as FormCard
 
 Kirigami.ScrollablePage {
@@ -409,7 +408,7 @@ Kirigami.ScrollablePage {
             flat: true
             actions: [
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Show native window") // qmllint disable
                     icon.name: "window-duplicate-symbolic"
                     enabled: DB.Manager.main.showNativePluginUi
@@ -423,7 +422,7 @@ Kirigami.ScrollablePage {
                     }
                 },
                 Kirigami.Action {
-                    displayHint: KirigamiLayouts.DisplayHint.KeepVisible
+                    displayHint: Kirigami.DisplayHint.KeepVisible
                     text: i18n("Reset") // qmllint disable
                     icon.name: "edit-reset-symbolic"
                     onTriggered: {


### PR DESCRIPTION
Just a cleanup. This was an oversight of mine. I though `kirigami.layouts` was something separated, but instead it's included in Kirigami, so we didn't need `KirigamiLayouts`. Just use `Kirigami` as already made in other parts of the code. 