### PR TITLE
Dont hide the text for Effects button

### DIFF
--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -436,10 +436,9 @@ Kirigami.ApplicationWindow {
                 overflowIconName: "overflow-menu-left"
                 actions: [
                     Kirigami.Action {
-                        text: i18n("Turn effects on/off") // qmllint disable
+                        text: checked === true ? i18n("Active") : i18n("Inactive")// qmllint disable
                         icon.name: "system-shutdown-symbolic"
                         icon.color: checked === true ? Kirigami.Theme.positiveTextColor : Kirigami.Theme.negativeTextColor
-                        displayHint: Kirigami.DisplayHint.IconOnly
                         checkable: true
                         checked: !DB.Manager.main.bypass
                         onTriggered: {


### PR DESCRIPTION
- Made the button text of effects text visible, since it conveys the functionality better. 
- Also added text based on checked/active state

After 
<img width="178" height="64" alt="image" src="https://github.com/user-attachments/assets/c74531c6-260d-4866-9d4d-11135d0489d2" /> <img width="186" height="65" alt="image" src="https://github.com/user-attachments/assets/3f512f7f-4601-49f6-97e8-788add46692e" />



