### PR TITLE
Respect user-defined Qt style instead of forcing Breeze (fixes #4332)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -300,17 +300,10 @@ int main(int argc, char* argv[]) {
 
   KColorSchemeManager::instance();
 
-  // Keep system widget colors
-  if (qEnvironmentVariableIsEmpty("QT_STYLE_OVERRIDE"))
-   QApplication::setStyle(QStyleFactory::create(QApplication::style()->objectName()));
- 
-  // Force icons to breeze regardless of color theme
-  QIcon::setThemeName(QStringLiteral("breeze"));
-  QIcon::setFallbackThemeName(QStringLiteral("breeze"));
- 
-  // Keep org.kde.desktop for QQC2 style, but don’t override user env
-  if (qEnvironmentVariableIsEmpty("QT_QUICK_CONTROLS_STYLE") && QQuickStyle::name().isEmpty())
-   QQuickStyle::setStyle(QStringLiteral("org.kde.desktop"));
+  QIcon::setFallbackThemeName(QStringLiteral("breeze")); 
+  if (qEnvironmentVariableIsEmpty("QT_QUICK_CONTROLS_STYLE") && QQuickStyle::name().isEmpty()) { 
+   QQuickStyle::setStyle(QStringLiteral("org.kde.desktop")); 
+  }
 
   // Parsing command line options
 


### PR DESCRIPTION
This PR removes the hardcoded `QApplication::setStyle("breeze")` call and updates the Quick Controls style initialization logic.
Previously, EasyEffects forced the Breeze widget style regardless of user or system configuration, which broke theming under qt6ct. (see #4332)

The new logic:
- Keeps breeze as fallback icon theme only (no forced widget style).
- applies `org.kde.desktop` only if no `QT_QUICK_CONTROLS_STYLE` is set and `QQuickStyle::name()` is empty.

Allows user-configured system QT themes to take effect properly.

There still seem to be a few of icons that don’t theme correctly, but I’m looking into that. Also, I’m not sure if this has any negative impact on systems that don’t have a system theme as I can't really test that on my machine.