### PR TITLE
Silence out qmllint errors about i18n

### DIFF
--- a/.contextProperties.ini
+++ b/.contextProperties.ini
@@ -1,0 +1,2 @@
+[General]
+disableUnqualifiedAccess = "i18nc,xi18nc,i18ncp,i18n,i18np"


### PR DESCRIPTION
Use the newly introduced .contextProperties.ini. Unfortunately this only works in Qt 6.11 (unreleased), but it doesn't hurt to have it already :)