### PR TITLE
Pass GitHub Token to Flatpak lint workflow

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -92,6 +92,8 @@ jobs:
       uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
       with:
         args: util/flatpak/com.github.wwmm.easyeffects.Devel.json
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Write exceptions file
       run: |


### PR DESCRIPTION
This will avoid unnecessary failures and rate limiting. I’m surprised I did not think of this ages ago.