### PR TITLE
Use nullish coalescing to avoid undefined to bool assignment

### DIFF
--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -440,7 +440,8 @@ Kirigami.ApplicationWindow {
                         text: i18n("Go back") // qmllint disable
                         icon.name: "draw-arrow-back-symbolic"
                         displayHint: Kirigami.DisplayHint.IconOnly
-                        visible: (pageStack.currentItem as Kirigami.Page).showBackButton
+                        // Use nullish coalescing to avoid the `Unable to assign [undefined] to bool` message.
+                        visible: (pageStack.currentItem as Kirigami.Page)?.showBackButton ?? false
                         onTriggered: {
                             pageStack.currentItem.goBack();
                         }


### PR DESCRIPTION
Switching between in/output tabs, I see `qrc:/ui/main.qml:443:25: Unable to assign [undefined] to bool`.

Use nullish coalescing to avoid it.