### PR TITLE
Global bypass button: show label and inline message

### DIFF
--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -447,15 +447,19 @@ Kirigami.ApplicationWindow {
                         }
                     },
                     Kirigami.Action {
-                        text: i18n("Turn effects on/off") // qmllint disable
+                        text: i18n("Effects") // qmllint disable
+                        tooltip: i18n("Turn effects on/off") // qmllint disable
                         icon.name: "system-shutdown-symbolic"
                         icon.color: checked === true ? Kirigami.Theme.positiveTextColor : Kirigami.Theme.negativeTextColor
-                        displayHint: Kirigami.DisplayHint.IconOnly
+                        displayHint: Kirigami.DisplayHint.KeepVisible
                         checkable: true
                         checked: !DB.Manager.main.bypass
                         onTriggered: {
-                            if (checked !== !DB.Manager.main.bypass)
+                            if (checked !== !DB.Manager.main.bypass) {
                                 DB.Manager.main.bypass = !checked;
+                            }
+
+                            checked ? appWindow.showStatus(i18n("Audio effects are enabled."), Kirigami.MessageType.Positive) : appWindow.showStatus(i18n("Audio effects are disabled.")); // qmllint disable
                         }
                     },
                     Kirigami.Action {


### PR DESCRIPTION
This is an attempt to solve #4353 remaining on the On/Off logic without reintroducing the global bypass concept.

The previous tooltip is retained and an inline message is shown. The message for the disabled effects uses "informative" style, not the "negative" one because it's not an error.

@wwmm If you don't like it, just discard this PR.