### PR TITLE
Fix swapped Access and API data fields in client list delegate

### DIFF
--- a/src/contents/ui/DelegateClientsList.qml
+++ b/src/contents/ui/DelegateClientsList.qml
@@ -44,14 +44,14 @@ Controls.ItemDelegate {
         }
 
         Controls.Label {
-            text: i18n("Access: %1", root.api)
+            text: i18n("Access: %1", root.access)
             visible: root.api
 
             Layout.fillWidth: true
         }
 
         Controls.Label {
-            text: i18n("API: %1", root.access)
+            text: i18n("API: %1", root.api)
             visible: root.access
 
             Layout.fillWidth: true


### PR DESCRIPTION
The “Access” and “API” labels were displaying each other’s values due to a field mix-up.
This commit assigns each label to the correct root property.
