### PR TITLE
Fix swapped visibility properties on client list delegate

### DIFF
--- a/src/contents/ui/DelegateClientsList.qml
+++ b/src/contents/ui/DelegateClientsList.qml
@@ -45,14 +45,14 @@ Controls.ItemDelegate {
 
         Controls.Label {
             text: i18n("Access: %1", root.access)
-            visible: root.api
+            visible: root.access
 
             Layout.fillWidth: true
         }
 
         Controls.Label {
             text: i18n("API: %1", root.api)
-            visible: root.access
+            visible: root.api
 
             Layout.fillWidth: true
         }


### PR DESCRIPTION
Followup to my previous merge request. Turns out that the visibility properties of Access and API were also swapped.
This PR swaps them to their correct place.
