### PR TITLE
fix `--hide-window` occasionally don't work in dwm 

### DIFF
--- a/src/contents/ui/Main.qml
+++ b/src/contents/ui/Main.qml
@@ -12,7 +12,7 @@ import org.kde.kirigami as Kirigami
 
 Kirigami.ApplicationWindow {
     id: appWindow
-	visible: false
+    visible: false
 
     width: DB.Manager.main.width
     height: DB.Manager.main.height


### PR DESCRIPTION
fix issue #4450

I tried many times. Initially, I thought it was due to DWM's forced map request, but that wasn't the case. Qt shouldn't send a map request to the Xorg server when creating an object. Explicitly declaring `visible: false` in the QML can prevent sending map requests. This worked for me, and I've tested it on X11-based DWM/XFCE4/KDE, and it works correctly. 