### PR TITLE
Fix manual for F1 shortcut

### DIFF
--- a/src/contents/ui/Main.qml
+++ b/src/contents/ui/Main.qml
@@ -161,7 +161,7 @@ Kirigami.ApplicationWindow {
     Shortcut {
         sequences: ["F1"]
         onActivated: {
-            Help.Manager.openManual();
+            helpSheet.open();
         }
     }
 


### PR DESCRIPTION
Help manager was removed.

Fixes: f71b953d848c43c45d00280103c98fb64fb991e5
See-Also: 6507b8bcc20cb5c59640d3fd7b69be0f240694fb

Btw would you receptive to the idea of making qtwebengine optional? Unfortunately it would require restoring the helpmanager due to how the docs are embedded. Or maybe open "https://wwmm.github.io/easyeffects/" instead in the browser?

Qtwebengine is a big package with high build requirements which make it a hard pill to swallow if its only used for the manual. On gentoo it would require dropping support several architectures in easyeffects as its hard to justify support in qtwebengine for them.