### PR TITLE
Add flatpak socket x11 permission

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -97,7 +97,7 @@ jobs:
 
     - name: Write exceptions file
       run: |
-        echo '{"com.github.wwmm.easyeffects.Devel": ["appid-uses-code-hosting-domain", "toplevel-unnecessary-branch"]}' > exceptions.json
+        echo '{"com.github.wwmm.easyeffects.Devel": ["appid-uses-code-hosting-domain", "toplevel-unnecessary-branch", "finish-args-contains-both-x11-and-wayland"]}' > exceptions.json
 
     - name: Verify flatpak builder lint
       uses: docker://ghcr.io/flathub/flatpak-builder-lint:latest

--- a/util/flatpak/com.github.wwmm.easyeffects.Devel.json
+++ b/util/flatpak/com.github.wwmm.easyeffects.Devel.json
@@ -9,7 +9,7 @@
     "command": "easyeffects",
     "finish-args": [
         "--share=ipc",
-        "--socket=fallback-x11",
+        "--socket=x11",
         "--env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--socket=wayland",


### PR DESCRIPTION
Native plugin windows only support x11. However, we still want the main window to be using wayland, so allow the wayland permission as well.