### PR TITLE
global blocklist setting

### DIFF
--- a/src/contents/kcfg/easyeffects_db.kcfg
+++ b/src/contents/kcfg/easyeffects_db.kcfg
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <kcfg xmlns="http://www.kde.org/standards/kcfg/1.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0 http://www.kde.org/standards/kcfg/1.0/kcfg.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0 http://www.kde.org/standards/kcfg/1.0/kcfg.xsd">
     <kcfgfile name="easyeffects/db/easyeffectsrc" />
     <group name="Window">
         <entry name="width" type="Int">
@@ -26,6 +25,10 @@
         </entry>
         <entry name="reducePluginsListControls" type="Bool">
             <label>Effect controls in the plugins list are shown inside a context menu</label>
+            <default>false</default>
+        </entry>
+        <entry name="useGlobalBlocklist" type="Bool">
+            <label>Use a global blocklist instead of the one saved in presets.</label>
             <default>false</default>
         </entry>
         <entry name="lastLoadedInputPreset" type="String">

--- a/src/contents/ui/PreferencesSheet.qml
+++ b/src/contents/ui/PreferencesSheet.qml
@@ -510,6 +510,20 @@ KirigamiSettings.ConfigurationView {
                         DbMain.presetsAutoloadInterval = v;
                     }
                 }
+
+                EeSwitch {
+                    id: useGlobalBlocklist
+
+                    label: i18n("Use shared excluded apps list") // qmllint disable
+                    subtitle: i18n("Do not exclude applications per preset.") // qmllint disable
+                    maximumLineCount: -1
+                    isChecked: DbMain.useGlobalBlocklist
+                    onCheckedChanged: {
+                        if (isChecked !== DbMain.useGlobalBlocklist) {
+                            DbMain.useGlobalBlocklist = isChecked;
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -219,6 +219,10 @@ void Manager::save_blocklist(const PipelineType& pipeline_type, nlohmann::json& 
 }
 
 auto Manager::load_blocklist(const PipelineType& pipeline_type, const nlohmann::json& json) -> bool {
+  if (DbMain::useGlobalBlocklist()) {
+    return true;
+  }
+
   std::vector<std::string> blocklist;
 
   switch (pipeline_type) {


### PR DESCRIPTION
Fixes #4532 

If enabled, it will always use `easyeffectsrc`'s blocklist regardless of the preset.

<img width="900" height="562" alt="image" src="https://github.com/user-attachments/assets/da91d501-802d-471a-bfd6-de2d2b57e9ee" />
