### PR TITLE
Use a `checkable` MenuItem to indicate the current preset in the tray

### DIFF
--- a/src/contents/ui/Main.qml
+++ b/src/contents/ui/Main.qml
@@ -280,7 +280,8 @@ Kirigami.ApplicationWindow {
 
                 delegate: MenuItem {
                     text: modelData// qmllint disable
-                    icon.name: DbMain.lastLoadedInputPreset === modelData ? "checkbox-symbolic" : ""
+                    checkable: true
+                    checked: DbMain.lastLoadedInputPreset === modelData
                     onTriggered: {
                         Presets.Manager.loadLocalPresetFile(0, modelData);// qmllint disable
 
@@ -297,7 +298,8 @@ Kirigami.ApplicationWindow {
 
                 delegate: MenuItem {
                     text: modelData// qmllint disable
-                    icon.name: DbMain.lastLoadedOutputPreset === modelData ? "checkbox-symbolic" : ""
+                    checkable: true
+                    checked: DbMain.lastLoadedOutputPreset === modelData
                     onTriggered: {
                         Presets.Manager.loadLocalPresetFile(1, modelData);// qmllint disable
 


### PR DESCRIPTION
The `checkbox-symbolic` icon has drastically different meanings in Breeze (checkmark) and Adwaita (unchecked checkbox), making it unsuitable to indicate the last set preset.

![Screenshot](https://github.com/user-attachments/assets/1aae9eb6-e75e-48d2-9069-840366de0740)

Instead of explicitly changing the icon, make it a `checkable` MenuItem. This is already used for the "Active" MenuItem and translates better across different desktops.

![Screenshot](https://github.com/user-attachments/assets/53f1ac9c-9e8b-4929-a6a6-9d84850c182a)