### PR TITLE
Use symbolic app icon in the ActionToolBar and the Tray

### DIFF
--- a/src/contents/ui/Main.qml
+++ b/src/contents/ui/Main.qml
@@ -241,7 +241,7 @@ Kirigami.ApplicationWindow {
         id: tray
 
         visible: DbMain.showTrayIcon && canUseSysTray // qmllint disable
-        icon.name: applicationId
+        icon.name: applicationId + "-symbolic"
         tooltip: applicationName
         onActivated: {
             if (!appWindow.visible) {
@@ -575,7 +575,7 @@ Kirigami.ApplicationWindow {
                     },
                     Kirigami.Action {
                         text: i18n("About Easy Effects") // qmllint disable
-                        icon.name: applicationId
+                        icon.name: applicationId + "-symbolic"
                         displayHint: Kirigami.DisplayHint.AlwaysHide
                         onTriggered: {
                             appWindow.pageStack.pushDialogLayer(Qt.resolvedUrl("./AboutPage.qml"));


### PR DESCRIPTION
Explicitly request the symbolic icon variant. KDE already preferred the symbolic variant for the system tray, but GNOME didn't.
