### PR TITLE
Fix a little baby typo in extract-translation-messages.sh

### DIFF
--- a/util/extract-translation-messages.sh
+++ b/util/extract-translation-messages.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # https://techbase.kde.org/Development/Tutorials/Localization/i18n_Build_Systems/Outside_KDE_repositories
-# the command extractrc is provided by the pacakge kde-dev-scripts
+# the command extractrc is provided by the package kde-dev-scripts
 
 # https://api.kde.org/frameworks/ki18n/html/prg_guide.html
 


### PR DESCRIPTION
A little baby typo on line 4: 'the pacakge kde-dev-scripts' should be 'package' not 'pacakge'.