### PR TITLE
SOFA dialog UI: improve right/left padding

### DIFF
--- a/src/contents/ui/ConvolverSofaDialog.qml
+++ b/src/contents/ui/ConvolverSofaDialog.qml
@@ -10,8 +10,8 @@ Kirigami.Dialog {
     required property var pluginBackend
 
     title: i18n("Target Orientation") // qmllint disable
-    leftPadding: Kirigami.Units.smallSpacing
-    rightPadding: Kirigami.Units.smallSpacing
+    leftPadding: Kirigami.Units.largeSpacing
+    rightPadding: Kirigami.Units.largeSpacing
     topPadding: Kirigami.Units.smallSpacing
     bottomPadding: Kirigami.Units.smallSpacing
 


### PR DESCRIPTION
`Database` label seems too attached to the border, so improve the left/right padding of SOFA dialog UI:

Before:
<p>
<img width="296" height="620" alt="Schermata del 2025-12-12 11-19-10" src="https://github.com/user-attachments/assets/c1265a91-08e6-489f-b7ae-c1b93b090d8a" />
</p>

After:
<p>
<img width="306" height="623" alt="Schermata del 2025-12-12 11-22-16" src="https://github.com/user-attachments/assets/14ee7c6a-d212-4a8f-8930-b612274c48d9" />
</p>
