### PR TITLE
Effects list sidebar: increase top/bottom padding

### DIFF
--- a/src/contents/ui/PageStreamsEffects.qml
+++ b/src/contents/ui/PageStreamsEffects.qml
@@ -336,8 +336,8 @@ Kirigami.Page {
                 GridLayout {
                     columns: DbMain.collapsePluginsList === true ? 1 : 2
                     Layout.fillWidth: true
-                    Layout.topMargin: Kirigami.Units.smallSpacing
-                    Layout.bottomMargin: Kirigami.Units.smallSpacing
+                    Layout.topMargin: Kirigami.Units.largeSpacing
+                    Layout.bottomMargin: Kirigami.Units.largeSpacing
                     Layout.leftMargin: Kirigami.Units.smallSpacing
                     Layout.rightMargin: Kirigami.Units.smallSpacing
                     Layout.alignment: Qt.AlignCenter


### PR DESCRIPTION
I remember that top and bottom bars were shorter, so the padding was increased, but the same has not been done for the header in the sidebar. Indeed `Add effect` and `Close` buttons feels too attached to the top and bottom borders.

This is the original with small spacing:

<p>
<img width="480" height="605" alt="Schermata del 2025-12-16 10-00-24" src="https://github.com/user-attachments/assets/beb80a15-ce07-479a-8cc8-a70ac6b0a68a" />
</p>

This is with medium spacing:

<p>
<img width="480" height="605" alt="Schermata del 2025-12-16 10-01-07" src="https://github.com/user-attachments/assets/7517b02e-db00-464a-a89f-6755c62888d9" />
</p>

This is with large spacing:

<p>
<img width="480" height="605" alt="Schermata del 2025-12-16 10-03-47" src="https://github.com/user-attachments/assets/09323149-4c68-4735-af44-26edf6a3952c" />
</p>

@wwmm  I feel large spacing is better. and follows the padding in the top and bottom bars of the window app. But feel free to change it if it seems out of place on your system.