### PR TITLE
Crystalizer UI: enable spinbox only when oversampling mode is set

### DIFF
--- a/src/contents/ui/Crystalizer.qml
+++ b/src/contents/ui/Crystalizer.qml
@@ -80,6 +80,7 @@ Kirigami.ScrollablePage {
         EeSpinBox {
             Layout.alignment: Qt.AlignHCenter
             Layout.fillWidth: false
+            enabled: crystalizerPage.pluginDB.oversampling
             label: i18n("Oversampling quality") // qmllint disable
             spinboxMaximumWidth: Kirigami.Units.gridUnit * 7
             from: crystalizerPage.pluginDB.getMinValue("oversamplingQuality")


### PR DESCRIPTION
Since we disable the ALR card in the Limiter when ALR is unset, I thought we could do the same for Oversampling quality in the Crystalizer.