### PR TITLE
Fix app name

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,4 +1,4 @@
-site_name: EasyEffects Manual
+site_name: Easy Effects Manual
 repo_url: https://github.com/wwmm/easyeffects
 repo_name: wwmm/easyeffects
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -327,7 +327,7 @@ int main(int argc, char* argv[]) {
 
   KAboutData about(QStringLiteral(APPLICATION_DOMAIN), QStringLiteral(APPLICATION_NAME),
                    QStringLiteral(PROJECT_VERSION), i18n("Global audio effects"), KAboutLicense::GPL_V3,
-                   i18n("© 2017-2026 EasyEffects Team"));
+                   i18n("© 2017-2026 Easy Effects Team"));
 
   about.addAuthor(i18n("Wellington Wallace"), i18nc("@info:credit", "Developer"),
                   QStringLiteral("wellingtonwallace@gmail.com"));


### PR DESCRIPTION
I see a lot of `EasyEffects Manual` labels in the HTML pages. I suppose changing the title in `mkdocs.yaml`, they will be regenerated with the proper label, right?

Please update translation templates.