### PR TITLE
Revert "Add x-checker-data metadata for qt graphs"

### DIFF
--- a/util/flatpak/easyeffects-modules.json
+++ b/util/flatpak/easyeffects-modules.json
@@ -10,15 +10,7 @@
                     "url": "https://github.com/qt/qtgraphs.git",
                     "tag": "v6.10.1",
                     "commit": "b50b4e3b46940e5aa3cf31babb4ff1c9454ab473",
-                    "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^v([\\d.]+)$",
-                        "//": "make sure version matches kde runtime version of org.kde.Platform",
-                        "versions": {
-                            ">=": "v6.10",
-                            "<": "v6.11"
-                        }
-                    }
+                    "//": "We cannot use x-checker-data here as this version has to match the qt/kde runtime"
                 }
             ],
             "post-install": [


### PR DESCRIPTION
This reverts commit f915fd391d37e76b4e26d5f5640ac3c265be2283.

It turns out we really can't update this too often as too new versions will not build with the runtime. We will have to check very carefully that the version matches when the runtime is updated. Ideally, this module would be built in the kde runtime itself.