### PR TITLE
Improve autoload preset dialog readability for long device names

### DIFF
--- a/src/contents/ui/PresetsAutoloadPage.qml
+++ b/src/contents/ui/PresetsAutoloadPage.qml
@@ -23,6 +23,7 @@ import QtQuick.Layouts
 import ee.pipewire as PW
 import ee.presets as Presets
 import org.kde.kirigami as Kirigami
+import org.kde.kirigamiaddons.delegates as Delegates
 import org.kde.kirigamiaddons.formcard as FormCard
 
 ColumnLayout {
@@ -58,6 +59,19 @@ ColumnLayout {
             editable: false
             model: DbMain.visiblePage === 0 ? PW.ModelSinkDevices : PW.ModelSourceDevices
             description: `${i18n("Route")}: ${deviceRouteDescription}` // qmllint disable
+
+            comboBoxDelegate: Delegates.RoundedItemDelegate {
+                required property var model
+                required property int index
+
+                implicitWidth: ListView.view ? ListView.view.width : Kirigami.Units.gridUnit * 16
+                text: model[device.textRole]
+                highlighted: device.highlightedIndex === index
+
+                Controls.ToolTip.text: model[device.textRole]
+                Controls.ToolTip.visible: hovered && contentItem.labelItem.truncated
+                Controls.ToolTip.delay: Kirigami.Units.toolTipDelay
+            }
 
             function updateRouteDescription() {
                 const proxyIndex = model.index(currentIndex, 0);
@@ -184,10 +198,12 @@ ColumnLayout {
                 }
 
                 contentItem: Kirigami.FlexColumn {
+                    maximumWidth: Kirigami.Units.gridUnit * 40
 
                     GridLayout {
                         id: delegateLayout
 
+                        Layout.fillWidth: true
                         columns: 3
                         rows: 4
 
@@ -200,8 +216,7 @@ ColumnLayout {
 
                         Controls.Label {
                             Layout.fillWidth: true
-                            wrapMode: Text.NoWrap
-                            elide: Text.ElideRight
+                            wrapMode: Text.Wrap
                             text: listItemDelegate.deviceName
                             color: Kirigami.Theme.disabledTextColor
                         }
@@ -229,8 +244,7 @@ ColumnLayout {
 
                         Controls.Label {
                             Layout.fillWidth: true
-                            wrapMode: Text.NoWrap
-                            elide: Text.ElideRight
+                            wrapMode: Text.Wrap
                             text: listItemDelegate.deviceDescription
                             color: Kirigami.Theme.disabledTextColor
                         }
@@ -244,8 +258,7 @@ ColumnLayout {
 
                         Controls.Label {
                             Layout.fillWidth: true
-                            wrapMode: Text.NoWrap
-                            elide: Text.ElideRight
+                            wrapMode: Text.Wrap
                             text: listItemDelegate.deviceProfile
                             color: Kirigami.Theme.disabledTextColor
                         }
@@ -258,8 +271,7 @@ ColumnLayout {
 
                         Controls.Label {
                             Layout.fillWidth: true
-                            wrapMode: Text.NoWrap
-                            elide: Text.ElideRight
+                            wrapMode: Text.Wrap
                             text: listItemDelegate.devicePreset
                             color: Kirigami.Theme.disabledTextColor
                         }

--- a/src/contents/ui/PresetsDialog.qml
+++ b/src/contents/ui/PresetsDialog.qml
@@ -45,7 +45,7 @@ Kirigami.Dialog {
         return "";
     }
 
-    implicitWidth: Math.min(Kirigami.Units.gridUnit * 30, appWindow.width * 0.8) // qmllint disable
+    implicitWidth: Math.min(Kirigami.Units.gridUnit * 40, appWindow.width * 0.9) // qmllint disable
     implicitHeight: Math.min(Kirigami.Units.gridUnit * 40, Math.round(Controls.ApplicationWindow.window.height * 0.8))
     bottomPadding: 1
     anchors.centerIn: parent


### PR DESCRIPTION
## Problem

Long device names such as `Alder Lake PCH-P High Definition Audio Controller` and device identifiers like `alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__Speaker__sink` were truncated in the autoload tab, making it impossible to distinguish between multiple outputs on the same sound card.

## Changes

- **Wider dialog**: Increased preset dialog width from 30 to 40 grid units (90% of window width)
- **Text wrapping**: Autoload list entry labels (Device, Description, Route, Local preset) now wrap instead of being truncated with ellipsis
- **Layout constraints**: Added `maximumWidth` to contentItem FlexColumn and `Layout.fillWidth` to GridLayout so wrapping is properly constrained
- **Dropdown tooltip**: Added tooltip on hover for truncated device names in the combo box dropdown, using `contentItem.labelItem.truncated` to only show when text is actually elided

## Files changed

- `src/contents/ui/PresetsDialog.qml` — dialog width
- `src/contents/ui/PresetsAutoloadPage.qml` — wrapping, layout constraints, tooltip

## Use of AI

These changes were generated using GitHub Copilot CLI. I'll admit I do not have prior knowledge of QML nor this repo. From looking at the proposed changes and the resulting rendering in UI they seem right but do let me know if they're garbage.

## Screenshots

Before the changes: (easyeffects 8.1.2 on Debian Sid running Gnome)
<img width="938" height="704" alt="image" src="https://github.com/user-attachments/assets/ac078d28-c3f1-4e78-8e57-e76ef61398bc" />
<img width="938" height="704" alt="image" src="https://github.com/user-attachments/assets/fe77cada-cd79-4745-96b1-bb3db696f1fb" />

After the changes:
<img width="1224" height="723" alt="image" src="https://github.com/user-attachments/assets/1eaa0b95-165c-4aba-8d6c-df2aed159a29" />
<img width="1224" height="723" alt="image" src="https://github.com/user-attachments/assets/261ba7ac-ad80-43bb-b900-382c33def370" />
