### PR TITLE
Add x42 autotune (fat1) plugin

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ qt_add_qml_module(easyeffects
         presets_list_model.hpp
         units.hpp
         autogain.hpp
+        autotune.hpp
         bass_enhancer.hpp
         bass_loudness.hpp
         compressor.hpp
@@ -66,6 +67,7 @@ qt_add_qml_module(easyeffects
     QML_FILES
         contents/ui/AboutPage.qml
         contents/ui/Autogain.qml
+        contents/ui/Autotune.qml
         contents/ui/BassEnhancer.qml
         contents/ui/BassLoudness.qml
         contents/ui/BlocklistDialog.qml
@@ -157,6 +159,8 @@ target_sources(easyeffects PRIVATE
     autogain.cpp
     autogain_preset.cpp
     autostart.cpp
+    autotune.cpp
+    autotune_preset.cpp
     bass_enhancer.cpp
     bass_enhancer_preset.cpp
     bass_loudness.cpp

--- a/src/autotune.cpp
+++ b/src/autotune.cpp
@@ -76,6 +76,10 @@ Autotune::Autotune(const std::string& tag, pw::Manager* pipe_manager, PipelineTy
   {
     const float lv2_mode = settings->mode() == 0 ? 0.0F : 2.0F;
     lv2_wrapper->set_control_port_value("mode", lv2_mode);
+    lv2_wrapper->sync_funcs.emplace_back([this]() {
+      const float lv2_mode = lv2_wrapper->get_control_port_value("mode");
+      settings->setMode(lv2_mode >= 1.5F ? 1 : 0);
+    });
     connect(settings, &DbAutotune::modeChanged, [this]() {
       if (this == nullptr || settings == nullptr || lv2_wrapper == nullptr) {
         return;

--- a/src/autotune.cpp
+++ b/src/autotune.cpp
@@ -72,7 +72,17 @@ Autotune::Autotune(const std::string& tag, pw::Manager* pipe_manager, PipelineTy
     }
   }
 
-  BIND_LV2_PORT("mode", mode, setMode, DbAutotune::modeChanged);
+  // UI mode: 0=Auto, 1=Manual. LV2 mode: 0=Auto, 1=MIDI, 2=Manual.
+  {
+    const float lv2_mode = settings->mode() == 0 ? 0.0F : 2.0F;
+    lv2_wrapper->set_control_port_value("mode", lv2_mode);
+    connect(settings, &DbAutotune::modeChanged, [this]() {
+      if (this == nullptr || settings == nullptr || lv2_wrapper == nullptr) {
+        return;
+      }
+      lv2_wrapper->set_control_port_value("mode", settings->mode() == 0 ? 0.0F : 2.0F);
+    });
+  }
   BIND_LV2_PORT("channelf", channelFilter, setChannelFilter, DbAutotune::channelFilterChanged);
   BIND_LV2_PORT("tuning", tuning, setTuning, DbAutotune::tuningChanged);
   BIND_LV2_PORT("bias", bias, setBias, DbAutotune::biasChanged);

--- a/src/autotune.cpp
+++ b/src/autotune.cpp
@@ -64,10 +64,9 @@ Autotune::Autotune(const std::string& tag, pw::Manager* pipe_manager, PipelineTy
 
   init_common_controls<DbAutotune>(settings);
 
-  // Find the MIDI atom input port index
   for (const auto& port : lv2_wrapper->ports) {
     if (port.type == lv2::PortType::TYPE_ATOM && port.is_input) {
-      midi_port_index = port.index;
+      atom_port_index = port.index;
       break;
     }
   }
@@ -210,12 +209,12 @@ void Autotune::process(std::span<float>& left_in,
 
   auto mono_span = std::span<float>(mono_buffer);
 
-  // Provide an empty MIDI atom sequence for the fat1 MIDI input port
-  midi_in_buf.seq.atom.size = sizeof(LV2_Atom_Sequence_Body);
-  midi_in_buf.seq.atom.type = lv2_wrapper->map_urid(LV2_ATOM__Sequence);
-  midi_in_buf.seq.body.unit = 0;
-  midi_in_buf.seq.body.pad = 0;
-  lilv_instance_connect_port(lv2_wrapper->get_instance(), midi_port_index, &midi_in_buf);
+  // fat1 requires its atom input port to be connected
+  atom_in_buf.seq.atom.size = sizeof(LV2_Atom_Sequence_Body);
+  atom_in_buf.seq.atom.type = lv2_wrapper->map_urid(LV2_ATOM__Sequence);
+  atom_in_buf.seq.body.unit = 0;
+  atom_in_buf.seq.body.pad = 0;
+  lilv_instance_connect_port(lv2_wrapper->get_instance(), atom_port_index, &atom_in_buf);
 
   lv2_wrapper->connect_data_ports(mono_span, right_in, left_out, right_out);
   lv2_wrapper->run();

--- a/src/autotune.cpp
+++ b/src/autotune.cpp
@@ -1,0 +1,234 @@
+/**
+ * Copyright © 2017-2026 Wellington Wallace
+ *
+ * This file is part of Easy Effects.
+ *
+ * Easy Effects is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easy Effects is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easy Effects. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "autotune.hpp"
+#include <qnamespace.h>
+#include <qobjectdefs.h>
+#include <qtypes.h>
+#include <QApplication>
+#include <algorithm>
+#include <format>
+#include <memory>
+#include <mutex>
+#include <span>
+#include <string>
+#include "db_manager.hpp"
+#include "easyeffects_db_autotune.h"
+#include "lv2_macros.hpp"
+#include "lv2_wrapper.hpp"
+#include "pipeline_type.hpp"
+#include "plugin_base.hpp"
+#include "pw_manager.hpp"
+#include "tags_plugin_name.hpp"
+#include "util.hpp"
+
+Autotune::Autotune(const std::string& tag, pw::Manager* pipe_manager, PipelineType pipe_type, QString instance_id)
+    : PluginBase(tag,
+                 tags::plugin_name::BaseName::autotune,
+                 tags::plugin_package::Package::x42,
+                 instance_id,
+                 pipe_manager,
+                 pipe_type),
+      settings(db::Manager::self().get_plugin_db<DbAutotune>(
+          pipe_type,
+          tags::plugin_name::BaseName::autotune + "#" + instance_id)) {
+  const auto lv2_plugin_uri = "http://gareus.org/oss/lv2/fat1";
+
+  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>(lv2_plugin_uri);
+
+  packageInstalled = lv2_wrapper->found_plugin;
+
+  if (!packageInstalled) {
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
+  }
+
+  init_common_controls<DbAutotune>(settings);
+
+  BIND_LV2_PORT("mode", mode, setMode, DbAutotune::modeChanged);
+  BIND_LV2_PORT("channelf", channelFilter, setChannelFilter, DbAutotune::channelFilterChanged);
+  BIND_LV2_PORT("tuning", tuning, setTuning, DbAutotune::tuningChanged);
+  BIND_LV2_PORT("bias", bias, setBias, DbAutotune::biasChanged);
+  BIND_LV2_PORT("filter", filter, setFilter, DbAutotune::filterChanged);
+  BIND_LV2_PORT("corr", correction, setCorrection, DbAutotune::correctionChanged);
+  BIND_LV2_PORT("offset", offset, setOffset, DbAutotune::offsetChanged);
+  BIND_LV2_PORT("bendrange", bendRange, setBendRange, DbAutotune::bendRangeChanged);
+  BIND_LV2_PORT("fastmode", fastMode, setFastMode, DbAutotune::fastModeChanged);
+
+  BIND_LV2_PORT("m00", noteC, setNoteC, DbAutotune::noteCChanged);
+  BIND_LV2_PORT("m01", noteCSharp, setNoteCSharp, DbAutotune::noteCSharpChanged);
+  BIND_LV2_PORT("m02", noteD, setNoteD, DbAutotune::noteDChanged);
+  BIND_LV2_PORT("m03", noteDSharp, setNoteDSharp, DbAutotune::noteDSharpChanged);
+  BIND_LV2_PORT("m04", noteE, setNoteE, DbAutotune::noteEChanged);
+  BIND_LV2_PORT("m05", noteF, setNoteF, DbAutotune::noteFChanged);
+  BIND_LV2_PORT("m06", noteFSharp, setNoteFSharp, DbAutotune::noteFSharpChanged);
+  BIND_LV2_PORT("m07", noteG, setNoteG, DbAutotune::noteGChanged);
+  BIND_LV2_PORT("m08", noteGSharp, setNoteGSharp, DbAutotune::noteGSharpChanged);
+  BIND_LV2_PORT("m09", noteA, setNoteA, DbAutotune::noteAChanged);
+  BIND_LV2_PORT("m10", noteASharp, setNoteASharp, DbAutotune::noteASharpChanged);
+  BIND_LV2_PORT("m11", noteB, setNoteB, DbAutotune::noteBChanged);
+}
+
+Autotune::~Autotune() {
+  stop_worker();
+
+  if (connected_to_pw) {
+    disconnect_from_pw();
+  }
+
+  settings->disconnect();
+
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
+}
+
+void Autotune::reset() {
+  settings->setDefaults();
+}
+
+void Autotune::clear_data() {
+  if (lv2_wrapper == nullptr) {
+    return;
+  }
+
+  {
+    std::scoped_lock<std::mutex> lock(data_mutex);
+
+    lv2_wrapper->destroy_instance();
+  }
+
+  setup();
+}
+
+void Autotune::setup() {
+  if (rate == 0 || n_samples == 0) {
+    return;
+  }
+
+  std::scoped_lock<std::mutex> lock(data_mutex);
+
+  if (!lv2_wrapper->found_plugin) {
+    return;
+  }
+
+  lv2_wrapper->set_n_samples(n_samples);
+
+  if (lv2_wrapper->has_instance() && rate == lv2_wrapper->get_rate()) {
+    return;
+  }
+
+  ready = false;
+
+  mono_buffer.resize(n_samples);
+
+  // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks)
+  QMetaObject::invokeMethod(
+      baseWorker,
+      [this] {
+        lv2_wrapper->create_instance(rate);
+
+        std::scoped_lock<std::mutex> lock(data_mutex);
+
+        ready = true;
+      },
+      Qt::QueuedConnection);
+  // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
+}
+
+void Autotune::process(std::span<float>& left_in,
+                       std::span<float>& right_in,
+                       std::span<float>& left_out,
+                       std::span<float>& right_out) {
+  std::scoped_lock<std::mutex> lock(data_mutex);
+
+  if (bypass) {
+    std::ranges::copy(left_in, left_out.begin());
+    std::ranges::copy(right_in, right_out.begin());
+
+    return;
+  }
+
+  if (!ready) {
+    std::ranges::copy(left_in, left_out.begin());
+    std::ranges::copy(right_in, right_out.begin());
+
+    if (output_gain != 1.0F) {
+      apply_gain(left_out, right_out, output_gain);
+    }
+
+    return;
+  }
+
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
+
+  // fat1 is mono — mix stereo to mono for processing
+  for (size_t i = 0; i < left_in.size(); i++) {
+    mono_buffer[i] = (left_in[i] + right_in[i]) * 0.5F;
+  }
+
+  auto mono_span = std::span<float>(mono_buffer);
+
+  lv2_wrapper->connect_data_ports(mono_span, right_in, left_out, right_out);
+  lv2_wrapper->run();
+
+  // left_out now has the processed mono signal; copy to right_out
+  std::ranges::copy(left_out, right_out.begin());
+
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
+
+  const auto lv = static_cast<uint>(lv2_wrapper->get_control_port_value("latency"));
+
+  if (latency_n_frames != lv) {
+    latency_n_frames = lv;
+
+    latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+
+    util::debug(std::format("{}{} latency: {} s", log_tag, name.toStdString(), latency_value));
+
+    update_filter_params();
+  }
+
+  if (updateLevelMeters) {
+    get_peaks(left_in, right_in, left_out, right_out);
+
+    pitch_error = lv2_wrapper->get_control_port_value("error");
+    pitch_bend = lv2_wrapper->get_control_port_value("bend");
+  }
+}
+
+void Autotune::process([[maybe_unused]] std::span<float>& left_in,
+                       [[maybe_unused]] std::span<float>& right_in,
+                       [[maybe_unused]] std::span<float>& left_out,
+                       [[maybe_unused]] std::span<float>& right_out,
+                       [[maybe_unused]] std::span<float>& probe_left,
+                       [[maybe_unused]] std::span<float>& probe_right) {}
+
+auto Autotune::get_latency_seconds() -> float {
+  return this->latency_value;
+}
+
+float Autotune::getPitchError() const {
+  return pitch_error;
+}
+
+float Autotune::getPitchBend() const {
+  return pitch_bend;
+}

--- a/src/autotune.cpp
+++ b/src/autotune.cpp
@@ -81,7 +81,7 @@ Autotune::Autotune(const std::string& tag, pw::Manager* pipe_manager, PipelineTy
       settings->setMode(lv2_mode >= 1.5F ? 1 : 0);
     });
     connect(settings, &DbAutotune::modeChanged, [this]() {
-      if (this == nullptr || settings == nullptr || lv2_wrapper == nullptr) {
+      if (this == nullptr || settings == nullptr || lv2_wrapper == nullptr) {  // NOLINT
         return;
       }
       lv2_wrapper->set_control_port_value("mode", settings->mode() == 0 ? 0.0F : 2.0F);

--- a/src/autotune.cpp
+++ b/src/autotune.cpp
@@ -18,6 +18,10 @@
  */
 
 #include "autotune.hpp"
+#include <lilv/lilv.h>
+#include <lv2/atom/atom.h>
+#include <lv2/atom/util.h>
+#include <lv2/urid/urid.h>
 #include <qnamespace.h>
 #include <qobjectdefs.h>
 #include <qtypes.h>
@@ -59,6 +63,14 @@ Autotune::Autotune(const std::string& tag, pw::Manager* pipe_manager, PipelineTy
   }
 
   init_common_controls<DbAutotune>(settings);
+
+  // Find the MIDI atom input port index
+  for (const auto& port : lv2_wrapper->ports) {
+    if (port.type == lv2::PortType::TYPE_ATOM && port.is_input) {
+      midi_port_index = port.index;
+      break;
+    }
+  }
 
   BIND_LV2_PORT("mode", mode, setMode, DbAutotune::modeChanged);
   BIND_LV2_PORT("channelf", channelFilter, setChannelFilter, DbAutotune::channelFilterChanged);
@@ -183,6 +195,13 @@ void Autotune::process(std::span<float>& left_in,
   }
 
   auto mono_span = std::span<float>(mono_buffer);
+
+  // Provide an empty MIDI atom sequence for the fat1 MIDI input port
+  midi_in_buf.seq.atom.size = sizeof(LV2_Atom_Sequence_Body);
+  midi_in_buf.seq.atom.type = lv2_wrapper->map_urid(LV2_ATOM__Sequence);
+  midi_in_buf.seq.body.unit = 0;
+  midi_in_buf.seq.body.pad = 0;
+  lilv_instance_connect_port(lv2_wrapper->get_instance(), midi_port_index, &midi_in_buf);
 
   lv2_wrapper->connect_data_ports(mono_span, right_in, left_out, right_out);
   lv2_wrapper->run();

--- a/src/autotune.cpp
+++ b/src/autotune.cpp
@@ -139,13 +139,13 @@ void Autotune::setup() {
 
   lv2_wrapper->set_n_samples(n_samples);
 
+  mono_buffer.resize(n_samples);
+
   if (lv2_wrapper->has_instance() && rate == lv2_wrapper->get_rate()) {
     return;
   }
 
   ready = false;
-
-  mono_buffer.resize(n_samples);
 
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks)
   QMetaObject::invokeMethod(

--- a/src/autotune.cpp
+++ b/src/autotune.cpp
@@ -229,7 +229,6 @@ void Autotune::process(std::span<float>& left_in,
     get_peaks(left_in, right_in, left_out, right_out);
 
     pitch_error = lv2_wrapper->get_control_port_value("error");
-    pitch_bend = lv2_wrapper->get_control_port_value("bend");
   }
 }
 
@@ -246,8 +245,4 @@ auto Autotune::get_latency_seconds() -> float {
 
 float Autotune::getPitchError() const {
   return pitch_error;
-}
-
-float Autotune::getPitchBend() const {
-  return pitch_bend;
 }

--- a/src/autotune.hpp
+++ b/src/autotune.hpp
@@ -1,0 +1,82 @@
+/**
+ * Copyright © 2017-2026 Wellington Wallace
+ *
+ * This file is part of Easy Effects.
+ *
+ * Easy Effects is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easy Effects is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easy Effects. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <qqmlintegration.h>
+#include <qtmetamacros.h>
+#include <qtypes.h>
+#include <QString>
+#include <span>
+#include <string>
+#include <vector>
+#include "easyeffects_db_autotune.h"
+#include "pipeline_type.hpp"
+#include "plugin_base.hpp"
+#include "pw_manager.hpp"
+
+class Autotune : public PluginBase {
+  Q_OBJECT
+  QML_NAMED_ELEMENT(BackendAutotune)
+  QML_UNCREATABLE("Use the c++ instance")
+
+ public:
+  Autotune(const std::string& tag, pw::Manager* pipe_manager, PipelineType pipe_type, QString instance_id);
+  Autotune(const Autotune&) = delete;
+  auto operator=(const Autotune&) -> Autotune& = delete;
+  Autotune(const Autotune&&) = delete;
+  auto operator=(const Autotune&&) -> Autotune& = delete;
+  ~Autotune() override;
+
+  void reset() override;
+
+  void clear_data() override;
+
+  void setup() override;
+
+  void process(std::span<float>& left_in,
+               std::span<float>& right_in,
+               std::span<float>& left_out,
+               std::span<float>& right_out) override;
+
+  void process(std::span<float>& left_in,
+               std::span<float>& right_in,
+               std::span<float>& left_out,
+               std::span<float>& right_out,
+               std::span<float>& probe_left,
+               std::span<float>& probe_right) override;
+
+  auto get_latency_seconds() -> float override;
+
+  Q_INVOKABLE [[nodiscard]] float getPitchError() const;
+
+  Q_INVOKABLE [[nodiscard]] float getPitchBend() const;
+
+ private:
+  bool ready = false;
+
+  uint latency_n_frames = 0U;
+
+  float pitch_error = 0.0F;
+  float pitch_bend = 0.0F;
+
+  std::vector<float> mono_buffer;
+
+  DbAutotune* settings = nullptr;
+};

--- a/src/autotune.hpp
+++ b/src/autotune.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <lv2/atom/atom.h>
 #include <qqmlintegration.h>
 #include <qtmetamacros.h>
 #include <qtypes.h>
@@ -77,6 +78,13 @@ class Autotune : public PluginBase {
   float pitch_bend = 0.0F;
 
   std::vector<float> mono_buffer;
+
+  // Empty MIDI atom sequence buffer for the fat1 MIDI input port
+  struct {
+    LV2_Atom_Sequence seq;
+  } midi_in_buf{};
+
+  uint midi_port_index = 0U;
 
   DbAutotune* settings = nullptr;
 };

--- a/src/autotune.hpp
+++ b/src/autotune.hpp
@@ -76,12 +76,11 @@ class Autotune : public PluginBase {
 
   std::vector<float> mono_buffer;
 
-  // Empty MIDI atom sequence buffer for the fat1 MIDI input port
   struct {
     LV2_Atom_Sequence seq;
-  } midi_in_buf{};
+  } atom_in_buf{};
 
-  uint midi_port_index = 0U;
+  uint atom_port_index = 0U;
 
   DbAutotune* settings = nullptr;
 };

--- a/src/autotune.hpp
+++ b/src/autotune.hpp
@@ -67,15 +67,12 @@ class Autotune : public PluginBase {
 
   Q_INVOKABLE [[nodiscard]] float getPitchError() const;
 
-  Q_INVOKABLE [[nodiscard]] float getPitchBend() const;
-
  private:
   bool ready = false;
 
   uint latency_n_frames = 0U;
 
   float pitch_error = 0.0F;
-  float pitch_bend = 0.0F;
 
   std::vector<float> mono_buffer;
 

--- a/src/autotune_preset.cpp
+++ b/src/autotune_preset.cpp
@@ -49,6 +49,10 @@ void AutotunePreset::save(nlohmann::json& json) {
 
   json[section][instance_name]["offset"] = settings->offset();
 
+  json[section][instance_name]["bend-range"] = settings->bendRange();
+
+  json[section][instance_name]["channel-filter"] = settings->channelFilter();
+
   json[section][instance_name]["fast-mode"] = settings->fastMode();
 
   json[section][instance_name]["note-c"] = settings->noteC();
@@ -85,6 +89,8 @@ void AutotunePreset::load(const nlohmann::json& json) {
   UPDATE_PROPERTY("filter", Filter);
   UPDATE_PROPERTY("correction", Correction);
   UPDATE_PROPERTY("offset", Offset);
+  UPDATE_PROPERTY("bend-range", BendRange);
+  UPDATE_PROPERTY("channel-filter", ChannelFilter);
   UPDATE_PROPERTY("fast-mode", FastMode);
   UPDATE_PROPERTY("note-c", NoteC);
   UPDATE_PROPERTY("note-c-sharp", NoteCSharp);

--- a/src/autotune_preset.cpp
+++ b/src/autotune_preset.cpp
@@ -39,8 +39,6 @@ void AutotunePreset::save(nlohmann::json& json) {
 
   json[section][instance_name]["mode"] = settings->defaultModeLabelsValue()[settings->mode()].toStdString();
 
-  json[section][instance_name]["channel-filter"] = settings->channelFilter();
-
   json[section][instance_name]["tuning"] = settings->tuning();
 
   json[section][instance_name]["bias"] = settings->bias();
@@ -50,8 +48,6 @@ void AutotunePreset::save(nlohmann::json& json) {
   json[section][instance_name]["correction"] = settings->correction();
 
   json[section][instance_name]["offset"] = settings->offset();
-
-  json[section][instance_name]["bend-range"] = settings->bendRange();
 
   json[section][instance_name]["fast-mode"] = settings->fastMode();
 
@@ -84,13 +80,11 @@ void AutotunePreset::load(const nlohmann::json& json) {
   UPDATE_PROPERTY("bypass", Bypass);
   UPDATE_PROPERTY("input-gain", InputGain);
   UPDATE_PROPERTY("output-gain", OutputGain);
-  UPDATE_PROPERTY("channel-filter", ChannelFilter);
   UPDATE_PROPERTY("tuning", Tuning);
   UPDATE_PROPERTY("bias", Bias);
   UPDATE_PROPERTY("filter", Filter);
   UPDATE_PROPERTY("correction", Correction);
   UPDATE_PROPERTY("offset", Offset);
-  UPDATE_PROPERTY("bend-range", BendRange);
   UPDATE_PROPERTY("fast-mode", FastMode);
   UPDATE_PROPERTY("note-c", NoteC);
   UPDATE_PROPERTY("note-c-sharp", NoteCSharp);

--- a/src/autotune_preset.cpp
+++ b/src/autotune_preset.cpp
@@ -1,0 +1,109 @@
+/**
+ * Copyright © 2017-2026 Wellington Wallace
+ *
+ * This file is part of Easy Effects.
+ *
+ * Easy Effects is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easy Effects is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easy Effects. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "autotune_preset.hpp"
+#include <nlohmann/json_fwd.hpp>
+#include <string>
+#include "easyeffects_db_autotune.h"
+#include "pipeline_type.hpp"
+#include "plugin_preset_base.hpp"
+#include "presets_macros.hpp"
+
+AutotunePreset::AutotunePreset(PipelineType pipeline_type, const std::string& instance_name)
+    : PluginPresetBase(pipeline_type, instance_name) {
+  settings = get_db_instance<DbAutotune>(pipeline_type);
+}
+
+void AutotunePreset::save(nlohmann::json& json) {
+  json[section][instance_name]["bypass"] = settings->bypass();
+
+  json[section][instance_name]["input-gain"] = settings->inputGain();
+
+  json[section][instance_name]["output-gain"] = settings->outputGain();
+
+  json[section][instance_name]["mode"] = settings->defaultModeLabelsValue()[settings->mode()].toStdString();
+
+  json[section][instance_name]["channel-filter"] = settings->channelFilter();
+
+  json[section][instance_name]["tuning"] = settings->tuning();
+
+  json[section][instance_name]["bias"] = settings->bias();
+
+  json[section][instance_name]["filter"] = settings->filter();
+
+  json[section][instance_name]["correction"] = settings->correction();
+
+  json[section][instance_name]["offset"] = settings->offset();
+
+  json[section][instance_name]["bend-range"] = settings->bendRange();
+
+  json[section][instance_name]["fast-mode"] = settings->fastMode();
+
+  json[section][instance_name]["note-c"] = settings->noteC();
+
+  json[section][instance_name]["note-c-sharp"] = settings->noteCSharp();
+
+  json[section][instance_name]["note-d"] = settings->noteD();
+
+  json[section][instance_name]["note-d-sharp"] = settings->noteDSharp();
+
+  json[section][instance_name]["note-e"] = settings->noteE();
+
+  json[section][instance_name]["note-f"] = settings->noteF();
+
+  json[section][instance_name]["note-f-sharp"] = settings->noteFSharp();
+
+  json[section][instance_name]["note-g"] = settings->noteG();
+
+  json[section][instance_name]["note-g-sharp"] = settings->noteGSharp();
+
+  json[section][instance_name]["note-a"] = settings->noteA();
+
+  json[section][instance_name]["note-a-sharp"] = settings->noteASharp();
+
+  json[section][instance_name]["note-b"] = settings->noteB();
+}
+
+void AutotunePreset::load(const nlohmann::json& json) {
+  UPDATE_PROPERTY("bypass", Bypass);
+  UPDATE_PROPERTY("input-gain", InputGain);
+  UPDATE_PROPERTY("output-gain", OutputGain);
+  UPDATE_PROPERTY("channel-filter", ChannelFilter);
+  UPDATE_PROPERTY("tuning", Tuning);
+  UPDATE_PROPERTY("bias", Bias);
+  UPDATE_PROPERTY("filter", Filter);
+  UPDATE_PROPERTY("correction", Correction);
+  UPDATE_PROPERTY("offset", Offset);
+  UPDATE_PROPERTY("bend-range", BendRange);
+  UPDATE_PROPERTY("fast-mode", FastMode);
+  UPDATE_PROPERTY("note-c", NoteC);
+  UPDATE_PROPERTY("note-c-sharp", NoteCSharp);
+  UPDATE_PROPERTY("note-d", NoteD);
+  UPDATE_PROPERTY("note-d-sharp", NoteDSharp);
+  UPDATE_PROPERTY("note-e", NoteE);
+  UPDATE_PROPERTY("note-f", NoteF);
+  UPDATE_PROPERTY("note-f-sharp", NoteFSharp);
+  UPDATE_PROPERTY("note-g", NoteG);
+  UPDATE_PROPERTY("note-g-sharp", NoteGSharp);
+  UPDATE_PROPERTY("note-a", NoteA);
+  UPDATE_PROPERTY("note-a-sharp", NoteASharp);
+  UPDATE_PROPERTY("note-b", NoteB);
+
+  UPDATE_ENUM_LIKE_PROPERTY("mode", Mode);
+}

--- a/src/autotune_preset.hpp
+++ b/src/autotune_preset.hpp
@@ -1,0 +1,38 @@
+/**
+ * Copyright © 2017-2026 Wellington Wallace
+ *
+ * This file is part of Easy Effects.
+ *
+ * Easy Effects is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easy Effects is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easy Effects. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+#include <string>
+#include "easyeffects_db_autotune.h"
+#include "pipeline_type.hpp"
+#include "plugin_preset_base.hpp"
+
+class AutotunePreset : public PluginPresetBase {
+ public:
+  explicit AutotunePreset(PipelineType pipeline_type, const std::string& instance_name);
+
+ private:
+  DbAutotune* settings = nullptr;
+
+  void save(nlohmann::json& json) override;
+
+  void load(const nlohmann::json& json) override;
+};

--- a/src/contents/kcfg/easyeffects_db_autotune.kcfg
+++ b/src/contents/kcfg/easyeffects_db_autotune.kcfg
@@ -24,7 +24,7 @@
             <default>0</default>
         </entry>
         <entry name="modeLabels" type="StringList">
-            <default>Auto,MIDI,Manual</default>
+            <default>Auto,Manual</default>
         </entry>
         <entry name="mode" type="Int">
             <label>Mode</label>

--- a/src/contents/kcfg/easyeffects_db_autotune.kcfg
+++ b/src/contents/kcfg/easyeffects_db_autotune.kcfg
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kcfg xmlns="http://www.kde.org/standards/kcfg/1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0 http://www.kde.org/standards/kcfg/1.0/kcfg.xsd">
+    <kcfgfile name="easyeffects/db/autotunerc">
+        <parameter name="masterGroup" />
+        <parameter name="instanceIndex" />
+    </kcfgfile>
+    <group parentGroupName="$(masterGroup)" name="Autotune#$(instanceIndex)">
+        <entry name="bypass" type="Bool">
+            <label></label>
+            <default>false</default>
+        </entry>
+        <entry name="inputGain" type="Double">
+            <label></label>
+            <min>-36</min>
+            <max>36</max>
+            <default>0</default>
+        </entry>
+        <entry name="outputGain" type="Double">
+            <label></label>
+            <min>-36</min>
+            <max>36</max>
+            <default>0</default>
+        </entry>
+        <entry name="modeLabels" type="StringList">
+            <default>Auto,MIDI,Manual</default>
+        </entry>
+        <entry name="mode" type="Int">
+            <label>Mode</label>
+            <default>0</default>
+        </entry>
+        <entry name="channelFilter" type="Int">
+            <label>MIDI Filter Channel</label>
+            <min>0</min>
+            <max>16</max>
+            <default>0</default>
+        </entry>
+        <entry name="tuning" type="Double">
+            <label>Tuning frequency</label>
+            <min>400.0</min>
+            <max>480.0</max>
+            <default>440.0</default>
+        </entry>
+        <entry name="bias" type="Double">
+            <label>Bias</label>
+            <min>0.0</min>
+            <max>1.0</max>
+            <default>0.5</default>
+        </entry>
+        <entry name="filter" type="Double">
+            <label>Filter</label>
+            <min>0.02</min>
+            <max>0.5</max>
+            <default>0.1</default>
+        </entry>
+        <entry name="correction" type="Double">
+            <label>Correction</label>
+            <min>0.0</min>
+            <max>1.0</max>
+            <default>1.0</default>
+        </entry>
+        <entry name="offset" type="Double">
+            <label>Offset</label>
+            <min>-2.0</min>
+            <max>2.0</max>
+            <default>0.0</default>
+        </entry>
+        <entry name="bendRange" type="Double">
+            <label>Pitch Bend Range</label>
+            <min>0.0</min>
+            <max>7.0</max>
+            <default>2.0</default>
+        </entry>
+        <entry name="fastMode" type="Bool">
+            <label>Fast Correction</label>
+            <default>false</default>
+        </entry>
+        <entry name="noteC" type="Bool">
+            <label></label>
+            <default>true</default>
+        </entry>
+        <entry name="noteCSharp" type="Bool">
+            <label></label>
+            <default>true</default>
+        </entry>
+        <entry name="noteD" type="Bool">
+            <label></label>
+            <default>true</default>
+        </entry>
+        <entry name="noteDSharp" type="Bool">
+            <label></label>
+            <default>true</default>
+        </entry>
+        <entry name="noteE" type="Bool">
+            <label></label>
+            <default>true</default>
+        </entry>
+        <entry name="noteF" type="Bool">
+            <label></label>
+            <default>true</default>
+        </entry>
+        <entry name="noteFSharp" type="Bool">
+            <label></label>
+            <default>true</default>
+        </entry>
+        <entry name="noteG" type="Bool">
+            <label></label>
+            <default>true</default>
+        </entry>
+        <entry name="noteGSharp" type="Bool">
+            <label></label>
+            <default>true</default>
+        </entry>
+        <entry name="noteA" type="Bool">
+            <label></label>
+            <default>true</default>
+        </entry>
+        <entry name="noteASharp" type="Bool">
+            <label></label>
+            <default>true</default>
+        </entry>
+        <entry name="noteB" type="Bool">
+            <label></label>
+            <default>true</default>
+        </entry>
+    </group>
+</kcfg>

--- a/src/contents/kcfg/easyeffects_db_autotune.kcfg
+++ b/src/contents/kcfg/easyeffects_db_autotune.kcfg
@@ -31,7 +31,7 @@
             <default>0</default>
         </entry>
         <entry name="channelFilter" type="Int">
-            <label>MIDI Filter Channel</label>
+            <label>Filter Channel</label>
             <min>0</min>
             <max>16</max>
             <default>0</default>
@@ -67,7 +67,7 @@
             <default>0.0</default>
         </entry>
         <entry name="bendRange" type="Double">
-            <label>Pitch Bend Range</label>
+            <label>Bend Range</label>
             <min>0.0</min>
             <max>7.0</max>
             <default>2.0</default>

--- a/src/contents/kcfg/easyeffects_db_autotune.kcfgc
+++ b/src/contents/kcfg/easyeffects_db_autotune.kcfgc
@@ -1,0 +1,11 @@
+File=easyeffects_db_autotune.kcfg
+ClassName=DbAutotune
+Inherits=KConfigBaseEE
+IncludeFiles="kconfig_base_ee.hpp"
+Mutators=true
+Notifiers=true
+DefaultValueGetters=true
+Singleton=false
+GenerateProperties=true
+QmlUncreatable=true
+QmlRegistration=true

--- a/src/contents/ui/Autotune.qml
+++ b/src/contents/ui/Autotune.qml
@@ -33,6 +33,37 @@ Kirigami.ScrollablePage {
     required property EffectsBase pipelineInstance
     property BackendAutotune pluginBackend
 
+    // Scale definitions: each is an array of 12 booleans [C, C#, D, D#, E, F, F#, G, G#, A, A#, B]
+    readonly property var scalePatterns: {
+        // Major: W-W-H-W-W-W-H
+        const major = [1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1];
+        // Minor (natural): W-H-W-W-H-W-W
+        const minor = [1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0];
+        return { "major": major, "minor": minor };
+    }
+
+    readonly property var noteNames: ["C", "Db", "D", "Eb", "E", "F", "F#", "G", "Ab", "A", "Bb", "B"]
+
+    function applyScale(rootIndex: int, scaleType: string) {
+        const pattern = scalePatterns[scaleType];
+        const notes = [];
+        for (let i = 0; i < 12; i++) {
+            notes.push(pattern[(12 + i - rootIndex) % 12] === 1);
+        }
+        pluginDB.noteC = notes[0];
+        pluginDB.noteCSharp = notes[1];
+        pluginDB.noteD = notes[2];
+        pluginDB.noteDSharp = notes[3];
+        pluginDB.noteE = notes[4];
+        pluginDB.noteF = notes[5];
+        pluginDB.noteFSharp = notes[6];
+        pluginDB.noteG = notes[7];
+        pluginDB.noteGSharp = notes[8];
+        pluginDB.noteA = notes[9];
+        pluginDB.noteASharp = notes[10];
+        pluginDB.noteB = notes[11];
+    }
+
     function updateMeters() {
         if (!pluginBackend)
             return;
@@ -53,255 +84,311 @@ Kirigami.ScrollablePage {
         Kirigami.CardsLayout {
             id: cardLayout
 
-            Layout.fillWidth: true
             minimumColumnWidth: Kirigami.Units.gridUnit * 17
-            maximumColumns: 6
             uniformCellWidths: true
 
-            EeCard {
-                title: i18n("Tuning") // qmllint disable
+            Kirigami.Card {
 
-                GridLayout {
-                    columns: 2
-                    uniformCellWidths: true
-                    rowSpacing: 0
+                header: Kirigami.Heading {
+                    text: i18n("Tuning") // qmllint disable
+                    level: 2
+                }
 
-                    FormCard.FormComboBoxDelegate {
-                        id: mode
+                contentItem: ColumnLayout {
+                    GridLayout {
+                        columns: 2
+                        uniformCellWidths: true
+                        Layout.alignment: Qt.AlignTop
 
-                        Layout.columnSpan: 2
-                        verticalPadding: Kirigami.Units.largeSpacing
-                        text: i18n("Mode") // qmllint disable
-                        displayMode: FormCard.FormComboBoxDelegate.ComboBox
-                        currentIndex: autotunePage.pluginDB.mode
-                        editable: false
-                        model: [i18n("Auto"), i18n("MIDI"), i18n("Manual")] //qmllint disable
-                        onActivated: idx => {
-                            autotunePage.pluginDB.mode = idx;
+                        FormCard.FormComboBoxDelegate {
+                            id: mode
+
+                            Layout.columnSpan: 2
+                            verticalPadding: Kirigami.Units.largeSpacing
+                            text: i18n("Mode") // qmllint disable
+                            displayMode: FormCard.FormComboBoxDelegate.ComboBox
+                            currentIndex: autotunePage.pluginDB.mode
+                            editable: false
+                            model: [i18n("Auto"), i18n("MIDI"), i18n("Manual")] //qmllint disable
+                            onActivated: idx => {
+                                autotunePage.pluginDB.mode = idx;
+                            }
                         }
-                    }
 
-                    EeSpinBox {
-                        id: tuning
+                        EeSpinBox {
+                            id: tuning
 
-                        label: i18n("Tuning") // qmllint disable
-                        labelAbove: true
-                        spinboxLayoutFillWidth: true
-                        from: autotunePage.pluginDB.getMinValue("tuning")
-                        to: autotunePage.pluginDB.getMaxValue("tuning")
-                        value: autotunePage.pluginDB.tuning
-                        decimals: 1
-                        stepSize: 0.5
-                        unit: Units.hz
-                        onValueModified: v => {
-                            autotunePage.pluginDB.tuning = v;
+                            label: i18n("Tuning") // qmllint disable
+                            labelAbove: true
+                            spinboxLayoutFillWidth: true
+                            from: autotunePage.pluginDB.getMinValue("tuning")
+                            to: autotunePage.pluginDB.getMaxValue("tuning")
+                            value: autotunePage.pluginDB.tuning
+                            decimals: 1
+                            stepSize: 0.5
+                            unit: Units.hz
+                            onValueModified: v => {
+                                autotunePage.pluginDB.tuning = v;
+                            }
                         }
-                    }
 
-                    EeSpinBox {
-                        id: correction
+                        EeSpinBox {
+                            id: correction
 
-                        label: i18n("Correction") // qmllint disable
-                        labelAbove: true
-                        spinboxLayoutFillWidth: true
-                        from: autotunePage.pluginDB.getMinValue("correction")
-                        to: autotunePage.pluginDB.getMaxValue("correction")
-                        value: autotunePage.pluginDB.correction
-                        decimals: 2
-                        stepSize: 0.01
-                        onValueModified: v => {
-                            autotunePage.pluginDB.correction = v;
+                            label: i18n("Correction") // qmllint disable
+                            labelAbove: true
+                            spinboxLayoutFillWidth: true
+                            from: autotunePage.pluginDB.getMinValue("correction")
+                            to: autotunePage.pluginDB.getMaxValue("correction")
+                            value: autotunePage.pluginDB.correction
+                            decimals: 2
+                            stepSize: 0.01
+                            onValueModified: v => {
+                                autotunePage.pluginDB.correction = v;
+                            }
                         }
-                    }
 
-                    EeSpinBox {
-                        id: bias
+                        EeSpinBox {
+                            id: bias
 
-                        label: i18n("Bias") // qmllint disable
-                        labelAbove: true
-                        spinboxLayoutFillWidth: true
-                        from: autotunePage.pluginDB.getMinValue("bias")
-                        to: autotunePage.pluginDB.getMaxValue("bias")
-                        value: autotunePage.pluginDB.bias
-                        decimals: 2
-                        stepSize: 0.01
-                        onValueModified: v => {
-                            autotunePage.pluginDB.bias = v;
+                            label: i18n("Bias") // qmllint disable
+                            labelAbove: true
+                            spinboxLayoutFillWidth: true
+                            from: autotunePage.pluginDB.getMinValue("bias")
+                            to: autotunePage.pluginDB.getMaxValue("bias")
+                            value: autotunePage.pluginDB.bias
+                            decimals: 2
+                            stepSize: 0.01
+                            onValueModified: v => {
+                                autotunePage.pluginDB.bias = v;
+                            }
                         }
-                    }
 
-                    EeSpinBox {
-                        id: filterControl
+                        EeSpinBox {
+                            id: filterControl
 
-                        label: i18n("Filter") // qmllint disable
-                        labelAbove: true
-                        spinboxLayoutFillWidth: true
-                        from: autotunePage.pluginDB.getMinValue("filter")
-                        to: autotunePage.pluginDB.getMaxValue("filter")
-                        value: autotunePage.pluginDB.filter
-                        decimals: 2
-                        stepSize: 0.01
-                        onValueModified: v => {
-                            autotunePage.pluginDB.filter = v;
+                            label: i18n("Filter") // qmllint disable
+                            labelAbove: true
+                            spinboxLayoutFillWidth: true
+                            from: autotunePage.pluginDB.getMinValue("filter")
+                            to: autotunePage.pluginDB.getMaxValue("filter")
+                            value: autotunePage.pluginDB.filter
+                            decimals: 2
+                            stepSize: 0.01
+                            onValueModified: v => {
+                                autotunePage.pluginDB.filter = v;
+                            }
                         }
-                    }
 
-                    EeSpinBox {
-                        id: offset
+                        EeSpinBox {
+                            id: offset
 
-                        label: i18n("Offset") // qmllint disable
-                        labelAbove: true
-                        spinboxLayoutFillWidth: true
-                        from: autotunePage.pluginDB.getMinValue("offset")
-                        to: autotunePage.pluginDB.getMaxValue("offset")
-                        value: autotunePage.pluginDB.offset
-                        decimals: 2
-                        stepSize: 0.01
-                        onValueModified: v => {
-                            autotunePage.pluginDB.offset = v;
+                            label: i18n("Offset") // qmllint disable
+                            labelAbove: true
+                            spinboxLayoutFillWidth: true
+                            from: autotunePage.pluginDB.getMinValue("offset")
+                            to: autotunePage.pluginDB.getMaxValue("offset")
+                            value: autotunePage.pluginDB.offset
+                            decimals: 2
+                            stepSize: 0.01
+                            onValueModified: v => {
+                                autotunePage.pluginDB.offset = v;
+                            }
                         }
-                    }
 
-                    EeSpinBox {
-                        id: bendRange
+                        EeSpinBox {
+                            id: bendRange
 
-                        label: i18n("Pitch bend range") // qmllint disable
-                        labelAbove: true
-                        spinboxLayoutFillWidth: true
-                        from: autotunePage.pluginDB.getMinValue("bendRange")
-                        to: autotunePage.pluginDB.getMaxValue("bendRange")
-                        value: autotunePage.pluginDB.bendRange
-                        decimals: 1
-                        stepSize: 0.5
-                        onValueModified: v => {
-                            autotunePage.pluginDB.bendRange = v;
+                            label: i18n("Pitch bend range") // qmllint disable
+                            labelAbove: true
+                            spinboxLayoutFillWidth: true
+                            from: autotunePage.pluginDB.getMinValue("bendRange")
+                            to: autotunePage.pluginDB.getMaxValue("bendRange")
+                            value: autotunePage.pluginDB.bendRange
+                            decimals: 1
+                            stepSize: 0.5
+                            onValueModified: v => {
+                                autotunePage.pluginDB.bendRange = v;
+                            }
                         }
                     }
                 }
             }
 
-            EeCard {
-                title: i18n("Notes") // qmllint disable
+            Kirigami.Card {
 
-                GridLayout {
-                    columns: 2
-                    uniformCellWidths: true
-                    rowSpacing: 0
+                header: Kirigami.Heading {
+                    text: i18n("Scale") // qmllint disable
+                    level: 2
+                }
 
-                    EeSwitch {
-                        label: "C"
-                        isChecked: autotunePage.pluginDB.noteC
-                        onCheckedChanged: {
-                            if (isChecked !== autotunePage.pluginDB.noteC)
-                                autotunePage.pluginDB.noteC = isChecked;
+                contentItem: ColumnLayout {
+                    GridLayout {
+                        columns: 2
+                        uniformCellWidths: true
+                        Layout.alignment: Qt.AlignTop
+
+                        FormCard.FormComboBoxDelegate {
+                            id: scaleRoot
+
+                            text: i18n("Root note") // qmllint disable
+                            displayMode: FormCard.FormComboBoxDelegate.ComboBox
+                            currentIndex: 0
+                            editable: false
+                            model: autotunePage.noteNames
+                        }
+
+                        FormCard.FormComboBoxDelegate {
+                            id: scaleType
+
+                            text: i18n("Scale type") // qmllint disable
+                            displayMode: FormCard.FormComboBoxDelegate.ComboBox
+                            currentIndex: 0
+                            editable: false
+                            model: [i18n("Major"), i18n("Minor")] // qmllint disable
+                        }
+
+                        Controls.Button {
+                            Layout.columnSpan: 2
+                            Layout.fillWidth: true
+                            text: i18n("Apply scale") // qmllint disable
+                            icon.name: "dialog-ok-apply-symbolic"
+                            onClicked: {
+                                autotunePage.applyScale(scaleRoot.currentIndex, scaleType.currentIndex === 0 ? "major" : "minor");
+                            }
                         }
                     }
 
-                    EeSwitch {
-                        label: "C#"
-                        isChecked: autotunePage.pluginDB.noteCSharp
-                        onCheckedChanged: {
-                            if (isChecked !== autotunePage.pluginDB.noteCSharp)
-                                autotunePage.pluginDB.noteCSharp = isChecked;
-                        }
-                    }
+                    GridLayout {
+                        columns: 2
+                        uniformCellWidths: true
+                        rowSpacing: 0
 
-                    EeSwitch {
-                        label: "D"
-                        isChecked: autotunePage.pluginDB.noteD
-                        onCheckedChanged: {
-                            if (isChecked !== autotunePage.pluginDB.noteD)
-                                autotunePage.pluginDB.noteD = isChecked;
+                        EeSwitch {
+                            label: "C"
+                            isChecked: autotunePage.pluginDB.noteC
+                            onCheckedChanged: {
+                                if (isChecked !== autotunePage.pluginDB.noteC)
+                                    autotunePage.pluginDB.noteC = isChecked;
+                            }
                         }
-                    }
 
-                    EeSwitch {
-                        label: "D#"
-                        isChecked: autotunePage.pluginDB.noteDSharp
-                        onCheckedChanged: {
-                            if (isChecked !== autotunePage.pluginDB.noteDSharp)
-                                autotunePage.pluginDB.noteDSharp = isChecked;
+                        EeSwitch {
+                            label: "C#"
+                            isChecked: autotunePage.pluginDB.noteCSharp
+                            onCheckedChanged: {
+                                if (isChecked !== autotunePage.pluginDB.noteCSharp)
+                                    autotunePage.pluginDB.noteCSharp = isChecked;
+                            }
                         }
-                    }
 
-                    EeSwitch {
-                        label: "E"
-                        isChecked: autotunePage.pluginDB.noteE
-                        onCheckedChanged: {
-                            if (isChecked !== autotunePage.pluginDB.noteE)
-                                autotunePage.pluginDB.noteE = isChecked;
+                        EeSwitch {
+                            label: "D"
+                            isChecked: autotunePage.pluginDB.noteD
+                            onCheckedChanged: {
+                                if (isChecked !== autotunePage.pluginDB.noteD)
+                                    autotunePage.pluginDB.noteD = isChecked;
+                            }
                         }
-                    }
 
-                    EeSwitch {
-                        label: "F"
-                        isChecked: autotunePage.pluginDB.noteF
-                        onCheckedChanged: {
-                            if (isChecked !== autotunePage.pluginDB.noteF)
-                                autotunePage.pluginDB.noteF = isChecked;
+                        EeSwitch {
+                            label: "D#"
+                            isChecked: autotunePage.pluginDB.noteDSharp
+                            onCheckedChanged: {
+                                if (isChecked !== autotunePage.pluginDB.noteDSharp)
+                                    autotunePage.pluginDB.noteDSharp = isChecked;
+                            }
                         }
-                    }
 
-                    EeSwitch {
-                        label: "F#"
-                        isChecked: autotunePage.pluginDB.noteFSharp
-                        onCheckedChanged: {
-                            if (isChecked !== autotunePage.pluginDB.noteFSharp)
-                                autotunePage.pluginDB.noteFSharp = isChecked;
+                        EeSwitch {
+                            label: "E"
+                            isChecked: autotunePage.pluginDB.noteE
+                            onCheckedChanged: {
+                                if (isChecked !== autotunePage.pluginDB.noteE)
+                                    autotunePage.pluginDB.noteE = isChecked;
+                            }
                         }
-                    }
 
-                    EeSwitch {
-                        label: "G"
-                        isChecked: autotunePage.pluginDB.noteG
-                        onCheckedChanged: {
-                            if (isChecked !== autotunePage.pluginDB.noteG)
-                                autotunePage.pluginDB.noteG = isChecked;
+                        EeSwitch {
+                            label: "F"
+                            isChecked: autotunePage.pluginDB.noteF
+                            onCheckedChanged: {
+                                if (isChecked !== autotunePage.pluginDB.noteF)
+                                    autotunePage.pluginDB.noteF = isChecked;
+                            }
                         }
-                    }
 
-                    EeSwitch {
-                        label: "G#"
-                        isChecked: autotunePage.pluginDB.noteGSharp
-                        onCheckedChanged: {
-                            if (isChecked !== autotunePage.pluginDB.noteGSharp)
-                                autotunePage.pluginDB.noteGSharp = isChecked;
+                        EeSwitch {
+                            label: "F#"
+                            isChecked: autotunePage.pluginDB.noteFSharp
+                            onCheckedChanged: {
+                                if (isChecked !== autotunePage.pluginDB.noteFSharp)
+                                    autotunePage.pluginDB.noteFSharp = isChecked;
+                            }
                         }
-                    }
 
-                    EeSwitch {
-                        label: "A"
-                        isChecked: autotunePage.pluginDB.noteA
-                        onCheckedChanged: {
-                            if (isChecked !== autotunePage.pluginDB.noteA)
-                                autotunePage.pluginDB.noteA = isChecked;
+                        EeSwitch {
+                            label: "G"
+                            isChecked: autotunePage.pluginDB.noteG
+                            onCheckedChanged: {
+                                if (isChecked !== autotunePage.pluginDB.noteG)
+                                    autotunePage.pluginDB.noteG = isChecked;
+                            }
                         }
-                    }
 
-                    EeSwitch {
-                        label: "A#"
-                        isChecked: autotunePage.pluginDB.noteASharp
-                        onCheckedChanged: {
-                            if (isChecked !== autotunePage.pluginDB.noteASharp)
-                                autotunePage.pluginDB.noteASharp = isChecked;
+                        EeSwitch {
+                            label: "G#"
+                            isChecked: autotunePage.pluginDB.noteGSharp
+                            onCheckedChanged: {
+                                if (isChecked !== autotunePage.pluginDB.noteGSharp)
+                                    autotunePage.pluginDB.noteGSharp = isChecked;
+                            }
                         }
-                    }
 
-                    EeSwitch {
-                        label: "B"
-                        isChecked: autotunePage.pluginDB.noteB
-                        onCheckedChanged: {
-                            if (isChecked !== autotunePage.pluginDB.noteB)
-                                autotunePage.pluginDB.noteB = isChecked;
+                        EeSwitch {
+                            label: "A"
+                            isChecked: autotunePage.pluginDB.noteA
+                            onCheckedChanged: {
+                                if (isChecked !== autotunePage.pluginDB.noteA)
+                                    autotunePage.pluginDB.noteA = isChecked;
+                            }
+                        }
+
+                        EeSwitch {
+                            label: "A#"
+                            isChecked: autotunePage.pluginDB.noteASharp
+                            onCheckedChanged: {
+                                if (isChecked !== autotunePage.pluginDB.noteASharp)
+                                    autotunePage.pluginDB.noteASharp = isChecked;
+                            }
+                        }
+
+                        EeSwitch {
+                            label: "B"
+                            isChecked: autotunePage.pluginDB.noteB
+                            onCheckedChanged: {
+                                if (isChecked !== autotunePage.pluginDB.noteB)
+                                    autotunePage.pluginDB.noteB = isChecked;
+                            }
                         }
                     }
                 }
             }
+        }
 
-            EeCard {
-                title: i18n("Meters") // qmllint disable
+        RowLayout {
+            Kirigami.Card {
+                Layout.topMargin: Kirigami.Units.smallSpacing
 
-                ColumnLayout {
+                header: Kirigami.Heading {
+                    text: i18n("Level") // qmllint disable
+                    level: 2
+                }
+
+                contentItem: ColumnLayout {
+                    anchors.fill: parent
+                    spacing: Kirigami.Units.gridUnit
+
                     EeProgressBar {
                         id: pitchErrorMeter
 

--- a/src/contents/ui/Autotune.qml
+++ b/src/contents/ui/Autotune.qml
@@ -1,0 +1,388 @@
+/**
+ * Copyright © 2025-2026 Wellington Wallace
+ *
+ * This file is part of Easy Effects.
+ *
+ * Easy Effects is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easy Effects is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easy Effects. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+import QtQuick
+import QtQuick.Controls as Controls
+import QtQuick.Layouts
+import ee.ui
+import org.kde.kirigami as Kirigami
+import org.kde.kirigamiaddons.formcard as FormCard
+
+Kirigami.ScrollablePage {
+    id: autotunePage
+
+    required property string name
+    required property DbAutotune pluginDB
+    required property EffectsBase pipelineInstance
+    property BackendAutotune pluginBackend
+
+    function updateMeters() {
+        if (!pluginBackend)
+            return;
+
+        inputOutputLevels.setInputLevelLeft(pluginBackend.getInputLevelLeft());
+        inputOutputLevels.setInputLevelRight(pluginBackend.getInputLevelRight());
+        inputOutputLevels.setOutputLevelLeft(pluginBackend.getOutputLevelLeft());
+        inputOutputLevels.setOutputLevelRight(pluginBackend.getOutputLevelRight());
+        pitchErrorMeter.setValue(pluginBackend.getPitchError());
+        pitchBendMeter.setValue(pluginBackend.getPitchBend());
+    }
+
+    Component.onCompleted: {
+        pluginBackend = pipelineInstance.getPluginInstance(name);
+    }
+
+    ColumnLayout {
+        Kirigami.CardsLayout {
+            id: cardLayout
+
+            Layout.fillWidth: true
+            minimumColumnWidth: Kirigami.Units.gridUnit * 17
+            maximumColumns: 6
+            uniformCellWidths: true
+
+            EeCard {
+                title: i18n("Tuning") // qmllint disable
+
+                GridLayout {
+                    columns: 2
+                    uniformCellWidths: true
+                    rowSpacing: 0
+
+                    FormCard.FormComboBoxDelegate {
+                        id: mode
+
+                        Layout.columnSpan: 2
+                        verticalPadding: Kirigami.Units.largeSpacing
+                        text: i18n("Mode") // qmllint disable
+                        displayMode: FormCard.FormComboBoxDelegate.ComboBox
+                        currentIndex: autotunePage.pluginDB.mode
+                        editable: false
+                        model: [i18n("Auto"), i18n("MIDI"), i18n("Manual")] //qmllint disable
+                        onActivated: idx => {
+                            autotunePage.pluginDB.mode = idx;
+                        }
+                    }
+
+                    EeSpinBox {
+                        id: tuning
+
+                        label: i18n("Tuning") // qmllint disable
+                        labelAbove: true
+                        spinboxLayoutFillWidth: true
+                        from: autotunePage.pluginDB.getMinValue("tuning")
+                        to: autotunePage.pluginDB.getMaxValue("tuning")
+                        value: autotunePage.pluginDB.tuning
+                        decimals: 1
+                        stepSize: 0.5
+                        unit: Units.hz
+                        onValueModified: v => {
+                            autotunePage.pluginDB.tuning = v;
+                        }
+                    }
+
+                    EeSpinBox {
+                        id: correction
+
+                        label: i18n("Correction") // qmllint disable
+                        labelAbove: true
+                        spinboxLayoutFillWidth: true
+                        from: autotunePage.pluginDB.getMinValue("correction")
+                        to: autotunePage.pluginDB.getMaxValue("correction")
+                        value: autotunePage.pluginDB.correction
+                        decimals: 2
+                        stepSize: 0.01
+                        onValueModified: v => {
+                            autotunePage.pluginDB.correction = v;
+                        }
+                    }
+
+                    EeSpinBox {
+                        id: bias
+
+                        label: i18n("Bias") // qmllint disable
+                        labelAbove: true
+                        spinboxLayoutFillWidth: true
+                        from: autotunePage.pluginDB.getMinValue("bias")
+                        to: autotunePage.pluginDB.getMaxValue("bias")
+                        value: autotunePage.pluginDB.bias
+                        decimals: 2
+                        stepSize: 0.01
+                        onValueModified: v => {
+                            autotunePage.pluginDB.bias = v;
+                        }
+                    }
+
+                    EeSpinBox {
+                        id: filterControl
+
+                        label: i18n("Filter") // qmllint disable
+                        labelAbove: true
+                        spinboxLayoutFillWidth: true
+                        from: autotunePage.pluginDB.getMinValue("filter")
+                        to: autotunePage.pluginDB.getMaxValue("filter")
+                        value: autotunePage.pluginDB.filter
+                        decimals: 2
+                        stepSize: 0.01
+                        onValueModified: v => {
+                            autotunePage.pluginDB.filter = v;
+                        }
+                    }
+
+                    EeSpinBox {
+                        id: offset
+
+                        label: i18n("Offset") // qmllint disable
+                        labelAbove: true
+                        spinboxLayoutFillWidth: true
+                        from: autotunePage.pluginDB.getMinValue("offset")
+                        to: autotunePage.pluginDB.getMaxValue("offset")
+                        value: autotunePage.pluginDB.offset
+                        decimals: 2
+                        stepSize: 0.01
+                        onValueModified: v => {
+                            autotunePage.pluginDB.offset = v;
+                        }
+                    }
+
+                    EeSpinBox {
+                        id: bendRange
+
+                        label: i18n("Pitch bend range") // qmllint disable
+                        labelAbove: true
+                        spinboxLayoutFillWidth: true
+                        from: autotunePage.pluginDB.getMinValue("bendRange")
+                        to: autotunePage.pluginDB.getMaxValue("bendRange")
+                        value: autotunePage.pluginDB.bendRange
+                        decimals: 1
+                        stepSize: 0.5
+                        onValueModified: v => {
+                            autotunePage.pluginDB.bendRange = v;
+                        }
+                    }
+                }
+            }
+
+            EeCard {
+                title: i18n("Notes") // qmllint disable
+
+                GridLayout {
+                    columns: 2
+                    uniformCellWidths: true
+                    rowSpacing: 0
+
+                    EeSwitch {
+                        label: "C"
+                        isChecked: autotunePage.pluginDB.noteC
+                        onCheckedChanged: {
+                            if (isChecked !== autotunePage.pluginDB.noteC)
+                                autotunePage.pluginDB.noteC = isChecked;
+                        }
+                    }
+
+                    EeSwitch {
+                        label: "C#"
+                        isChecked: autotunePage.pluginDB.noteCSharp
+                        onCheckedChanged: {
+                            if (isChecked !== autotunePage.pluginDB.noteCSharp)
+                                autotunePage.pluginDB.noteCSharp = isChecked;
+                        }
+                    }
+
+                    EeSwitch {
+                        label: "D"
+                        isChecked: autotunePage.pluginDB.noteD
+                        onCheckedChanged: {
+                            if (isChecked !== autotunePage.pluginDB.noteD)
+                                autotunePage.pluginDB.noteD = isChecked;
+                        }
+                    }
+
+                    EeSwitch {
+                        label: "D#"
+                        isChecked: autotunePage.pluginDB.noteDSharp
+                        onCheckedChanged: {
+                            if (isChecked !== autotunePage.pluginDB.noteDSharp)
+                                autotunePage.pluginDB.noteDSharp = isChecked;
+                        }
+                    }
+
+                    EeSwitch {
+                        label: "E"
+                        isChecked: autotunePage.pluginDB.noteE
+                        onCheckedChanged: {
+                            if (isChecked !== autotunePage.pluginDB.noteE)
+                                autotunePage.pluginDB.noteE = isChecked;
+                        }
+                    }
+
+                    EeSwitch {
+                        label: "F"
+                        isChecked: autotunePage.pluginDB.noteF
+                        onCheckedChanged: {
+                            if (isChecked !== autotunePage.pluginDB.noteF)
+                                autotunePage.pluginDB.noteF = isChecked;
+                        }
+                    }
+
+                    EeSwitch {
+                        label: "F#"
+                        isChecked: autotunePage.pluginDB.noteFSharp
+                        onCheckedChanged: {
+                            if (isChecked !== autotunePage.pluginDB.noteFSharp)
+                                autotunePage.pluginDB.noteFSharp = isChecked;
+                        }
+                    }
+
+                    EeSwitch {
+                        label: "G"
+                        isChecked: autotunePage.pluginDB.noteG
+                        onCheckedChanged: {
+                            if (isChecked !== autotunePage.pluginDB.noteG)
+                                autotunePage.pluginDB.noteG = isChecked;
+                        }
+                    }
+
+                    EeSwitch {
+                        label: "G#"
+                        isChecked: autotunePage.pluginDB.noteGSharp
+                        onCheckedChanged: {
+                            if (isChecked !== autotunePage.pluginDB.noteGSharp)
+                                autotunePage.pluginDB.noteGSharp = isChecked;
+                        }
+                    }
+
+                    EeSwitch {
+                        label: "A"
+                        isChecked: autotunePage.pluginDB.noteA
+                        onCheckedChanged: {
+                            if (isChecked !== autotunePage.pluginDB.noteA)
+                                autotunePage.pluginDB.noteA = isChecked;
+                        }
+                    }
+
+                    EeSwitch {
+                        label: "A#"
+                        isChecked: autotunePage.pluginDB.noteASharp
+                        onCheckedChanged: {
+                            if (isChecked !== autotunePage.pluginDB.noteASharp)
+                                autotunePage.pluginDB.noteASharp = isChecked;
+                        }
+                    }
+
+                    EeSwitch {
+                        label: "B"
+                        isChecked: autotunePage.pluginDB.noteB
+                        onCheckedChanged: {
+                            if (isChecked !== autotunePage.pluginDB.noteB)
+                                autotunePage.pluginDB.noteB = isChecked;
+                        }
+                    }
+                }
+            }
+
+            EeCard {
+                title: i18n("Meters") // qmllint disable
+
+                ColumnLayout {
+                    EeProgressBar {
+                        id: pitchErrorMeter
+
+                        label: i18n("Pitch error") // qmllint disable
+                        from: -1
+                        to: 1
+                        decimals: 2
+                    }
+
+                    EeProgressBar {
+                        id: pitchBendMeter
+
+                        label: i18n("Pitch bend") // qmllint disable
+                        from: -1
+                        to: 1
+                        decimals: 2
+                    }
+                }
+            }
+        }
+    }
+
+    EeInputOutputGain {
+        id: inputOutputLevels
+
+        pluginDB: autotunePage.pluginDB
+    }
+
+    header: inputOutputLevels
+
+    footer: RowLayout {
+        Controls.Label {
+            text: i18n("Using %1", `<strong>${PluginsPackage.x42}</strong>`) // qmllint disable
+            textFormat: Text.RichText
+            horizontalAlignment: Qt.AlignLeft
+            verticalAlignment: Qt.AlignVCenter
+            Layout.fillWidth: false
+            Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+            Layout.rightMargin: Kirigami.Units.largeSpacing * 8
+            color: Kirigami.Theme.disabledTextColor
+        }
+
+        Kirigami.ActionToolBar {
+            Layout.margins: Kirigami.Units.smallSpacing
+            alignment: Qt.AlignRight
+            position: Controls.ToolBar.Footer
+            flat: true
+            actions: [
+                Kirigami.Action {
+                    text: i18n("Fast correction") // qmllint disable
+                    icon.name: "player-time-symbolic"
+                    checkable: true
+                    checked: autotunePage.pluginDB.fastMode
+                    onTriggered: {
+                        if (autotunePage.pluginDB.fastMode !== checked)
+                            autotunePage.pluginDB.fastMode = checked;
+                    }
+                },
+                Kirigami.Action {
+                    displayHint: Kirigami.DisplayHint.KeepVisible
+                    text: i18n("Show native window") // qmllint disable
+                    icon.name: "window-duplicate-symbolic"
+                    enabled: DbMain.showNativePluginUi
+                    checkable: true
+                    checked: autotunePage.pluginBackend ? autotunePage.pluginBackend.hasNativeUi() : false
+                    onTriggered: {
+                        if (checked)
+                            autotunePage.pluginBackend.showNativeUi();
+                        else
+                            autotunePage.pluginBackend.closeNativeUi();
+                    }
+                },
+                Kirigami.Action {
+                    displayHint: Kirigami.DisplayHint.KeepVisible
+                    text: i18n("Reset settings") // qmllint disable
+                    icon.name: "edit-reset-symbolic"
+                    onTriggered: {
+                        autotunePage.pluginBackend.reset();
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/src/contents/ui/Autotune.qml
+++ b/src/contents/ui/Autotune.qml
@@ -33,16 +33,18 @@ Kirigami.ScrollablePage {
     required property EffectsBase pipelineInstance
     property BackendAutotune pluginBackend
 
-    readonly property var scalePatterns: {
-        const major = [1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1];
-        const minor = [1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0];
-        return { "major": major, "minor": minor };
-    }
+    readonly property var majorPattern: [1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1]
+    readonly property var minorPattern: [1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0]
 
-    readonly property var noteNames: ["C", "Db", "D", "Eb", "E", "F", "F#", "G", "Ab", "A", "Bb", "B"]
+    // Semitone index for each natural note: C=0, D=2, E=4, F=5, G=7, A=9, B=11
+    readonly property var naturalNoteIndex: [0, 2, 4, 5, 7, 9, 11]
 
-    function applyScale(rootIndex: int, scaleType: string) {
-        const pattern = scalePatterns[scaleType];
+    function applyCurrentScale() {
+        const baseIndex = naturalNoteIndex[scaleRoot.currentIndex];
+        const accidental = scaleAccidental.currentIndex; // 0=natural, 1=sharp, 2=flat
+        const offset = accidental === 1 ? 1 : (accidental === 2 ? -1 : 0);
+        const rootIndex = (baseIndex + offset + 12) % 12;
+        const pattern = scaleType.currentIndex === 0 ? majorPattern : minorPattern;
         const notes = [];
         for (let i = 0; i < 12; i++) {
             notes.push(pattern[(12 + i - rootIndex) % 12] === 1);
@@ -205,33 +207,46 @@ Kirigami.ScrollablePage {
 
                 contentItem: ColumnLayout {
                     GridLayout {
-                        columns: 2
+                        columns: 3
                         uniformCellWidths: true
                         Layout.alignment: Qt.AlignTop
 
                         FormCard.FormComboBoxDelegate {
                             id: scaleRoot
 
-                            text: i18n("Root note") // qmllint disable
+                            text: i18n("Root") // qmllint disable
                             displayMode: FormCard.FormComboBoxDelegate.ComboBox
                             currentIndex: 0
                             editable: false
-                            model: autotunePage.noteNames
+                            model: ["C", "D", "E", "F", "G", "A", "B"]
                             onActivated: {
-                                autotunePage.applyScale(scaleRoot.currentIndex, scaleType.currentIndex === 0 ? "major" : "minor");
+                                autotunePage.applyCurrentScale();
+                            }
+                        }
+
+                        FormCard.FormComboBoxDelegate {
+                            id: scaleAccidental
+
+                            text: i18n("Accidental") // qmllint disable
+                            displayMode: FormCard.FormComboBoxDelegate.ComboBox
+                            currentIndex: 0
+                            editable: false
+                            model: ["♮", "♯", "♭"]
+                            onActivated: {
+                                autotunePage.applyCurrentScale();
                             }
                         }
 
                         FormCard.FormComboBoxDelegate {
                             id: scaleType
 
-                            text: i18n("Scale type") // qmllint disable
+                            text: i18n("Scale") // qmllint disable
                             displayMode: FormCard.FormComboBoxDelegate.ComboBox
                             currentIndex: 0
                             editable: false
                             model: [i18n("Major"), i18n("Minor")] // qmllint disable
                             onActivated: {
-                                autotunePage.applyScale(scaleRoot.currentIndex, scaleType.currentIndex === 0 ? "major" : "minor");
+                                autotunePage.applyCurrentScale();
                             }
                         }
                     }

--- a/src/contents/ui/Autotune.qml
+++ b/src/contents/ui/Autotune.qml
@@ -107,7 +107,7 @@ Kirigami.ScrollablePage {
                             displayMode: FormCard.FormComboBoxDelegate.ComboBox
                             currentIndex: autotunePage.pluginDB.mode
                             editable: false
-                            model: [i18n("Auto"), i18n("MIDI"), i18n("Manual")] //qmllint disable
+                            model: [i18n("Auto"), i18n("Manual")] //qmllint disable
                             onActivated: idx => {
                                 autotunePage.pluginDB.mode = idx;
                             }

--- a/src/contents/ui/Autotune.qml
+++ b/src/contents/ui/Autotune.qml
@@ -33,11 +33,8 @@ Kirigami.ScrollablePage {
     required property EffectsBase pipelineInstance
     property BackendAutotune pluginBackend
 
-    // Scale definitions: each is an array of 12 booleans [C, C#, D, D#, E, F, F#, G, G#, A, A#, B]
     readonly property var scalePatterns: {
-        // Major: W-W-H-W-W-W-H
         const major = [1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1];
-        // Minor (natural): W-H-W-W-H-W-W
         const minor = [1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0];
         return { "major": major, "minor": minor };
     }
@@ -73,7 +70,6 @@ Kirigami.ScrollablePage {
         inputOutputLevels.setOutputLevelLeft(pluginBackend.getOutputLevelLeft());
         inputOutputLevels.setOutputLevelRight(pluginBackend.getOutputLevelRight());
         pitchErrorMeter.setValue(pluginBackend.getPitchError());
-        pitchBendMeter.setValue(pluginBackend.getPitchBend());
     }
 
     Component.onCompleted: {
@@ -125,7 +121,7 @@ Kirigami.ScrollablePage {
                             to: autotunePage.pluginDB.getMaxValue("tuning")
                             value: autotunePage.pluginDB.tuning
                             decimals: 1
-                            stepSize: 0.5
+                            stepSize: 0.2
                             unit: Units.hz
                             onValueModified: v => {
                                 autotunePage.pluginDB.tuning = v;
@@ -183,6 +179,7 @@ Kirigami.ScrollablePage {
                         EeSpinBox {
                             id: offset
 
+                            Layout.columnSpan: 2
                             label: i18n("Offset") // qmllint disable
                             labelAbove: true
                             spinboxLayoutFillWidth: true
@@ -193,22 +190,6 @@ Kirigami.ScrollablePage {
                             stepSize: 0.01
                             onValueModified: v => {
                                 autotunePage.pluginDB.offset = v;
-                            }
-                        }
-
-                        EeSpinBox {
-                            id: bendRange
-
-                            label: i18n("Pitch bend range") // qmllint disable
-                            labelAbove: true
-                            spinboxLayoutFillWidth: true
-                            from: autotunePage.pluginDB.getMinValue("bendRange")
-                            to: autotunePage.pluginDB.getMaxValue("bendRange")
-                            value: autotunePage.pluginDB.bendRange
-                            decimals: 1
-                            stepSize: 0.5
-                            onValueModified: v => {
-                                autotunePage.pluginDB.bendRange = v;
                             }
                         }
                     }
@@ -236,6 +217,9 @@ Kirigami.ScrollablePage {
                             currentIndex: 0
                             editable: false
                             model: autotunePage.noteNames
+                            onActivated: {
+                                autotunePage.applyScale(scaleRoot.currentIndex, scaleType.currentIndex === 0 ? "major" : "minor");
+                            }
                         }
 
                         FormCard.FormComboBoxDelegate {
@@ -246,14 +230,7 @@ Kirigami.ScrollablePage {
                             currentIndex: 0
                             editable: false
                             model: [i18n("Major"), i18n("Minor")] // qmllint disable
-                        }
-
-                        Controls.Button {
-                            Layout.columnSpan: 2
-                            Layout.fillWidth: true
-                            text: i18n("Apply scale") // qmllint disable
-                            icon.name: "dialog-ok-apply-symbolic"
-                            onClicked: {
+                            onActivated: {
                                 autotunePage.applyScale(scaleRoot.currentIndex, scaleType.currentIndex === 0 ? "major" : "minor");
                             }
                         }
@@ -393,15 +370,6 @@ Kirigami.ScrollablePage {
                         id: pitchErrorMeter
 
                         label: i18n("Pitch error") // qmllint disable
-                        from: -1
-                        to: 1
-                        decimals: 2
-                    }
-
-                    EeProgressBar {
-                        id: pitchBendMeter
-
-                        label: i18n("Pitch bend") // qmllint disable
                         from: -1
                         to: 1
                         decimals: 2

--- a/src/contents/ui/PageStreamsEffects.qml
+++ b/src/contents/ui/PageStreamsEffects.qml
@@ -157,6 +157,7 @@ Kirigami.Page {
 
                 const pluginMap = {
                     [PluginsBaseName.autogain]: Qt.resolvedUrl("Autogain.qml"),
+                    [PluginsBaseName.autotune]: Qt.resolvedUrl("Autotune.qml"),
                     [PluginsBaseName.bassEnhancer]: Qt.resolvedUrl("BassEnhancer.qml"),
                     [PluginsBaseName.bassLoudness]: Qt.resolvedUrl("BassLoudness.qml"),
                     [PluginsBaseName.compressor]: Qt.resolvedUrl("Compressor.qml"),
@@ -189,6 +190,7 @@ Kirigami.Page {
                 };
 
                 const packageMap = {
+                    [PluginsBaseName.autotune]: PluginsPackage.x42,
                     [PluginsBaseName.bassEnhancer]: PluginsPackage.calf,
                     [PluginsBaseName.bassLoudness]: PluginsPackage.mda,
                     [PluginsBaseName.compressor]: PluginsPackage.lsp,

--- a/src/db_manager.cpp
+++ b/src/db_manager.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "easyeffects_db.h"
 #include "easyeffects_db_autogain.h"
+#include "easyeffects_db_autotune.h"
 #include "easyeffects_db_bass_enhancer.h"
 #include "easyeffects_db_bass_loudness.h"
 #include "easyeffects_db_compressor.h"
@@ -181,6 +182,9 @@ void Manager::create_plugin_db(const QString& parentGroup,
 
     if (name.startsWith(tags::plugin_name::BaseName::autogain)) {
       ensureExists(makeKey(tags::plugin_name::BaseName::autogain, id), [&] { return new DbAutogain(parentGroup, id); });
+
+    } else if (name.startsWith(tags::plugin_name::BaseName::autotune)) {
+      ensureExists(makeKey(tags::plugin_name::BaseName::autotune, id), [&] { return new DbAutotune(parentGroup, id); });
 
     } else if (name.startsWith(tags::plugin_name::BaseName::bassEnhancer)) {
       ensureExists(makeKey(tags::plugin_name::BaseName::bassEnhancer, id),

--- a/src/effects_base.cpp
+++ b/src/effects_base.cpp
@@ -39,6 +39,7 @@
 #include <utility>
 #include <vector>
 #include "autogain.hpp"
+#include "autotune.hpp"
 #include "bass_enhancer.hpp"
 #include "bass_loudness.hpp"
 #include "compressor.hpp"
@@ -157,6 +158,9 @@ void EffectsBase::create_filters_if_necessary() {
 
     if (name.startsWith(tags::plugin_name::BaseName::autogain)) {
       filter = std::make_unique<Autogain>(log_tag, pm, pipeline_type, instance_id);
+
+    } else if (name.startsWith(tags::plugin_name::BaseName::autotune)) {
+      filter = std::make_unique<Autotune>(log_tag, pm, pipeline_type, instance_id);
 
     } else if (name.startsWith(tags::plugin_name::BaseName::bassEnhancer)) {
       filter = std::make_unique<BassEnhancer>(log_tag, pm, pipeline_type, instance_id);

--- a/src/effects_base.cpp
+++ b/src/effects_base.cpp
@@ -325,6 +325,9 @@ QVariant EffectsBase::getPluginInstance(const QString& pluginName) {
   if (pluginName.startsWith(tags::plugin_name::BaseName::autogain)) {
     return QVariant::fromValue(dynamic_cast<Autogain*>(p.get()));
 
+  } else if (pluginName.startsWith(tags::plugin_name::BaseName::autotune)) {
+    return QVariant::fromValue(dynamic_cast<Autotune*>(p.get()));
+
   } else if (pluginName.startsWith(tags::plugin_name::BaseName::bassEnhancer)) {
     return QVariant::fromValue(dynamic_cast<BassEnhancer*>(p.get()));
 

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -45,6 +45,7 @@
 #include <string>
 #include <vector>
 #include "autogain_preset.hpp"
+#include "autotune_preset.hpp"
 #include "bass_enhancer_preset.hpp"
 #include "bass_loudness_preset.hpp"
 #include "compressor_preset.hpp"
@@ -877,6 +878,9 @@ auto Manager::create_wrapper(const PipelineType& pipeline_type, const QString& f
     -> std::optional<std::unique_ptr<PluginPresetBase>> {
   if (filter_name.startsWith(tags::plugin_name::BaseName::autogain)) {
     return std::make_unique<AutoGainPreset>(pipeline_type, filter_name.toStdString());
+
+  } else if (filter_name.startsWith(tags::plugin_name::BaseName::autotune)) {
+    return std::make_unique<AutotunePreset>(pipeline_type, filter_name.toStdString());
 
   } else if (filter_name.startsWith(tags::plugin_name::BaseName::bassEnhancer)) {
     return std::make_unique<BassEnhancerPreset>(pipeline_type, filter_name.toStdString());

--- a/src/tags_plugin_name.cpp
+++ b/src/tags_plugin_name.cpp
@@ -44,6 +44,7 @@ namespace tags::plugin_name {
 Model::Model(QObject* parent)
     : QAbstractListModel(parent),
       modelMap({{BaseName::autogain, i18n("Autogain")},
+                {BaseName::autotune, i18n("Autotune")},
                 {BaseName::bassEnhancer, i18n("Bass Enhancer")},
                 {BaseName::bassLoudness, i18n("Bass Loudness")},
                 {BaseName::compressor, i18n("Compressor")},

--- a/src/tags_plugin_name.hpp
+++ b/src/tags_plugin_name.hpp
@@ -71,6 +71,7 @@ class Package : public QObject {
   CREATE_PROPERTY(QString, bs2b, QStringLiteral("bs2b"));
   CREATE_PROPERTY(QString, calf, QStringLiteral("Calf Studio Gear"));
   CREATE_PROPERTY(QString, deepfilternet, QStringLiteral("DeepFilterNet"));
+  CREATE_PROPERTY(QString, x42, QStringLiteral("x42"));
   CREATE_PROPERTY(QString, ebur128, QStringLiteral("libebur128"));
   CREATE_PROPERTY(QString, ee, QStringLiteral("Easy Effects"));
   CREATE_PROPERTY(QString, lsp, QStringLiteral("Linux Studio Plugins"));
@@ -116,6 +117,7 @@ class BaseName : public QObject {
 
   // NOLINTBEGIN(bugprone-throwing-static-initialization)
   CREATE_PROPERTY(QString, autogain, QStringLiteral("autogain"));
+  CREATE_PROPERTY(QString, autotune, QStringLiteral("autotune"));
   CREATE_PROPERTY(QString, bassEnhancer, QStringLiteral("bass_enhancer"));
   CREATE_PROPERTY(QString, bassLoudness, QStringLiteral("bass_loudness"));
   CREATE_PROPERTY(QString, compressor, QStringLiteral("compressor"));


### PR DESCRIPTION
## Summary

Integrates the x42 fat1 LV2 autotune plugin with a custom UI, preset framework integration, and all relevant control parameters.

- Full custom QML UI with tuning controls (correction, bias, filter, offset), scale selector (root note + accidental + major/minor), individual note toggles, and pitch error meter
- Preset save/load for all parameters
- Stereo-to-mono mixing (fat1 is a mono plugin) with output duplicated to both channels
- Empty MIDI atom sequence provided each cycle for fat1's required MIDI sidechain port
- Handles "plugin not found" gracefully when x42-plugins is not installed
- Flatpak users can install `org.freedesktop.LinuxAudio.Plugins.x42Plugins` for support

## Disclosure

This contribution was heavily AI-assisted (Claude). I reviewed, tested, and iterated on every change, but want to be transparent about the process. All code was tested locally against the actual fat1 LV2 plugin.

## New files
- `autotune.hpp/cpp` — backend wrapping fat1 LV2 plugin (`http://gareus.org/oss/lv2/fat1`)
- `autotune_preset.hpp/cpp` — JSON preset serialization
- `easyeffects_db_autotune.kcfg/kcfgc` — KConfig schema
- `Autotune.qml` — QML UI

## Test plan
- [x] Add Autotune to output effects, verify controls appear and work
- [x] Play audio and verify pitch correction processes correctly
- [x] Test scale selector: root + accidental + major/minor auto-applies note toggles
- [x] Add/remove other plugins after autotune (previously crashed, fixed)
- [x] Save and load presets with autotune settings
- [x] Native UI button opens the x42 fat1 window
- [x] Plugin shows "not available" message when x42-plugins is not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)