### PR TITLE
Improve Autotune UI, README and PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -36,12 +36,12 @@ depends=(
   'libmysofa'
 )
 makedepends=('cmake' 'extra-cmake-modules' 'git' 'ninja' 'intltool' 'appstream' 'mold' 'ladspa')
-optdepends=('calf: limiter, exciter, bass enhancer and others'
-            'lsp-plugins: equalizer, compressor, delay, loudness'
-            'zam-plugins: maximizer'
+optdepends=('calf: exciter, bass enhancer and others'
+            'lsp-plugins-lv2: limiter, equalizer, compressor, loudness and others'
+            'zam-plugins-lv2: maximizer'
             'mda.lv2: bass loudness'
             'x42-plugins-lv2: autotune'
-            'libdeep_filter_ladspa: noise remover'
+            'libdeep_filter_ladspa: deep noise remover'
             'breeze: kde breeze style')
 conflicts=(easyeffects)
 provides=(easyeffects)

--- a/PKGBUILD_AUR
+++ b/PKGBUILD_AUR
@@ -36,12 +36,12 @@ depends=(
   'libmysofa'
 )
 makedepends=('cmake' 'extra-cmake-modules' 'git' 'ninja' 'intltool' 'appstream' 'ladspa')
-optdepends=('calf: limiter, exciter, bass enhancer and others'
-            'lsp-plugins: equalizer, compressor, delay, loudness'
-            'zam-plugins: maximizer'
+optdepends=('calf: exciter, bass enhancer and others'
+            'lsp-plugins-lv2: limiter, equalizer, compressor, loudness and others'
+            'zam-plugins-lv2: maximizer'
             'mda.lv2: bass loudness'
             'x42-plugins-lv2: autotune'
-            'libdeep_filter_ladspa: noise remover'
+            'libdeep_filter_ladspa: deep noise remover'
             'breeze: kde breeze style')
 conflicts=("${pkgname%%-git}")
 provides=("${pkgname%%-git}")

--- a/README.md
+++ b/README.md
@@ -48,12 +48,21 @@ a combination of Qt, QML and KDE/Kirigami frameworks.
 
 ## Effects available
 
-- Auto gain
+The user has full control over the effects order. Just use the up/down arrows
+next to the effect labels on the left side.
+
+<details>
+<summary>See the full list of available effects</summary>
+<p>
+
+- Autogain
+- Autotune
 - Bass enhancer
 - Bass loudness
 - Compressor
 - Convolver
 - Crossfeed
+- Crosstalk canceller
 - Crusher
 - Crystalizer
 - De-esser
@@ -76,15 +85,17 @@ a combination of Qt, QML and KDE/Kirigami frameworks.
 - Reverberation
 - Speech processor
 - Stereo tools
+- Voice Suppressor
 
-The user has full control over the effects order. Just use the up/down arrows
-next to the effect labels on the left side.
+</p>
+</details>
 
 Some packages do not provide all plugin packages by default. In case some effects are not available,
 ensure you have the following installed on your system:
 
 <details>
 <summary>Dependencies</summary>
+<p>
 
 Plugins needed for effects:
 
@@ -100,6 +111,7 @@ Plugins needed for effects:
 - [DeepFilterNet](https://github.com/Rikorose/DeepFilterNet). For Deep noise remover.
 
 Other dependencies include:
+
 - [libsamplerate](http://www.mega-nerd.com/SRC/index.html)
 - [libsndfile](http://www.mega-nerd.com/libsndfile/)
 - [libbs2b](https://sourceforge.net/projects/bs2b/files/libbs2b/)
@@ -108,6 +120,7 @@ Other dependencies include:
 - [nlohmann json](https://github.com/nlohmann/json)
 - [tbb](https://www.threadingbuildingblocks.org)
 
+</p>
 </details>
 
 ## Donate

--- a/README.md
+++ b/README.md
@@ -109,14 +109,15 @@ Plugins needed for effects:
 - [SoundTouch](https://www.surina.net/soundtouch/). For Pitch shift.
 - [RNNoise](https://gitlab.xiph.org/xiph/rnnoise). For Noise reduction.
 - [DeepFilterNet](https://github.com/Rikorose/DeepFilterNet). For Deep noise remover.
+- [x42-plugins](https://x42-plugins.com/) For Autotune.
 
 Other dependencies include:
 
 - [libsamplerate](http://www.mega-nerd.com/SRC/index.html)
 - [libsndfile](http://www.mega-nerd.com/libsndfile/)
 - [libbs2b](https://sourceforge.net/projects/bs2b/files/libbs2b/)
+- [libmysofa](https://github.com/hoene/libmysofa/)
 - [fftw](https://fftw.org/)
-- [speexdsp](https://www.speex.org/)
 - [nlohmann json](https://github.com/nlohmann/json)
 - [tbb](https://www.threadingbuildingblocks.org)
 

--- a/src/contents/ui/Autotune.qml
+++ b/src/contents/ui/Autotune.qml
@@ -82,7 +82,8 @@ Kirigami.ScrollablePage {
         Kirigami.CardsLayout {
             id: cardLayout
 
-            minimumColumnWidth: Kirigami.Units.gridUnit * 17
+            minimumColumnWidth: Kirigami.Units.gridUnit * 20
+            maximumColumnWidth: Kirigami.Units.gridUnit * 23
             uniformCellWidths: true
 
             Kirigami.Card {


### PR DESCRIPTION
The Autotune had the cards too narrow.

<p>
<img width="1233" height="501" alt="Schermata del 2026-05-01 10-04-11" src="https://github.com/user-attachments/assets/445bd922-1339-411c-a105-45e798606be9" />
</p>

Using a proper min and max column width it now seems better:

<p>
<img width="1233" height="467" alt="Schermata del 2026-05-01 10-15-36" src="https://github.com/user-attachments/assets/33a9749e-86e8-49cc-a445-d7c82ba585dc" />
</p>

Added new effects to the list in the README. Since the list is too long, I put it in a summary like the dependencies. 

Replaced the lv2 variants of lsp and zam plugins in the PKGBUILD. Also fixed the opt dependencies descriptions since the limiter is provided by lsp, not calf anymore. Fixes #5025