### PR TITLE
Expand spectrum analyzer frequency limits.

### DIFF
--- a/src/contents/kcfg/easyeffects_db_spectrum.kcfg
+++ b/src/contents/kcfg/easyeffects_db_spectrum.kcfg
@@ -48,14 +48,14 @@
         </entry>
         <entry name="minimumFrequency" type="Int">
             <label></label>
-            <min>20</min>
+            <min>1</min>
             <max>21900</max>
             <default>20</default>
         </entry>
         <entry name="maximumFrequency" type="Int">
             <label></label>
             <min>120</min>
-            <max>22000</max>
+            <max>25000</max>
             <default>20000</default>
         </entry>
         <entry name="avsyncDelay" type="Int">

--- a/src/effects_base.cpp
+++ b/src/effects_base.cpp
@@ -490,8 +490,12 @@ void EffectsBase::requestSpectrumData() {
           }
         }
 
-        const auto min_freq = static_cast<float>(DbSpectrum::minimumFrequency());
-        const auto max_freq = static_cast<float>(DbSpectrum::maximumFrequency());
+        const auto min_available_freq = static_cast<float>(cached_spectrum_frequencies.front());
+        const auto max_available_freq = static_cast<float>(cached_spectrum_frequencies.back());
+        const auto min_freq = std::clamp(static_cast<float>(DbSpectrum::minimumFrequency()), min_available_freq,
+                                         max_available_freq);
+        const auto max_freq = std::clamp(static_cast<float>(DbSpectrum::maximumFrequency()), min_available_freq,
+                                         max_available_freq);
 
         if (min_freq > (max_freq - 100.0F)) {
           return;


### PR DESCRIPTION
Allow minimum frequency down to 1 Hz and maximum frequency up to 25 kHz.

My audio setup is....

| Item | Model | Frequency response |
|---|---|---:|
| Subwoofer | Klipsch Reference Premiere RP-1200SW | 16.5 Hz – 138 Hz ±3 dB |
| Bookshelf speakers | Klipsch Reference Premiere RP-500M II | 50 Hz – 25,000 Hz ±3 dB |

My sub can go down alot lower then the 20 Hz limit that was set.  So I thought.  Why not let us go all the way down?
Same with the upper limit.  It was only 20 Khz.  But my speakers, (well probably the tweaters) can go higher..  