### PR TITLE
Fixed RNNoise timeout on empty input

### DIFF
--- a/src/rnnoise.cpp
+++ b/src/rnnoise.cpp
@@ -190,7 +190,11 @@ void RNNoise::process(std::span<float>& left_in,
   }
 
 #ifdef ENABLE_RNNOISE
-  if (!rnnoise_ready) {
+  auto eps = 1e-6F;
+  auto empty = std::ranges::all_of(left_in, [&](float v){ return std::fabs(v) <= eps; }) &&
+               std::ranges::all_of(right_in, [&](float v){ return std::fabs(v) <= eps; });
+
+  if (!rnnoise_ready || empty) {
     std::ranges::fill(left_out, 0.0F);
     std::ranges::fill(right_out, 0.0F);
 


### PR DESCRIPTION
Fixed a bug where RNNoise exceeded the real‑time time limit (rttime), causing EasyEffects to be terminated.

## Reproduce the "crash"
 - turn on RNNoise
 - start a recording application
 - mute/unmute the input device a few times