### PR TITLE
Add "Duplicate" button

### DIFF
--- a/po/af/easyeffects.po
+++ b/po/af/easyeffects.po
@@ -1230,12 +1230,17 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr ""
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 #, fuzzy
 msgid "Toggle this effect"
 msgstr "EasyEffects"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "EasyEffects"

--- a/po/ar/easyeffects.po
+++ b/po/ar/easyeffects.po
@@ -1283,11 +1283,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr ""
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "بدل هذا التأثير"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "احذف هذا التأثير"
 

--- a/po/bg/easyeffects.po
+++ b/po/bg/easyeffects.po
@@ -1274,12 +1274,17 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr ""
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 #, fuzzy
 msgid "Toggle this effect"
 msgstr "Предварително задаване"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "Предварително задаване"

--- a/po/ca/easyeffects.po
+++ b/po/ca/easyeffects.po
@@ -1252,11 +1252,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr ""
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr ""
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "Silencia l'aplicació"

--- a/po/cs/easyeffects.po
+++ b/po/cs/easyeffects.po
@@ -1227,11 +1227,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Není nastaven žádný popis"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "Přepnout tento efekt"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "Odstranit tento efekt"
 

--- a/po/da/easyeffects.po
+++ b/po/da/easyeffects.po
@@ -1323,12 +1323,17 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Beskrivelse"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 #, fuzzy
 msgid "Toggle this effect"
 msgstr "Fjern denne modelfil"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "Fjern denne modelfil"

--- a/po/de/easyeffects.po
+++ b/po/de/easyeffects.po
@@ -1267,11 +1267,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Keine Beschreibung festgelegt"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "Diesen Effekt umschalten"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "Diesen Effekt entfernen"
 

--- a/po/easyeffects.pot
+++ b/po/easyeffects.pot
@@ -1219,11 +1219,15 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr ""
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr ""
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr ""
 

--- a/po/es/easyeffects.po
+++ b/po/es/easyeffects.po
@@ -1239,11 +1239,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Sin descripción"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "Alternar este efecto"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "Quitar este efecto"
 

--- a/po/es_CO/easyeffects.po
+++ b/po/es_CO/easyeffects.po
@@ -1332,12 +1332,17 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Detección"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 #, fuzzy
 msgid "Toggle this effect"
 msgstr "Borrar este perfil"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "Borrar este perfil"

--- a/po/es_MX/easyeffects.po
+++ b/po/es_MX/easyeffects.po
@@ -1236,11 +1236,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Sin descripción"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "Alternar este efecto"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "Quitar este efecto"
 

--- a/po/es_VE/easyeffects.po
+++ b/po/es_VE/easyeffects.po
@@ -1330,12 +1330,17 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Detección"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 #, fuzzy
 msgid "Toggle this effect"
 msgstr "Borrar este perfil"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "Borrar este perfil"

--- a/po/eu/easyeffects.po
+++ b/po/eu/easyeffects.po
@@ -1300,12 +1300,17 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Deskribapena"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 #, fuzzy
 msgid "Toggle this effect"
 msgstr "Inportatu aurrezarpena"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "Inportatu aurrezarpena"

--- a/po/fa/easyeffects.po
+++ b/po/fa/easyeffects.po
@@ -1316,12 +1316,17 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "توضیحات"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 #, fuzzy
 msgid "Toggle this effect"
 msgstr "فعال/غیرفعال کردن این افکت"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "حذف این افکت"

--- a/po/fr/easyeffects.po
+++ b/po/fr/easyeffects.po
@@ -1232,11 +1232,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Description non définie"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "Basculer cet effet"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "Supprimer cet effet"
 

--- a/po/ga/easyeffects.po
+++ b/po/ga/easyeffects.po
@@ -1233,11 +1233,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Níl aon tuairisc socraithe"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "Scoraigh an éifeacht seo"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "Bain an éifeacht seo"
 

--- a/po/gl/easyeffects.po
+++ b/po/gl/easyeffects.po
@@ -1329,12 +1329,17 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Descrición"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 #, fuzzy
 msgid "Toggle this effect"
 msgstr "Retirar este ficheiro de preconfiguracións"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "Retirar este ficheiro de preconfiguracións"

--- a/po/hr/easyeffects.po
+++ b/po/hr/easyeffects.po
@@ -1303,11 +1303,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Opis nije postavljen"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "Uključi/Isključi ovaj efekt"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "Ukloni ovaj efekt"
 

--- a/po/hu/easyeffects.po
+++ b/po/hu/easyeffects.po
@@ -1303,12 +1303,17 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Leírás"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 #, fuzzy
 msgid "Toggle this effect"
 msgstr "Beállítás Importálás"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "Beállítás Importálás"

--- a/po/id_ID/easyeffects.po
+++ b/po/id_ID/easyeffects.po
@@ -1228,11 +1228,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Tidak ada deskripsi yang diatur"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "Alihkan efek ini"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "Hapus efek ini"
 

--- a/po/it_IT/easyeffects.po
+++ b/po/it_IT/easyeffects.po
@@ -1234,11 +1234,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Descrizione non impostata"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "Abilita/disabilita questo effetto"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "Rimuovi questo effetto"
 

--- a/po/ja/easyeffects.po
+++ b/po/ja/easyeffects.po
@@ -1250,11 +1250,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "説明が設定されていません"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "このエフェクトの有効化/無効化"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "このエフェクトを削除"
 

--- a/po/ka/easyeffects.po
+++ b/po/ka/easyeffects.po
@@ -1268,12 +1268,17 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "აღწერა"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 #, fuzzy
 msgid "Toggle this effect"
 msgstr "პრესეტის შემოტანა"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "პრესეტის შემოტანა"

--- a/po/km/easyeffects.po
+++ b/po/km/easyeffects.po
@@ -1221,11 +1221,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr ""
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr ""
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr ""
 

--- a/po/ko/easyeffects.po
+++ b/po/ko/easyeffects.po
@@ -1306,12 +1306,17 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr ""
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 #, fuzzy
 msgid "Toggle this effect"
 msgstr "이 효과 제거하기"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "이 효과 제거하기"

--- a/po/nb_NO/easyeffects.po
+++ b/po/nb_NO/easyeffects.po
@@ -1311,12 +1311,17 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Beskrivelse"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 #, fuzzy
 msgid "Toggle this effect"
 msgstr "Fjern denne modellfilen"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "Fjern denne modellfilen"

--- a/po/nl/easyeffects.po
+++ b/po/nl/easyeffects.po
@@ -1247,11 +1247,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Geen omschrijving ingesteld"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "Dit effect omschakelen"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "Dit effect verwijderen"
 

--- a/po/nn/easyeffects.po
+++ b/po/nn/easyeffects.po
@@ -1302,12 +1302,17 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Skildring"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 #, fuzzy
 msgid "Toggle this effect"
 msgstr "Importer førehandsinnstillingar"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "Importer førehandsinnstillingar"

--- a/po/pl/easyeffects.po
+++ b/po/pl/easyeffects.po
@@ -1248,11 +1248,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Nie ustawiono opisu"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "Włącz/wyłącz ten efekt"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "Usuń ten efekt"
 

--- a/po/pt/easyeffects.po
+++ b/po/pt/easyeffects.po
@@ -1231,11 +1231,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Nenhuma descrição definida"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "Ative/desative este efeito"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "Remover este efeito"
 

--- a/po/pt_BR/easyeffects.po
+++ b/po/pt_BR/easyeffects.po
@@ -1233,11 +1233,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Nenhuma descrição definida"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "Ative/desative este efeito"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "Remover esse efeito"
 

--- a/po/ro/easyeffects.po
+++ b/po/ro/easyeffects.po
@@ -1234,11 +1234,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Nu există descriere"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "Activează acest efect"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "Elimină acest efect"
 

--- a/po/ru/easyeffects.po
+++ b/po/ru/easyeffects.po
@@ -1252,11 +1252,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Описание не задано"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "Включить/отключить этот эффект"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "Убрать этот эффект"
 

--- a/po/sk/easyeffects.po
+++ b/po/sk/easyeffects.po
@@ -1333,12 +1333,17 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Detekcia"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 #, fuzzy
 msgid "Toggle this effect"
 msgstr "Odstrániť predvoľbu"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "Odstrániť predvoľbu"

--- a/po/sr/easyeffects.po
+++ b/po/sr/easyeffects.po
@@ -1227,11 +1227,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr ""
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr ""
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr ""
 

--- a/po/sv/easyeffects.po
+++ b/po/sv/easyeffects.po
@@ -1296,12 +1296,17 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Beskrivning"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 #, fuzzy
 msgid "Toggle this effect"
 msgstr "Ta bort denna effekt"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "Ta bort denna effekt"

--- a/po/ta/easyeffects.po
+++ b/po/ta/easyeffects.po
@@ -1234,11 +1234,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "விளக்கம் எதுவும் அமைக்கப்படவில்லை"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "இந்த விளைவை மாற்றவும்"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "இந்த விளைவை அகற்றவும்"
 

--- a/po/th/easyeffects.po
+++ b/po/th/easyeffects.po
@@ -1221,11 +1221,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr ""
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr ""
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr ""
 

--- a/po/tr/easyeffects.po
+++ b/po/tr/easyeffects.po
@@ -1324,12 +1324,17 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Açıklama"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 #, fuzzy
 msgid "Toggle this effect"
 msgstr "Bu efekti etkinleştir/devre dışı bırak"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 #, fuzzy
 msgid "Remove this effect"
 msgstr "Bu efekti kaldır"

--- a/po/uk/easyeffects.po
+++ b/po/uk/easyeffects.po
@@ -1231,11 +1231,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "Опис не встановлено"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "Увімкнути цей ефект"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "Вилучити цей ефект"
 

--- a/po/vi/easyeffects.po
+++ b/po/vi/easyeffects.po
@@ -1219,11 +1219,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr ""
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr ""
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr ""
 

--- a/po/zh_CN/easyeffects.po
+++ b/po/zh_CN/easyeffects.po
@@ -1224,11 +1224,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "未设置描述"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "开关此音效"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "移除此音效"
 

--- a/po/zh_Hant/easyeffects.po
+++ b/po/zh_Hant/easyeffects.po
@@ -1223,11 +1223,16 @@ msgctxt "@info:placeholder"
 msgid "No description set"
 msgstr "沒有描述設定"
 
-#: src/contents/ui/DelegatePluginsList.qml:119
+#: src/contents/ui/DelegatePluginsList.qml:160
 msgid "Toggle this effect"
 msgstr "切換此音效"
 
-#: src/contents/ui/DelegatePluginsList.qml:127
+#, empty
+#: src/contents/ui/DelegatePluginsList.qml:168
+msgid "Duplicate this effect"
+msgstr ""
+
+#: src/contents/ui/DelegatePluginsList.qml:174
 msgid "Remove this effect"
 msgstr "移除此音效"
 

--- a/src/contents/ui/DelegatePluginsList.qml
+++ b/src/contents/ui/DelegatePluginsList.qml
@@ -40,6 +40,7 @@ Item {
     readonly property bool bypass: delegateItem.pluginDB?.bypass ?? false
 
     signal selectedChanged(string name)
+    signal duplicate(string oldName, string newName)
 
     width: ListView.view.width
 
@@ -74,6 +75,46 @@ Item {
                 }
 
                 delegateItem.pluginDB.bypass = !checked;
+            }
+
+            function duplicateEffect() {
+                let plugins = delegateItem.streamDB.plugins.slice();
+
+                let index_list = [];
+                let baseName = delegateItem.name.replace(/#\d+$/, "");
+
+                // get a list of every plugin index # 
+                for (let n = 0; n < plugins.length; n++) {
+                    if (plugins[n].startsWith(baseName)) {
+                        const m = plugins[n].match(/#(\d+)$/);
+                        if (m.length === 2) {
+                            index_list.push(m[1]);
+                        }
+                    }
+                }
+
+                // base the new plugin off the highest index #
+                const new_id = (index_list.length === 0) ? null : Math.max.apply(null, index_list) + 1;
+                
+                // create the new plugin name (used as a unique identifier)
+                const newName = baseName + "#" + new_id;
+
+                // since we are duplicating, new_id should NEVER be null
+                if (new_id != null) {
+                    // add to list
+                    plugins.splice(delegateItem.index + 1, 0, newName);
+
+                    // save list
+                    delegateItem.streamDB.plugins = plugins;
+
+                    // select new plugin
+                    delegateItem.streamDB.visiblePlugin = newName;
+
+                    // update new plugin with original plugin's data
+                    delegateItem.duplicate(delegateItem.name, newName);
+
+                    appWindow.showStatus(i18n("Added a new effect to the pipeline: %1", `<strong>${delegateItem.translatedName}</strong>`), Kirigami.MessageType.Positive); // qmllint disable
+                }
             }
 
             function removedEffect() {
@@ -122,6 +163,12 @@ Item {
                         checkable: true
                         checked: !bypass
                         onTriggered: pluginRowItem.toggledEffect(checked)
+                    },
+                    Kirigami.Action {
+                        text: i18n("Duplicate this effect") // qmllint disable
+                        icon.name: "document-duplicate"
+                        displayHint: DbMain.reducePluginsListControls ? Kirigami.DisplayHint.AlwaysHide : (Kirigami.DisplayHint.IconOnly | Kirigami.DisplayHint.KeepVisible)
+                        onTriggered: pluginRowItem.duplicateEffect()
                     },
                     Kirigami.Action {
                         text: i18n("Remove this effect") // qmllint disable

--- a/src/contents/ui/PageStreamsEffects.qml
+++ b/src/contents/ui/PageStreamsEffects.qml
@@ -460,6 +460,15 @@ Kirigami.Page {
 
                                 pagePluginsGrid.createPluginStack(name, baseName, pageStreamsEffects.pluginsDB[name]);
                             }
+                        }   
+                        onDuplicate: (oldName, newName) => {
+                            for (let key in pageStreamsEffects.pluginsDB[oldName]) {
+                                try {
+                                    pageStreamsEffects.pluginsDB[newName][key] = pageStreamsEffects.pluginsDB[oldName][key]
+                                } catch (e) {
+                                    // Skip read-only values
+                                }
+                            }
                         }
                     }
 


### PR DESCRIPTION
# Why?
Having a duplicate button would save significant amounts of time while adding multiple of the same effect (I found that when I was adding filters for EQing my speakers it would be a nice UX improvement to have a "Duplicate" button)

# To-Do
1. Test further (I was unable to successfully build a testing Flatpak of EasyEffects with every available effect - I'm new to this stuff, and I tried for hours, I promise...) 
**There's a chance one effect being duplicated will break the logic I built!**
**The try catch I made could be used to easily see if there is a problem while copying values of effects**
2. Add translations (currently every translation is marked with "empty" that isn't English)
