### PR TITLE
Add audio sharing global shortcut

### DIFF
--- a/src/contents/ui/ShortcutsSheet.qml
+++ b/src/contents/ui/ShortcutsSheet.qml
@@ -399,6 +399,46 @@ Kirigami.OverlaySheet {
                     text: i18n("Toggle microphone monitoring") // qmllint disable
                 }
 
+                RowLayout {
+                    Layout.alignment: Qt.AlignRight
+
+                    Kirigami.Chip {
+                        text: "Meta"
+                        closable: false
+                        checkable: false
+                        down: false
+                        hoverEnabled: false
+                    }
+
+                    Controls.Label {
+                        text: "+"
+                    }
+
+                    Kirigami.Chip {
+                        text: "Ctrl"
+                        closable: false
+                        checkable: false
+                        down: false
+                        hoverEnabled: false
+                    }
+
+                    Controls.Label {
+                        text: "+"
+                    }
+
+                    Kirigami.Chip {
+                        text: "O"
+                        closable: false
+                        checkable: false
+                        down: false
+                        hoverEnabled: false
+                    }
+                }
+
+                Controls.Label {
+                    text: i18n("Toggle audio sharing") // qmllint disable
+                }
+
                 Item {
                     implicitHeight: Kirigami.Units.gridUnit
                 }

--- a/src/global_shortcuts.cpp
+++ b/src/global_shortcuts.cpp
@@ -35,6 +35,7 @@
 #include <utility>
 #include "easyeffects_db.h"
 #include "easyeffects_db_streaminputs.h"
+#include "easyeffects_db_streamoutputs.h"
 #include "util.hpp"
 
 // Based on https://github.com/SourceReviver/qt_wayland_globalshortcut_via_portal/blob/main/wayland_shortcut.cpp
@@ -118,6 +119,12 @@ void GlobalShortcuts::process_activated_signal([[maybe_unused]] const QDBusObjec
 
     return;
   }
+
+  if (shortcut_id == "audio sharing") {
+    DbStreamOutputs::setLinkToVirtualSource(!DbStreamOutputs::linkToVirtualSource());
+
+    return;
+  }
 }
 
 void GlobalShortcuts::bind_shortcuts() {
@@ -132,7 +139,7 @@ void GlobalShortcuts::bind_shortcuts() {
 
     QVariantMap shortcut_options;
     shortcut.first = gsd.shortcut_id;
-    shortcut_options.insert("description", gsd.shortcut_id);
+    shortcut_options.insert("description", gsd.description);
     shortcut_options.insert("preferred_trigger", gsd.preferred_trigger);
     shortcut.second = shortcut_options;
 

--- a/src/global_shortcuts.hpp
+++ b/src/global_shortcuts.hpp
@@ -78,13 +78,16 @@ class GlobalShortcuts : public QObject {
 
   void bind_shortcuts();
 
-  std::array<GlobalShortcutData, 2> ee_global_shortcuts_array = {
+  std::array<GlobalShortcutData, 3> ee_global_shortcuts_array = {
       {{.shortcut_id = "global bypass",
         .description = i18n("Toggle global bypass"),
         .preferred_trigger = "LOGO+CTRL+E"},
        {.shortcut_id = "microphone monitoring",
         .description = i18n("Toggle microphone monitoring"),
-        .preferred_trigger = "LOGO+CTRL+I"}},
+        .preferred_trigger = "LOGO+CTRL+I"},
+       {.shortcut_id = "audio sharing",
+        .description = i18n("Toggle audio sharing"),
+        .preferred_trigger = "LOGO+CTRL+O"}},
   };
 
  Q_SIGNALS:


### PR DESCRIPTION
## Summary

This adds a new global shortcut for toggling audio sharing:

- `Meta/Super + Ctrl + O` toggles audio sharing ( You may change it if you find it's too close to the other one )
- the shortcut is registered through the existing GlobalShortcuts portal flow
- the shortcut help sheet now lists the new binding
- shortcut portal descriptions now use the translated description field instead of the internal shortcut id

## Details

The new shortcut toggles `DbStreamOutputs::linkToVirtualSource`, which is the same setting used by the existing
audio sharing UI action.

## Testing

Tested locally with:

- `cmake --build build-arch-test`
- `DESTDIR=/tmp/easyeffects-arch-test cmake --install build-arch-test`
- Flatpak build using the existing development Flatpak manifest
- Flatpak appstream test passed

Also manually tested the generated build and confirmed the shortcut works.
