### PR TITLE
Upgrade to flatpak kde runtime 6.11

### DIFF
--- a/util/flatpak/com.github.wwmm.easyeffects.Devel.json
+++ b/util/flatpak/com.github.wwmm.easyeffects.Devel.json
@@ -1,7 +1,7 @@
 {
     "id": "com.github.wwmm.easyeffects.Devel",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.10",
+    "runtime-version": "6.11",
     "sdk": "org.kde.Sdk",
     "branch": "stable",
     "command": "easyeffects",

--- a/util/flatpak/easyeffects-modules.json
+++ b/util/flatpak/easyeffects-modules.json
@@ -2,22 +2,6 @@
     "name": "easyeffects-modules",
     "modules": [
         {
-            "name": "qt6-graphs",
-            "buildsystem": "cmake-ninja",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/qt/qtgraphs.git",
-                    "tag": "v6.10.2",
-                    "commit": "6cd2b17ad3828029520c5b590060bff91ac43ceb",
-                    "//": "We cannot use x-checker-data here as this version has to match the qt/kde runtime"
-                }
-            ],
-            "post-install": [
-                "cp -a $FLATPAK_DEST/lib/*-linux-gnu/*.so $FLATPAK_DEST/lib/*-linux-gnu/*.so.* $FLATPAK_DEST/lib"
-            ]
-        },
-        {
             "name": "libsigc++",
             "buildsystem": "meson",
             "config-opts": [


### PR DESCRIPTION
Means we can drop our build qt6-graphs which often ran into ABI/API mismatches with the QT build in the kde runtime, which caused bugs when the kde flatpak runtime was updated outside of our control.