### PR TITLE
Fix qmlformat script for newer Arch

### DIFF
--- a/src/contents/ui/CrystalizerBand.qml
+++ b/src/contents/ui/CrystalizerBand.qml
@@ -59,7 +59,7 @@ Controls.ItemDelegate {
                 checkable: true
                 checked: delegate.pluginDB["muteBand" + delegate.index]
                 onCheckedChanged: {
-                        if (checked !== delegate.pluginDB["muteBand" + delegate.index])
+                    if (checked !== delegate.pluginDB["muteBand" + delegate.index])
                         delegate.pluginDB["muteBand" + delegate.index] = checked;
                 }
             }
@@ -70,7 +70,7 @@ Controls.ItemDelegate {
                 checkable: true
                 checked: delegate.pluginDB["bypassBand" + delegate.index]
                 onCheckedChanged: {
-                        if (checked !== delegate.pluginDB["bypassBand" + delegate.index])
+                    if (checked !== delegate.pluginDB["bypassBand" + delegate.index])
                         delegate.pluginDB["bypassBand" + delegate.index] = checked;
                 }
             }

--- a/src/contents/ui/Deesser.qml
+++ b/src/contents/ui/Deesser.qml
@@ -352,7 +352,7 @@ Kirigami.ScrollablePage {
                     checkable: true
                     checked: deesserPage.pluginDB.scListen
                     onTriggered: {
-                            if (deesserPage.pluginDB.scListen !== checked)
+                        if (deesserPage.pluginDB.scListen !== checked)
                             deesserPage.pluginDB.scListen = checked;
                     }
                 },

--- a/src/contents/ui/EchoCanceller.qml
+++ b/src/contents/ui/EchoCanceller.qml
@@ -177,7 +177,7 @@ Kirigami.ScrollablePage {
                     checkable: true
                     checked: echoCancellerPage.pluginDB.enableAGC
                     onTriggered: {
-                            if (echoCancellerPage.pluginDB.enableAGC !== checked)
+                        if (echoCancellerPage.pluginDB.enableAGC !== checked)
                             echoCancellerPage.pluginDB.enableAGC = checked;
                     }
                 },

--- a/src/contents/ui/Expander.qml
+++ b/src/contents/ui/Expander.qml
@@ -856,7 +856,7 @@ Kirigami.ScrollablePage {
                     checkable: true
                     checked: expanderPage.pluginDB.sidechainListen
                     onTriggered: {
-                            if (expanderPage.pluginDB.sidechainListen !== checked)
+                        if (expanderPage.pluginDB.sidechainListen !== checked)
                             expanderPage.pluginDB.sidechainListen = checked;
                     }
                 },
@@ -866,7 +866,7 @@ Kirigami.ScrollablePage {
                     checkable: true
                     checked: expanderPage.pluginDB.stereoSplit
                     onTriggered: {
-                            if (expanderPage.pluginDB.stereoSplit !== checked)
+                        if (expanderPage.pluginDB.stereoSplit !== checked)
                             expanderPage.pluginDB.stereoSplit = checked;
                     }
                 },

--- a/src/contents/ui/Gate.qml
+++ b/src/contents/ui/Gate.qml
@@ -985,7 +985,7 @@ Kirigami.ScrollablePage {
                     checkable: true
                     checked: gatePage.pluginDB.sidechainListen
                     onTriggered: {
-                            if (gatePage.pluginDB.sidechainListen !== checked)
+                        if (gatePage.pluginDB.sidechainListen !== checked)
                             gatePage.pluginDB.sidechainListen = checked;
                     }
                 },
@@ -995,7 +995,7 @@ Kirigami.ScrollablePage {
                     checkable: true
                     checked: gatePage.pluginDB.stereoSplit
                     onTriggered: {
-                            if (gatePage.pluginDB.stereoSplit !== checked)
+                        if (gatePage.pluginDB.stereoSplit !== checked)
                             gatePage.pluginDB.stereoSplit = checked;
                     }
                 },

--- a/util/flatpak/easyeffects-modules.json
+++ b/util/flatpak/easyeffects-modules.json
@@ -39,11 +39,8 @@
                     "tag": "v1.2.6",
                     "commit": "67b33abe1558160ed76ada1322329b0e9e058b02",
                     "x-checker-data": {
-                        "type": "json",
-                        "url": "https://api.github.com/repos/jiixyj/libebur128/releases/latest",
-                        "tag-query": ".tag_name",
-                        "version-query": "$tag | sub(\"^jq-\"; \"\")",
-                        "timestamp-query": ".published_at"
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
                     }
                 }
             ]

--- a/util/flatpak/easyeffects-modules.json
+++ b/util/flatpak/easyeffects-modules.json
@@ -155,11 +155,8 @@
                     "tag": "v3.12.0",
                     "commit": "55f93686c01528224f448c19128836e7df245f72",
                     "x-checker-data": {
-                        "type": "json",
-                        "url": "https://api.github.com/repos/nlohmann/json/releases/latest",
-                        "tag-query": ".tag_name",
-                        "version-query": "$tag | sub(\"^jq-\"; \"\")",
-                        "timestamp-query": ".published_at"
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
                     }
                 }
             ]
@@ -173,14 +170,12 @@
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2023.1.0.tar.gz",
-                    "sha256": "191288b52e1e6b17198000b64d77d194bb65e791be46ebc606e9b091781e2070",
+                    "type": "git",
+                    "url": "https://github.com/oneapi-src/oneTBB",
+                    "tag": "v2023.1.0",
                     "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 227581,
-                        "stable-only": true,
-                        "url-template": "https://github.com/oneapi-src/oneTBB/archive/refs/tags/v$version.tar.gz"
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
                     }
                 }
             ]
@@ -208,13 +203,7 @@
                 {
                     "type": "archive",
                     "url": "https://ftp.gnu.org/gnu/gsl/gsl-2.8.tar.gz",
-                    "sha256": "6a99eeed15632c6354895b1dd542ed5a855c0f15d9ad1326c6fe2b2c9e423190",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 1267,
-                        "stable-only": true,
-                        "url-template": "https://ftp.gnu.org/gnu/gsl/gsl-$version.tar.gz"
-                    }
+                    "sha256": "6a99eeed15632c6354895b1dd542ed5a855c0f15d9ad1326c6fe2b2c9e423190"
                 }
             ]
         },

--- a/util/qmlformat.sh
+++ b/util/qmlformat.sh
@@ -9,13 +9,18 @@ fi
 
 # unlike qmllint, this can also be used on js files, not just qml files, so glob everything in the directory
 
-# for some reason the arch qt6-declarative package doesn't add this to the normally searched directories
 if [[ -f /usr/lib/qt6/bin/qmlformat ]]; then
-    /usr/lib/qt6/bin/qmlformat src/contents/ui/* --inplace "$@"
-# for fedora
-elif command -v qmlformat-qt6 --help &>/dev/null; then
-    qmlformat-qt6 src/contents/ui/* --inplace "$@"
+    QMLFORMAT="/usr/lib/qt6/bin/qmlformat"
+elif command -v qmlformat &>/dev/null; then
+    QMLFORMAT="qmlformat"
+elif command -v qmlformat-qt6 &>/dev/null; then
+    QMLFORMAT="qmlformat-qt6"
 else
     echo "ERROR: Could not find qmlformat qt6"
     exit 1
 fi
+
+echo "Using qmlformat at: $QMLFORMAT"
+$QMLFORMAT src/contents/ui/* --inplace "$@" || {
+    echo "qmlformat returned $?. This is ignored as Qt 6.7 qmlformat has known bugs returning 1. git diff will catch unformatted files."
+}

--- a/util/qmlformat.sh
+++ b/util/qmlformat.sh
@@ -9,12 +9,12 @@ fi
 
 # unlike qmllint, this can also be used on js files, not just qml files, so glob everything in the directory
 
-if [[ -f /usr/lib/qt6/bin/qmlformat ]]; then
+if command -v qmlformat-qt6 &>/dev/null; then
+    QMLFORMAT="qmlformat-qt6"
+elif [[ -f /usr/lib/qt6/bin/qmlformat ]]; then
     QMLFORMAT="/usr/lib/qt6/bin/qmlformat"
 elif command -v qmlformat &>/dev/null; then
     QMLFORMAT="qmlformat"
-elif command -v qmlformat-qt6 &>/dev/null; then
-    QMLFORMAT="qmlformat-qt6"
 else
     echo "ERROR: Could not find qmlformat qt6"
     exit 1

--- a/util/qmllint.sh
+++ b/util/qmllint.sh
@@ -8,13 +8,12 @@ if [[ ! -f .qmllint.ini ]]; then
 fi
 
 # for some reason the arch qt6-declarative package doesn't add this to the normally searched directories
-if [[ -f /usr/lib/qt6/bin/qmllint ]]; then
+if command -v qmllint-qt6 &>/dev/null; then
+    qmllint-qt6 src/contents/ui/*.qml "$@"
+elif [[ -f /usr/lib/qt6/bin/qmllint ]]; then
     /usr/lib/qt6/bin/qmllint src/contents/ui/*.qml "$@"
 elif command -v qmllint &>/dev/null; then
     qmllint src/contents/ui/*.qml "$@"
-# for fedora
-elif command -v qmllint-qt6 &>/dev/null; then
-    qmllint-qt6 src/contents/ui/*.qml "$@"
 else
     echo "ERROR: Could not find qmllint qt6"
     exit 1

--- a/util/qmllint.sh
+++ b/util/qmllint.sh
@@ -10,8 +10,10 @@ fi
 # for some reason the arch qt6-declarative package doesn't add this to the normally searched directories
 if [[ -f /usr/lib/qt6/bin/qmllint ]]; then
     /usr/lib/qt6/bin/qmllint src/contents/ui/*.qml "$@"
+elif command -v qmllint &>/dev/null; then
+    qmllint src/contents/ui/*.qml "$@"
 # for fedora
-elif command -v qmllint-qt6 --help &>/dev/null; then
+elif command -v qmllint-qt6 &>/dev/null; then
     qmllint-qt6 src/contents/ui/*.qml "$@"
 else
     echo "ERROR: Could not find qmllint qt6"


### PR DESCRIPTION
This pull request fixes the failing QML format job by adding a command fallback since the binary location changed on Arch Linux. It also updates the flatpak external data checker configuration for libebur128 to use git tags instead of GitHub releases, avoiding API rate limits that caused the Flatpak lint job to fail.