### PR TITLE
fix preset autoload on volume changes

### DIFF
--- a/src/pw_device_manager.cpp
+++ b/src/pw_device_manager.cpp
@@ -167,11 +167,12 @@ void DeviceManager::on_device_event_param(void* object,
 
   enum spa_direction direction {};
   enum spa_param_availability available {};
+  int32_t route_device_id = -1;
 
   if (spa_pod_parse_object(param, SPA_TYPE_OBJECT_ParamRoute, nullptr, SPA_PARAM_ROUTE_direction,
                            SPA_POD_Id(&direction), SPA_PARAM_ROUTE_name, SPA_POD_String(&name),
                            SPA_PARAM_ROUTE_description, SPA_POD_String(&description), SPA_PARAM_ROUTE_available,
-                           SPA_POD_Id(&available)) < 0) {
+                           SPA_POD_Id(&available), SPA_PARAM_ROUTE_device, SPA_POD_OPT_Int(&route_device_id)) < 0) {
     return;
   }
 
@@ -187,6 +188,8 @@ void DeviceManager::on_device_event_param(void* object,
     if (device.id != dd->id) {
       continue;
     }
+
+    device.route_device_id = route_device_id;
 
     if (direction == SPA_DIRECTION_INPUT) {
       device.input_route_name = name;

--- a/src/pw_manager.cpp
+++ b/src/pw_manager.cpp
@@ -250,6 +250,11 @@ Manager::Manager(QObject* parent)
       }
 
       for (auto& node : nodes) {
+        if (node.card_profile_device_id != -1 && device.route_device_id != -1 &&
+            node.card_profile_device_id != device.route_device_id) {
+          continue;
+        }
+
         if (node.media_class == tags::pipewire::media_class::source ||
             node.media_class == tags::pipewire::media_class::virtual_source ||
             node.media_class == tags::pipewire::media_class::duplex) {
@@ -277,6 +282,11 @@ Manager::Manager(QObject* parent)
       }
 
       for (auto& node : nodes) {
+        if (node.card_profile_device_id != -1 && device.route_device_id != -1 &&
+            node.card_profile_device_id != device.route_device_id) {
+          continue;
+        }
+
         if (node.media_class == tags::pipewire::media_class::sink ||
             node.media_class == tags::pipewire::media_class::virtual_sink ||
             node.media_class == tags::pipewire::media_class::duplex) {

--- a/src/pw_node_manager.cpp
+++ b/src/pw_node_manager.cpp
@@ -231,6 +231,8 @@ auto NodeManager::registerNode(pw_registry* registry, uint32_t id, const char* t
 
   util::spa_dict_get_num(props, PW_KEY_DEVICE_ID, nd->nd_info->device_id);
 
+  util::spa_dict_get_num(props, tags::pipewire::card_profile_device, nd->nd_info->card_profile_device_id);
+
   const auto user_blocklist = (media_class == tags::pipewire::media_class::output_stream) ? DbStreamOutputs::blocklist()
                                                                                           : DbStreamInputs::blocklist();
 
@@ -414,6 +416,8 @@ void NodeManager::onNodeInfo(void* object, const pw_node_info* info) {
   }
 
   util::spa_dict_get_num(info->props, PW_KEY_DEVICE_ID, nd->nd_info->device_id);
+
+  util::spa_dict_get_num(info->props, tags::pipewire::card_profile_device, nd->nd_info->card_profile_device_id);
 
   // Now that we know the media name we check the blocklist again
 

--- a/src/pw_objects.hpp
+++ b/src/pw_objects.hpp
@@ -40,6 +40,8 @@ struct NodeInfo {
 
   uint device_id = SPA_ID_INVALID;
 
+  int32_t card_profile_device_id = -1;
+
   QString name;
 
   QString description;
@@ -185,6 +187,8 @@ struct DeviceInfo {
 
   QString output_route_name;
   QString output_route_description;
+
+  int32_t route_device_id = -1;
 
   QString bus_id;
 

--- a/src/tags_pipewire.hpp
+++ b/src/tags_pipewire.hpp
@@ -25,6 +25,8 @@ inline constexpr auto ee_source_name = "easyeffects_source";
 
 inline constexpr auto ee_sink_name = "easyeffects_sink";
 
+inline constexpr auto card_profile_device = "card.profile.device";
+
 }  // namespace tags::pipewire
 
 namespace tags::pipewire::media_class {


### PR DESCRIPTION
Fixes #4729.

PipeWire's Route param includes the profile device it belongs to. EasyEffects currently discards it and applies each enumerated route to every node on the card. Volume changes update route volume props, so cards with several nodes cycle through unrelated routes and reload autoload presets.

Keep card.profile.device for each node and only apply its matching route. Fall back to the old behavior when either id is missing.