### PR TITLE
feat: implement Mid-Side Equalizer effect

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ qt_add_qml_module(easyeffects
         effects_base.hpp
         equalizer.hpp
         exciter.hpp
+        midside_equalizer.hpp
         expander.hpp
         filter.hpp
         gate.hpp
@@ -100,6 +101,7 @@ qt_add_qml_module(easyeffects
         contents/ui/EeSpinBox.qml
         contents/ui/EeSwitch.qml
         contents/ui/Equalizer.qml
+        contents/ui/MidSideEqualizer.qml
         contents/ui/EqualizerBand.qml
         contents/ui/EqualizerBandMenu.qml
         contents/ui/Exciter.qml
@@ -174,6 +176,8 @@ target_sources(easyeffects PRIVATE
     equalizer_apo.cpp
     equalizer_preset.cpp
     exciter.cpp
+    midside_equalizer.cpp
+    midside_equalizer_preset.cpp
     exciter_preset.cpp
     expander.cpp
     expander_preset.cpp

--- a/src/contents/docs/plugins/midside_equalizer.md
+++ b/src/contents/docs/plugins/midside_equalizer.md
@@ -1,0 +1,75 @@
+# Mid-Side Equalizer
+
+The Mid-Side Equalizer processes the Mid (sum) and Side (difference) components of a stereo signal independently. This is useful to, for example, correct the overall tonality of a recording through the Mid channel while leaving only the stereo ambience untouched through the Side channel. Easy Effects uses the Parametric Equalizer x32 MidSide from Linux Studio Plugins. The user can choose from 1 to 32 bands per channel. Width and center frequency of each band can be customized as needed.
+
+## Global Options
+
+**Bands**  
+The number of bands.
+
+**Mode**  
+- **IIR** - Infinite Impulse Response filters, nonlinear minimal phase. In most cases does not add noticeable latency to output signal.
+- **FIR** - Finite Impulse Response filters with linear phase, finite approximation of Equalizer's impulse response. Adds noticeable latency to output signal.
+- **FFT** - Fast Fourier Transform approximation of the frequency chart, linear phase. Adds noticeable latency to output signal.
+
+**Balance**  
+Balance between left and right output channels.
+
+**Pitch Mid**  
+The frequency shift for all filters of the mid channel, in semitones.
+
+**Pitch Side**  
+The frequency shift for all filters of the side channel, in semitones.
+
+**Link Mid/Side**  
+When enabled it is possible to apply different configurations to mid and side channels.
+
+**Flat Response**  
+This function sets each band gain to 0.
+
+**Calculate Frequencies**  
+This function calculates the center frequency and the width of each band using the current number of bands. Useful when the user wants fewer than 32 bands but has no idea about which frequencies should be chosen.
+
+## Band Options
+
+**Type**  
+- **Off** - The filter is not working (turned off).
+- **Bell** - Bell filter with smooth peak/recess.
+- **High Pass** - High Pass filter with rejection of low frequencies.
+- **High Shelf** - Shelving filter with adjustment of high frequency range.
+- **Low Pass** - Low Pass filter with rejection of high frequencies.
+- **Low Shelf** - Shelving filter with adjustment of low frequency range.
+- **Notch** - Notch filter with full rejection of selected frequency.
+- **Resonance** - Resonance filter with sharp peak/recess.
+- **All Pass** - All Pass filter.
+
+**Mode**  
+- **RLC** - Very smooth filters based on similar cascades of RLC contours. Bilinear Z-transform (BT) or Matched Z-transform (MT) is used for pole/zero mapping.
+- **BWC** - Butterworth-Chebyshev-type-1 based filters. Does not affect Resonance and Notch filters. Bilinear Z-transform (BT) or Matched Z-transform (MT) is used for pole/zero mapping.
+- **LRX** - Linkwitz-Riley based filters. Does not affect Resonance and Notch filters. Bilinear Z-transform (BT) or Matched Z-transform (MT) is used for pole/zero mapping.
+- **APO** - Digital biquad filters derived from canonic analog biquad prototypes digitalized through Bilinear transform. These are [textbook filters](https://shepazu.github.io/Audio-EQ-Cookbook/audio-eq-cookbook.html) which are implemented as in the [Equalizer APO](https://equalizerapo.com/) software. Direct design (DR) is used to serve the digital filter coefficients directly in the digital domain, without performing transforms.
+
+**Slope**  
+The slope of the filter characteristics.
+
+**Solo**  
+Makes the selected band the only one active.
+
+**Mute**  
+Mutes the selected band.
+
+**Frequency**  
+Center frequency of the selected band.
+
+**Width**  
+Bandwidth calculated as `width = frequency / quality`.
+
+**Quality**  
+The quality factor of the filter used.
+
+## References
+
+- [Wikipedia Equalization (audio)](https://en.wikipedia.org/wiki/Equalization_(audio))
+- [LSP Parametric Equalizer x32 MidSide](http://lsp-plug.in/?page=manuals&section=para_equalizer_x32_ms)
+- [Wikipedia Q Factor](https://en.wikipedia.org/wiki/Q_factor)
+- [How to EQ - Q Factor and Bandwidth in EQ: What They Mean](https://howtoeq.wordpress.com/2010/10/07/q-factor-and-bandwidth-in-eq-what-it-all-means/)

--- a/src/contents/docs/plugins/midside_equalizer.md
+++ b/src/contents/docs/plugins/midside_equalizer.md
@@ -1,71 +1,71 @@
 # Mid-Side Equalizer
 
-The Mid-Side Equalizer processes the Mid (sum) and Side (difference) components of a stereo signal independently. This is useful to, for example, correct the overall tonality of a recording through the Mid channel while leaving only the stereo ambience untouched through the Side channel. Easy Effects uses the Parametric Equalizer x32 MidSide from Linux Studio Plugins. The user can choose from 1 to 32 bands per channel. Width and center frequency of each band can be customized as needed.
+The Mid-Side Equalizer processes the Mid (sum) and Side (difference) parts of a stereo signal independently. It's useful, for example, to fix the overall tone of a recording through the Mid channel while keeping the stereo ambience untouched on the Side channel. Easy Effects uses the Parametric Equalizer x32 MidSide from Linux Studio Plugins. You can run anywhere from 1 to 32 bands per channel, and tweak the width and center frequency of each band.
 
 ## Global Options
 
 **Bands**  
-The number of bands.
+Number of bands.
 
 **Mode**  
-- **IIR** - Infinite Impulse Response filters, nonlinear minimal phase. In most cases does not add noticeable latency to output signal.
-- **FIR** - Finite Impulse Response filters with linear phase, finite approximation of Equalizer's impulse response. Adds noticeable latency to output signal.
-- **FFT** - Fast Fourier Transform approximation of the frequency chart, linear phase. Adds noticeable latency to output signal.
+- **IIR** - Infinite Impulse Response filters, nonlinear minimal phase. Usually doesn't add noticeable latency to the output.
+- **FIR** - Finite Impulse Response filters with linear phase, a finite approximation of the equalizer's impulse response. Adds noticeable latency to the output.
+- **FFT** - Fast Fourier Transform approximation of the frequency chart, linear phase. Adds noticeable latency to the output.
 
 **Balance**  
-Balance between left and right output channels.
+Balance between the left and right output channels.
 
 **Pitch Mid**  
-The frequency shift for all filters of the mid channel, in semitones.
+Frequency shift for all mid channel filters, in semitones.
 
 **Pitch Side**  
-The frequency shift for all filters of the side channel, in semitones.
+Frequency shift for all side channel filters, in semitones.
 
 **Link Mid/Side**  
-When enabled it is possible to apply different configurations to mid and side channels.
+When enabled, you can apply different configurations to the mid and side channels.
 
 **Flat Response**  
-This function sets each band gain to 0.
+Resets all band gains to 0.
 
 **Calculate Frequencies**  
-This function calculates the center frequency and the width of each band using the current number of bands. Useful when the user wants fewer than 32 bands but has no idea about which frequencies should be chosen.
+Figures out the center frequency and width for each band based on the current band count. Handy if you want fewer than 32 bands but aren't sure which frequencies to pick.
 
 ## Band Options
 
 **Type**  
-- **Off** - The filter is not working (turned off).
+- **Off** - Filter is disabled.
 - **Bell** - Bell filter with smooth peak/recess.
-- **High Pass** - High Pass filter with rejection of low frequencies.
-- **High Shelf** - Shelving filter with adjustment of high frequency range.
-- **Low Pass** - Low Pass filter with rejection of high frequencies.
-- **Low Shelf** - Shelving filter with adjustment of low frequency range.
-- **Notch** - Notch filter with full rejection of selected frequency.
+- **High Pass** - High Pass filter that removes low frequencies.
+- **High Shelf** - Shelving filter that adjusts the high frequency range.
+- **Low Pass** - Low Pass filter that removes high frequencies.
+- **Low Shelf** - Shelving filter that adjusts the low frequency range.
+- **Notch** - Notch filter that fully rejects the selected frequency.
 - **Resonance** - Resonance filter with sharp peak/recess.
 - **All Pass** - All Pass filter.
 
 **Mode**  
-- **RLC** - Very smooth filters based on similar cascades of RLC contours. Bilinear Z-transform (BT) or Matched Z-transform (MT) is used for pole/zero mapping.
-- **BWC** - Butterworth-Chebyshev-type-1 based filters. Does not affect Resonance and Notch filters. Bilinear Z-transform (BT) or Matched Z-transform (MT) is used for pole/zero mapping.
-- **LRX** - Linkwitz-Riley based filters. Does not affect Resonance and Notch filters. Bilinear Z-transform (BT) or Matched Z-transform (MT) is used for pole/zero mapping.
-- **APO** - Digital biquad filters derived from canonic analog biquad prototypes digitalized through Bilinear transform. These are [textbook filters](https://shepazu.github.io/Audio-EQ-Cookbook/audio-eq-cookbook.html) which are implemented as in the [Equalizer APO](https://equalizerapo.com/) software. Direct design (DR) is used to serve the digital filter coefficients directly in the digital domain, without performing transforms.
+- **RLC** - Very smooth filters built from cascaded RLC contours. Uses Bilinear Z-transform (BT) or Matched Z-transform (MT) for pole/zero mapping.
+- **BWC** - Butterworth-Chebyshev-type-1 based filters. Doesn't affect Resonance and Notch filters. Uses Bilinear Z-transform (BT) or Matched Z-transform (MT) for pole/zero mapping.
+- **LRX** - Linkwitz-Riley based filters. Doesn't affect Resonance and Notch filters. Uses Bilinear Z-transform (BT) or Matched Z-transform (MT) for pole/zero mapping.
+- **APO** - Digital biquad filters derived from canonical analog biquad prototypes digitalized through Bilinear transform. These are [textbook filters](https://shepazu.github.io/Audio-EQ-Cookbook/audio-eq-cookbook.html) implemented the same way as in [Equalizer APO](https://equalizerapo.com/). Direct design (DR) generates the digital filter coefficients directly in the digital domain, without any transforms.
 
 **Slope**  
-The slope of the filter characteristics.
+Slope of the filter curve.
 
 **Solo**  
-Makes the selected band the only one active.
+Makes the selected band the only active one.
 
 **Mute**  
 Mutes the selected band.
 
 **Frequency**  
-Center frequency of the selected band.
+Center frequency of the band.
 
 **Width**  
-Bandwidth calculated as `width = frequency / quality`.
+Bandwidth, calculated as `width = frequency / quality`.
 
 **Quality**  
-The quality factor of the filter used.
+Quality factor of the filter.
 
 ## References
 

--- a/src/contents/kcfg/easyeffects_db_midside_equalizer.kcfg
+++ b/src/contents/kcfg/easyeffects_db_midside_equalizer.kcfg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kcfg xmlns="http://www.kde.org/standards/kcfg/1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0 http://www.kde.org/standards/kcfg/1.0/kcfg.xsd">
+    <kcfgfile name="easyeffects/db/midsideequalizerrc">
+        <parameter name="masterGroup" />
+        <parameter name="instanceIndex" />
+    </kcfgfile>
+    <group parentGroupName="$(masterGroup)" name="MidSideEqualizer#$(instanceIndex)">
+        <entry name="bypass" type="Bool">
+            <label></label>
+            <default>false</default>
+        </entry>
+        <entry name="inputGain" type="Double">
+            <label></label>
+            <min>-36</min>
+            <max>36</max>
+            <default>0</default>
+        </entry>
+        <entry name="outputGain" type="Double">
+            <label></label>
+            <min>-36</min>
+            <max>36</max>
+            <default>0</default>
+        </entry>
+        <entry name="numBands" type="Int">
+            <label></label>
+            <min>1</min>
+            <max>32</max>
+            <default>32</default>
+        </entry>
+        <entry name="modeLabels" type="StringList">
+            <default>IIR,FIR,FFT,SPM</default>
+        </entry>
+        <entry name="mode" type="Int">
+            <label></label>
+            <default>0</default>
+        </entry>
+        <entry name="splitChannels" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="balance" type="Double">
+            <label></label>
+            <min>-100</min>
+            <max>100</max>
+            <default>0</default>
+        </entry>
+        <entry name="pitchMid" type="Double">
+            <label></label>
+            <min>-120</min>
+            <max>120</max>
+            <default>0</default>
+        </entry>
+        <entry name="pitchSide" type="Double">
+            <label></label>
+            <min>-120</min>
+            <max>120</max>
+            <default>0</default>
+        </entry>
+        <entry name="viewMidChannel" type="Bool">
+            <label></label>
+            <default>true</default>
+        </entry>
+        <entry name="decrampLabels" type="StringList">
+            <default>Off,x2,x3,x4,x6,x8</default>
+        </entry>
+        <entry name="decramp" type="Int">
+            <label></label>
+            <default>0</default>
+        </entry>
+    </group>
+</kcfg>

--- a/src/contents/kcfg/easyeffects_db_midside_equalizer.kcfgc
+++ b/src/contents/kcfg/easyeffects_db_midside_equalizer.kcfgc
@@ -1,0 +1,11 @@
+File=easyeffects_db_midside_equalizer.kcfg
+ClassName=DbMidSideEqualizer
+Inherits=KConfigBaseEE
+IncludeFiles=\"kconfig_base_ee.hpp\"
+Mutators=true
+Notifiers=true
+DefaultValueGetters=true
+Singleton=false
+GenerateProperties=true
+QmlUncreatable=true
+QmlRegistration=true

--- a/src/contents/ui/MidSideEqualizer.qml
+++ b/src/contents/ui/MidSideEqualizer.qml
@@ -1,0 +1,409 @@
+/**
+ * Copyright © 2026 Alessio Attilio
+ *
+ * This file is part of Easy Effects.
+ *
+ * Easy Effects is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easy Effects is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easy Effects. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+//pragma explanation: https://doc.qt.io/qt-6/qtqml-documents-structure.html
+pragma ComponentBehavior: Bound
+import QtCore
+import QtQuick
+import QtQuick.Controls as Controls
+import QtQuick.Dialogs
+import QtQuick.Layouts
+import ee.ui
+import org.kde.kirigami as Kirigami
+import org.kde.kirigamiaddons.formcard as FormCard
+
+Kirigami.ScrollablePage {
+    id: midsideEqualizerPage
+
+    required property string name
+    required property DbMidSideEqualizer pluginDB
+    required property DbEqualizerChannel midDB
+    required property DbEqualizerChannel sideDB
+    required property EffectsBase pipelineInstance
+    property BackendMidSideEqualizer pluginBackend
+
+    function updateMeters() {
+        if (!pluginBackend)
+            return;
+
+        inputOutputLevels.setInputLevelLeft(pluginBackend.getInputLevelLeft());
+        inputOutputLevels.setInputLevelRight(pluginBackend.getInputLevelRight());
+        inputOutputLevels.setOutputLevelLeft(pluginBackend.getOutputLevelLeft());
+        inputOutputLevels.setOutputLevelRight(pluginBackend.getOutputLevelRight());
+    }
+
+    Component.onCompleted: {
+        pluginBackend = pipelineInstance.getPluginInstance(name);
+    }
+
+    EqualizerBandMenu {
+        id: bandMenu
+
+        bandDB: midsideEqualizerPage.pluginDB.splitChannels ? (midsideEqualizerPage.pluginDB.viewMidChannel ? midsideEqualizerPage.midDB : midsideEqualizerPage.sideDB) : midsideEqualizerPage.midDB // qmllint disable
+    }
+
+    FileDialog {
+        id: apoFileDialog
+
+        fileMode: FileDialog.OpenFiles
+        currentFolder: StandardPaths.standardLocations(StandardPaths.DownloadLocation)[0]
+        nameFilters: [`${i18n("APO preset")} (*.txt)`] // qmllint disable
+        onAccepted: {
+            if (midsideEqualizerPage.pluginBackend.importApoPreset(apoFileDialog.selectedFiles) === false) {
+                appWindow.showStatus(i18n("Failed to import the Mid-Side Equalizer APO preset file."), Kirigami.MessageType.Error, false); // qmllint disable
+            } else {
+                let status = "";
+
+                if (!midsideEqualizerPage.pluginDB.splitChannels) {
+                    status = i18n("Imported the Mid-Side Equalizer APO preset file."); // qmllint disable
+                } else if (midsideEqualizerPage.pluginDB.viewMidChannel) {
+                    status = i18n("Imported the Mid-Side Equalizer APO preset file into the mid channel."); // qmllint disable
+                } else {
+                    status = i18n("Imported the Mid-Side Equalizer APO preset file into the side channel."); // qmllint disable
+                }
+
+                appWindow.showStatus(status, Kirigami.MessageType.Positive);
+            }
+        }
+    }
+
+    FileDialog {
+        id: apoGraphicEqFileDialog
+
+        fileMode: FileDialog.OpenFiles
+        currentFolder: StandardPaths.standardLocations(StandardPaths.DownloadLocation)[0]
+        nameFilters: [`${i18n("GraphicEQ preset")} (*.txt)`] // qmllint disable
+        onAccepted: {
+            if (midsideEqualizerPage.pluginBackend.importApoGraphicEqPreset(apoGraphicEqFileDialog.selectedFiles) === true) {
+                appWindow.showStatus(i18n("Imported the GraphicEQ preset file."), Kirigami.MessageType.Positive); // qmllint disable
+            } else {
+                appWindow.showStatus(i18n("Failed to import the GraphicEQ preset file."), Kirigami.MessageType.Error, false); // qmllint disable
+            }
+        }
+    }
+
+    FileDialog {
+        id: apoExportFileDialog
+
+        fileMode: FileDialog.SaveFile
+        currentFolder: StandardPaths.standardLocations(StandardPaths.DownloadLocation)[0]
+        nameFilters: [`${i18n("APO preset")} (*.txt)`] // qmllint disable
+        onAccepted: {
+            if (midsideEqualizerPage.pluginBackend.exportApoPreset(apoExportFileDialog.selectedFile) === false) {
+                appWindow.showStatus(i18n("Failed to export the current Mid-Side Equalizer settings to an external APO preset file."), Kirigami.MessageType.Error, false); // qmllint disable
+            } else {
+                let status = "";
+
+                if (!midsideEqualizerPage.pluginDB.splitChannels) {
+                    status = i18n("Exported the current Mid-Side Equalizer settings to an external APO preset file."); // qmllint disable
+                } else if (midsideEqualizerPage.pluginDB.viewMidChannel) {
+                    status = i18n("Exported the current Mid-Side Equalizer settings of the mid channel to an external APO preset file."); // qmllint disable
+                } else {
+                    status = i18n("Exported the current Mid-Side Equalizer settings of the side channel to an external APO preset file."); // qmllint disable
+                }
+
+                appWindow.showStatus(status, Kirigami.MessageType.Positive);
+            }
+        }
+    }
+
+    ColumnLayout {
+        height: midsideEqualizerPage.height - midsideEqualizerPage.header.height - midsideEqualizerPage.footer.height - Kirigami.Units.gridUnit
+        Kirigami.CardsLayout {
+            maximumColumns: 6
+            readonly property real columnSize: pitchMid.implicitWidth
+            minimumColumnWidth: columnSize
+            maximumColumnWidth: columnSize
+            Layout.fillHeight: false
+
+            FormCard.FormComboBoxDelegate {
+                id: mode
+
+                text: i18n("Mode") // qmllint disable
+                displayMode: FormCard.FormComboBoxDelegate.ComboBox
+                currentIndex: midsideEqualizerPage.pluginDB.mode
+                editable: false
+                model: [i18n("IIR"), i18n("FIR"), i18n("FFT"), i18n("SPM")]
+                onActivated: idx => {
+                    midsideEqualizerPage.pluginDB.mode = idx;
+                }
+            }
+
+            FormCard.FormComboBoxDelegate {
+                id: decramp
+
+                verticalPadding: Kirigami.Units.smallSpacing
+                text: i18n("Equalizer decramping") // qmllint disable
+                displayMode: FormCard.FormComboBoxDelegate.ComboBox
+                currentIndex: midsideEqualizerPage.pluginDB.decramp
+                editable: false
+                model: [i18n("Off"), i18n("x2"), i18n("x3"), i18n("x4"), i18n("x6"), i18n("x8")]
+                onActivated: idx => {
+                    midsideEqualizerPage.pluginDB.decramp = idx;
+                }
+            }
+
+            EeSpinBox {
+                id: numBands
+
+                label: i18n("Bands") // qmllint disable
+                labelAbove: true
+                spinboxLayoutFillWidth: true
+                from: midsideEqualizerPage.pluginDB.getMinValue("numBands")
+                to: midsideEqualizerPage.pluginDB.getMaxValue("numBands")
+                value: midsideEqualizerPage.pluginDB.numBands
+                decimals: 0
+                stepSize: 1
+                onValueModified: v => {
+                    midsideEqualizerPage.pluginDB.numBands = v;
+                }
+            }
+
+            EeSpinBox {
+                id: balance
+
+                label: i18n("Balance") // qmllint disable
+                labelAbove: true
+                spinboxLayoutFillWidth: true
+                from: midsideEqualizerPage.pluginDB.getMinValue("balance")
+                to: midsideEqualizerPage.pluginDB.getMaxValue("balance")
+                value: midsideEqualizerPage.pluginDB.balance
+                decimals: 1
+                stepSize: 0.1
+                unit: Units.percent
+                onValueModified: v => {
+                    midsideEqualizerPage.pluginDB.balance = v;
+                }
+            }
+
+            EeSpinBox {
+                id: pitchMid
+
+                label: i18n("Pitch mid") // qmllint disable
+                labelAbove: true
+                spinboxLayoutFillWidth: true
+                from: midsideEqualizerPage.pluginDB.getMinValue("pitchMid")
+                to: midsideEqualizerPage.pluginDB.getMaxValue("pitchMid")
+                value: midsideEqualizerPage.pluginDB.pitchMid
+                decimals: 2
+                stepSize: 0.01
+                unit: i18n("st")
+                onValueModified: v => {
+                    midsideEqualizerPage.pluginDB.pitchMid = v;
+                }
+            }
+
+            EeSpinBox {
+                id: pitchSide
+
+                label: i18n("Pitch side") // qmllint disable
+                labelAbove: true
+                spinboxLayoutFillWidth: true
+                from: midsideEqualizerPage.pluginDB.getMinValue("pitchSide")
+                to: midsideEqualizerPage.pluginDB.getMaxValue("pitchSide")
+                value: midsideEqualizerPage.pluginDB.pitchSide
+                decimals: 2
+                stepSize: 0.01
+                unit: i18n("st")
+                onValueModified: v => {
+                    midsideEqualizerPage.pluginDB.pitchSide = v;
+                }
+            }
+        }
+
+        Kirigami.CardsLayout {
+            maximumColumns: 1
+            readonly property real columnSize: bandsCard.implicitWidth
+            minimumColumnWidth: columnSize
+            maximumColumnWidth: columnSize
+            Layout.minimumHeight: Kirigami.Units.gridUnit * 20
+
+            Kirigami.Card {
+                id: bandsCard
+                Layout.fillHeight: true
+
+                header: RowLayout {
+                    Kirigami.Heading {
+                        visible: midsideEqualizerPage.pluginDB.splitChannels
+                        text: midsideEqualizerPage.pluginDB.splitChannels ? (midsideEqualizerPage.pluginDB.viewMidChannel ? i18n("Mid") : i18n("Side")) : "" // qmllint disable
+                        level: 2
+                    }
+
+                    Kirigami.ActionToolBar {
+                        Layout.margins: Kirigami.Units.smallSpacing
+                        alignment: Qt.AlignRight
+                        position: Controls.ToolBar.Header
+                        flat: true
+                        actions: [
+                            Kirigami.Action {
+                                id: viewMid
+                                visible: midsideEqualizerPage.pluginDB.splitChannels
+                                checkable: true
+                                checked: midsideEqualizerPage.pluginDB.viewMidChannel
+                                icon.name: "arrow-up-symbolic"
+                                onTriggered: {
+                                    midsideEqualizerPage.pluginDB.viewMidChannel = true;
+                                }
+                            },
+                            Kirigami.Action {
+                                id: viewSide
+                                visible: midsideEqualizerPage.pluginDB.splitChannels
+                                checkable: true
+                                checked: !midsideEqualizerPage.pluginDB.viewMidChannel
+                                icon.name: "arrow-down-symbolic"
+                                onTriggered: {
+                                    midsideEqualizerPage.pluginDB.viewMidChannel = false;
+                                }
+                            }
+                        ]
+                    }
+                }
+
+                footer: Controls.ScrollBar {
+                    id: listViewScrollBar
+
+                    Layout.fillWidth: true
+                }
+
+                contentItem: ListView {
+                    id: listview
+
+                    implicitWidth: contentItem.childrenRect.width < midsideEqualizerPage.width ? contentItem.childrenRect.width : midsideEqualizerPage.width - 4 * (bandsCard.leftPadding + bandsCard.rightPadding)
+                    clip: true
+                    reuseItems: true
+                    orientation: ListView.Horizontal
+                    model: midsideEqualizerPage.pluginDB.numBands
+                    Controls.ScrollBar.horizontal: listViewScrollBar
+
+                    delegate: EqualizerBand {
+                        bandDB: midsideEqualizerPage.pluginDB.splitChannels ? (midsideEqualizerPage.pluginDB.viewMidChannel ? midsideEqualizerPage.midDB : midsideEqualizerPage.sideDB) : midsideEqualizerPage.midDB // qmllint disable
+
+                        menu: bandMenu
+                    }
+                }
+            }
+        }
+    }
+
+    EeInputOutputGain {
+        id: inputOutputLevels
+
+        pluginDB: midsideEqualizerPage.pluginDB
+    }
+
+    header: inputOutputLevels
+
+    footer: ColumnLayout {
+        RowLayout {
+            Controls.Label {
+                text: i18n("Using %1", `<strong>${PluginsPackage.lsp}</strong>`) // qmllint disable
+                textFormat: Text.RichText
+                horizontalAlignment: Qt.AlignLeft
+                verticalAlignment: Qt.AlignVCenter
+                Layout.fillWidth: false
+                Layout.leftMargin: Kirigami.Units.mediumSpacing * 2
+                Layout.rightMargin: Kirigami.Units.largeSpacing * 8
+                color: Kirigami.Theme.disabledTextColor
+            }
+
+            Kirigami.ActionToolBar {
+                Layout.margins: Kirigami.Units.smallSpacing
+                alignment: Qt.AlignRight
+                position: Controls.ToolBar.Footer
+                flat: true
+                actions: [
+                    Kirigami.Action {
+                        displayHint: Kirigami.DisplayHint.KeepVisible
+                        text: i18n("Show native window") // qmllint disable
+                        icon.name: "window-duplicate-symbolic"
+                        enabled: DbMain.showNativePluginUi
+                        checkable: true
+                        checked: midsideEqualizerPage.pluginBackend ? midsideEqualizerPage.pluginBackend.hasNativeUi() : false
+                        onTriggered: {
+                            if (checked)
+                                midsideEqualizerPage.pluginBackend.showNativeUi();
+                            else
+                                midsideEqualizerPage.pluginBackend.closeNativeUi();
+                        }
+                    },
+                    Kirigami.Action {
+                        text: i18n("Link Mid/Side") // qmllint disable
+                        icon.name: "split-symbolic"
+                        checkable: true
+                        checked: midsideEqualizerPage.pluginDB.splitChannels
+                        onTriggered: {
+                            if (midsideEqualizerPage.pluginDB.splitChannels !== checked)
+                                midsideEqualizerPage.pluginDB.splitChannels = checked;
+                        }
+                    },
+                    Kirigami.Action {
+                        text: i18n("Flat response") // qmllint disable
+                        icon.name: "map-flat-symbolic"
+                        onTriggered: {
+                            midsideEqualizerPage.pluginBackend.flatResponse();
+                        }
+                    },
+                    Kirigami.Action {
+                        text: i18n("Calculate frequencies") // qmllint disable
+                        icon.name: "folder-calculate-symbolic"
+                        onTriggered: {
+                            midsideEqualizerPage.pluginBackend.calculateFrequencies();
+                        }
+                    },
+                    Kirigami.Action {
+                        text: i18n("Sort bands") // qmllint disable
+                        icon.name: "sort_incr-symbolic"
+                        onTriggered: {
+                            midsideEqualizerPage.pluginBackend.sortBands();
+                        }
+                    },
+                    Kirigami.Action {
+                        text: i18n("Import APO") // qmllint disable
+                        icon.name: "document-import-symbolic"
+                        onTriggered: {
+                            apoFileDialog.open();
+                        }
+                    },
+                    Kirigami.Action {
+                        text: i18n("Import APO (GraphicEQ)") // qmllint disable
+                        icon.name: "document-import-symbolic"
+                        onTriggered: {
+                            apoGraphicEqFileDialog.open();
+                        }
+                    },
+                    Kirigami.Action {
+                        text: i18n("Export APO") // qmllint disable
+                        icon.name: "document-export-symbolic"
+                        onTriggered: {
+                            apoExportFileDialog.open();
+                        }
+                    },
+                    Kirigami.Action {
+                        displayHint: Kirigami.DisplayHint.KeepVisible
+                        text: i18n("Reset") // qmllint disable
+                        icon.name: "edit-reset-symbolic"
+                        onTriggered: {
+                            midsideEqualizerPage.pluginBackend.reset();
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/contents/ui/PageStreamsEffects.qml
+++ b/src/contents/ui/PageStreamsEffects.qml
@@ -190,6 +190,7 @@ Kirigami.Page {
                     [PluginsBaseName.deepfilternet]: Qt.resolvedUrl("DeepFilterNet.qml"),
                     [PluginsBaseName.deesser]: Qt.resolvedUrl("Deesser.qml"),
                     [PluginsBaseName.equalizer]: Qt.resolvedUrl("Equalizer.qml"),
+                    [PluginsBaseName.midsideEqualizer]: Qt.resolvedUrl("MidSideEqualizer.qml"),
                     [PluginsBaseName.exciter]: Qt.resolvedUrl("Exciter.qml"),
                     [PluginsBaseName.echoCanceller]: Qt.resolvedUrl("EchoCanceller.qml"),
                     [PluginsBaseName.expander]: Qt.resolvedUrl("Expander.qml"),
@@ -222,6 +223,7 @@ Kirigami.Page {
                     [PluginsBaseName.deepfilternet]: PluginsPackage.deepfilternet,
                     [PluginsBaseName.deesser]: PluginsPackage.calf,
                     [PluginsBaseName.equalizer]: PluginsPackage.lsp,
+                    [PluginsBaseName.midsideEqualizer]: PluginsPackage.lsp,
                     [PluginsBaseName.exciter]: PluginsPackage.calf,
                     [PluginsBaseName.expander]: PluginsPackage.lsp,
                     [PluginsBaseName.filter]: PluginsPackage.lsp,
@@ -259,19 +261,27 @@ Kirigami.Page {
                     return;
                 }
 
-                if (baseName !== PluginsBaseName.equalizer) {
-                    pluginsStack.push(componentUrl, {
-                        name: name,
-                        pluginDB: pluginDB,
-                        pipelineInstance: pageStreamsEffects.pipelineInstance
-                    });
-                } else {
+                if (baseName === PluginsBaseName.equalizer) {
                     pluginsStack.push(componentUrl, {
                         name: name,
                         pluginDB: pluginDB,
                         pipelineInstance: pageStreamsEffects.pipelineInstance,
                         leftDB: pageStreamsEffects.pluginsDB[`${name}#left`],
                         rightDB: pageStreamsEffects.pluginsDB[`${name}#right`]
+                    });
+                } else if (baseName === PluginsBaseName.midsideEqualizer) {
+                    pluginsStack.push(componentUrl, {
+                        name: name,
+                        pluginDB: pluginDB,
+                        pipelineInstance: pageStreamsEffects.pipelineInstance,
+                        midDB: pageStreamsEffects.pluginsDB[`${name}#mid`],
+                        sideDB: pageStreamsEffects.pluginsDB[`${name}#side`]
+                    });
+                } else {
+                    pluginsStack.push(componentUrl, {
+                        name: name,
+                        pluginDB: pluginDB,
+                        pipelineInstance: pageStreamsEffects.pipelineInstance
                     });
                 }
             }

--- a/src/db_manager.cpp
+++ b/src/db_manager.cpp
@@ -45,6 +45,7 @@
 #include "easyeffects_db_echo_canceller.h"
 #include "easyeffects_db_equalizer.h"
 #include "easyeffects_db_equalizer_channel.h"
+#include "easyeffects_db_midside_equalizer.h"
 #include "easyeffects_db_exciter.h"
 #include "easyeffects_db_expander.h"
 #include "easyeffects_db_filter.h"
@@ -238,6 +239,14 @@ void Manager::create_plugin_db(const QString& parentGroup,
                    [&] { return new DbEqualizerChannel(parentGroup, id, "left"); });
       ensureExists(makeKey(tags::plugin_name::BaseName::equalizer, id, "right"),
                    [&] { return new DbEqualizerChannel(parentGroup, id, "right"); });
+
+    } else if (name.startsWith(tags::plugin_name::BaseName::midsideEqualizer)) {
+      ensureExists(makeKey(tags::plugin_name::BaseName::midsideEqualizer, id),
+                   [&] { return new DbMidSideEqualizer(parentGroup, id); });
+      ensureExists(makeKey(tags::plugin_name::BaseName::midsideEqualizer, id, "mid"),
+                   [&] { return new DbEqualizerChannel(parentGroup, id, "mid"); });
+      ensureExists(makeKey(tags::plugin_name::BaseName::midsideEqualizer, id, "side"),
+                   [&] { return new DbEqualizerChannel(parentGroup, id, "side"); });
 
     } else if (name.startsWith(tags::plugin_name::BaseName::exciter)) {
       ensureExists(makeKey(tags::plugin_name::BaseName::exciter, id), [&] { return new DbExciter(parentGroup, id); });

--- a/src/effects_base.cpp
+++ b/src/effects_base.cpp
@@ -55,6 +55,7 @@
 #include "echo_canceller.hpp"
 #include "equalizer.hpp"
 #include "exciter.hpp"
+#include "midside_equalizer.hpp"
 #include "expander.hpp"
 #include "filter.hpp"
 #include "gate.hpp"
@@ -203,6 +204,9 @@ void EffectsBase::create_filters_if_necessary() {
 
     } else if (name.startsWith(tags::plugin_name::BaseName::equalizer)) {
       filter = std::make_unique<Equalizer>(log_tag, pm, pipeline_type, instance_id);
+
+    } else if (name.startsWith(tags::plugin_name::BaseName::midsideEqualizer)) {
+      filter = std::make_unique<MidSideEqualizer>(log_tag, pm, pipeline_type, instance_id);
 
     } else if (name.startsWith(tags::plugin_name::BaseName::filter)) {
       filter = std::make_unique<Filter>(log_tag, pm, pipeline_type, instance_id);
@@ -363,6 +367,9 @@ QVariant EffectsBase::getPluginInstance(const QString& pluginName) {
 
   } else if (pluginName.startsWith(tags::plugin_name::BaseName::equalizer)) {
     return QVariant::fromValue(dynamic_cast<Equalizer*>(p.get()));
+
+  } else if (pluginName.startsWith(tags::plugin_name::BaseName::midsideEqualizer)) {
+    return QVariant::fromValue(dynamic_cast<MidSideEqualizer*>(p.get()));
 
   } else if (pluginName.startsWith(tags::plugin_name::BaseName::exciter)) {
     return QVariant::fromValue(dynamic_cast<Exciter*>(p.get()));

--- a/src/equalizer_apo.cpp
+++ b/src/equalizer_apo.cpp
@@ -724,4 +724,264 @@ auto export_apo_preset(DbEqualizer* settings,
   return !write_buffer.fail();
 }
 
+// ### MidSideEqualizer Section ###
+
+auto import_apo_preset(DbMidSideEqualizer* settings,
+                       DbEqualizerChannel* settings_mid,
+                       DbEqualizerChannel* settings_side,
+                       const std::string& file_path) -> bool {
+  std::filesystem::path p{file_path};
+
+  if (!std::filesystem::is_regular_file(p)) {
+    return false;
+  }
+
+  std::ifstream eq_file;
+  eq_file.open(p.c_str());
+
+  std::vector<struct APO_Band> bands;
+  double preamp = 0.0;
+
+  if (const auto re = std::regex(R"(^[ \t]*#)"); eq_file.is_open()) {
+    for (std::string line; std::getline(eq_file, line);) {
+      if (std::regex_search(line, re)) {  // Avoid commented lines
+        continue;
+      }
+
+      if (struct APO_Band filter; parse_apo_config_line(line, filter)) {
+        bands.push_back(filter);
+      } else {
+        parse_apo_preamp(line, preamp);
+      }
+    }
+  }
+
+  eq_file.close();
+
+  if (bands.empty()) {
+    return false;
+  }
+
+  const auto max_bands = static_cast<int>(settings->getMaxValue(num_bands));
+  const auto apo_bands = static_cast<int>(bands.size());
+
+  settings->setInputGain(preamp);
+
+  std::vector<DbEqualizerChannel*> settings_channels;
+
+  if (!settings->splitChannels()) {
+    settings->setNumBands(std::min(apo_bands, max_bands));
+
+    settings_channels.push_back(settings_mid);
+    settings_channels.push_back(settings_side);
+  } else {
+    settings->setNumBands(std::clamp(apo_bands, settings->numBands(), max_bands));
+
+    if (settings->viewMidChannel()) {
+      settings_channels.push_back(settings_mid);
+    } else {
+      settings_channels.push_back(settings_side);
+    }
+  }
+
+  for (int n = 0U; n < max_bands; n++) {
+    for (auto* channel : settings_channels) {
+      if (n < apo_bands) {
+        if (bands[n].freq >= channel->getMinValue(band_frequency[n].data()) &&
+            bands[n].freq <= channel->getMaxValue(band_frequency[n].data())) {
+          channel->setProperty(band_frequency[n].data(), bands[n].freq);
+
+          std::string current_band_type;
+
+          try {
+            current_band_type = ApoToEqualizerFilter.at(bands[n].type);
+          } catch (std::out_of_range const&) {
+            current_band_type = "Off";
+          }
+
+          channel->setProperty(band_type[n].data(), channel->bandTypeLabels().indexOf(current_band_type));
+
+        } else {
+          channel->resetProperty(band_frequency[n].data());
+          channel->setProperty(band_type[n].data(), channel->bandTypeLabels().indexOf("Off"));
+        }
+
+        if (bands[n].gain >= channel->getMinValue(band_gain[n].data()) &&
+            bands[n].gain <= channel->getMaxValue(band_gain[n].data())) {
+          channel->setProperty(band_gain[n].data(), bands[n].gain);
+
+        } else {
+          channel->resetProperty(band_gain[n].data());
+        }
+
+        if (bands[n].quality >= channel->getMinValue(band_q[n].data()) &&
+            bands[n].quality <= channel->getMaxValue(band_q[n].data())) {
+          channel->setProperty(band_q[n].data(), bands[n].quality);
+
+        } else {
+          channel->resetProperty(band_q[n].data());
+        }
+
+        channel->setProperty(band_mode[n].data(), channel->bandModeLabels().indexOf("APO (DR)"));
+      } else {
+        channel->setProperty(band_type[n].data(), channel->bandTypeLabels().indexOf("Off"));
+        channel->resetProperty(band_frequency[n].data());
+        channel->resetProperty(band_gain[n].data());
+        channel->resetProperty(band_q[n].data());
+        channel->resetProperty(band_mode[n].data());
+      }
+
+      channel->resetProperty(band_width[n].data());
+      channel->resetProperty(band_slope[n].data());
+      channel->resetProperty(band_solo[n].data());
+      channel->resetProperty(band_mute[n].data());
+    }
+  }
+
+  return true;
+}
+
+auto import_graphiceq_preset(DbMidSideEqualizer* settings,
+                             DbEqualizerChannel* settings_mid,
+                             DbEqualizerChannel* settings_side,
+                             const std::string& file_path) -> bool {
+  std::filesystem::path p{file_path};
+
+  if (!std::filesystem::is_regular_file(p)) {
+    return false;
+  }
+
+  std::ifstream eq_file;
+  eq_file.open(p.c_str());
+
+  std::vector<struct GraphicEQ_Band> bands;
+
+  if (const auto re = std::regex(R"(^[ \t]*#)"); eq_file.is_open()) {
+    for (std::string line; std::getline(eq_file, line);) {
+      if (std::regex_search(line, re)) {  // Avoid commented lines
+        continue;
+      }
+      if (parse_graphiceq_config(line, bands)) {
+        break;
+      }
+    }
+  }
+
+  eq_file.close();
+
+  if (bands.empty()) {
+    return false;
+  }
+
+  const auto max_bands = static_cast<int>(settings->getMaxValue(num_bands));
+  const auto geq_bands = static_cast<int>(bands.size());
+
+  settings->resetProperty("input-gain");
+
+  std::vector<DbEqualizerChannel*> settings_channels;
+
+  if (!settings->splitChannels()) {
+    settings->setNumBands(std::min(geq_bands, max_bands));
+
+    settings_channels.push_back(settings_mid);
+    settings_channels.push_back(settings_side);
+  } else {
+    settings->setNumBands(std::clamp(geq_bands, settings->numBands(), max_bands));
+
+    if (settings->viewMidChannel()) {
+      settings_channels.push_back(settings_mid);
+    } else {
+      settings_channels.push_back(settings_side);
+    }
+  }
+
+  for (int n = 0U; n < max_bands; n++) {
+    for (auto* channel : settings_channels) {
+      if (n < geq_bands) {
+        if (bands[n].freq >= channel->getMinValue(band_frequency[n].data()) &&
+            bands[n].freq <= channel->getMaxValue(band_frequency[n].data())) {
+          channel->setProperty(band_frequency[n].data(), bands[n].freq);
+          channel->setProperty(band_type[n].data(), channel->bandTypeLabels().indexOf("Bell"));
+        } else {
+          channel->resetProperty(band_frequency[n].data());
+          channel->setProperty(band_type[n].data(), channel->bandTypeLabels().indexOf("Off"));
+        }
+
+        if (bands[n].gain >= channel->getMinValue(band_gain[n].data()) &&
+            bands[n].gain <= channel->getMaxValue(band_gain[n].data())) {
+          channel->setProperty(band_gain[n].data(), bands[n].gain);
+
+        } else {
+          channel->resetProperty(band_gain[n].data());
+        }
+      } else {
+        channel->setProperty(band_type[n].data(), channel->bandTypeLabels().indexOf("Off"));
+        channel->resetProperty(band_frequency[n].data());
+        channel->resetProperty(band_gain[n].data());
+      }
+
+      channel->resetProperty(band_q[n].data());
+      channel->resetProperty(band_mode[n].data());
+      channel->resetProperty(band_width[n].data());
+      channel->resetProperty(band_slope[n].data());
+      channel->resetProperty(band_solo[n].data());
+      channel->resetProperty(band_mute[n].data());
+    }
+  }
+
+  return true;
+}
+
+auto export_apo_preset(DbMidSideEqualizer* settings,
+                       DbEqualizerChannel* settings_mid,
+                       DbEqualizerChannel* settings_side,
+                       const std::string& file_path) -> bool {
+  std::ofstream write_buffer(file_path);
+
+  const double preamp = settings->inputGain();
+
+  write_buffer << "Preamp: " << util::to_string(preamp) << " db"
+               << "\n";
+
+  DbEqualizerChannel* settings_channel = nullptr;
+
+  if (!settings->splitChannels()) {
+    settings_channel = settings_mid;
+  } else {
+    settings_channel = settings->viewMidChannel() ? settings_mid : settings_side;
+  }
+
+  for (int i = 0, k = 1; i < settings->numBands(); ++i) {
+    const auto current_band_type =
+        settings_channel->bandTypeLabels()[settings_channel->property(band_type[i].data()).value<int>()];
+
+    if (current_band_type == "Off") {
+      continue;
+    }
+
+    APO_Band apo_band;
+
+    try {
+      apo_band.type = EqualizerToApoFilter.at(current_band_type.toStdString());
+    } catch (std::out_of_range const&) {
+      apo_band.type = ApoFilter::PK;
+    }
+
+    apo_band.freq = settings_channel->property(band_frequency[i].data()).value<float>();
+    apo_band.gain = settings_channel->property(band_gain[i].data()).value<float>();
+    apo_band.quality = settings_channel->property(band_q[i].data()).value<float>();
+
+    write_buffer << "Filter " << util::to_string(k++) << ": ON " << apoFilterToString(apo_band.type) << " Fc "
+                 << util::to_string(apo_band.freq) << " Hz";
+
+    if (current_band_type == "Bell" || current_band_type == "Lo-shelf" || current_band_type == "Hi-shelf") {
+      write_buffer << " Gain " << util::to_string(apo_band.gain) << " dB";
+    }
+
+    write_buffer << " Q " << util::to_string(apo_band.quality) << "\n";
+  }
+
+  return !write_buffer.fail();
+}
+
 }  // namespace apo

--- a/src/equalizer_apo.hpp
+++ b/src/equalizer_apo.hpp
@@ -24,6 +24,7 @@
 #include <string>
 #include "easyeffects_db_equalizer.h"
 #include "easyeffects_db_equalizer_channel.h"
+#include "easyeffects_db_midside_equalizer.h"
 
 namespace apo {
 
@@ -93,8 +94,23 @@ auto import_graphiceq_preset(DbEqualizer* settings,
                              const std::string& file_path) -> bool;
 
 auto export_apo_preset(DbEqualizer* settings,
-                       DbEqualizerChannel* settings_left,
-                       DbEqualizerChannel* settings_right,
+                        DbEqualizerChannel* settings_left,
+                        DbEqualizerChannel* settings_right,
+                        const std::string& file_path) -> bool;
+
+auto import_apo_preset(DbMidSideEqualizer* settings,
+                       DbEqualizerChannel* settings_mid,
+                       DbEqualizerChannel* settings_side,
+                       const std::string& file_path) -> bool;
+
+auto import_graphiceq_preset(DbMidSideEqualizer* settings,
+                             DbEqualizerChannel* settings_mid,
+                             DbEqualizerChannel* settings_side,
+                             const std::string& file_path) -> bool;
+
+auto export_apo_preset(DbMidSideEqualizer* settings,
+                       DbEqualizerChannel* settings_mid,
+                       DbEqualizerChannel* settings_side,
                        const std::string& file_path) -> bool;
 
 }  // namespace apo

--- a/src/midside_equalizer.cpp
+++ b/src/midside_equalizer.cpp
@@ -1,0 +1,432 @@
+/**
+ * Copyright © 2017-2026 Wellington Wallace
+ *
+ * Copyright © 2026 Alessio Attilio
+ *
+ * This file is part of Easy Effects.
+ *
+ * Easy Effects is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easy Effects is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easy Effects. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "midside_equalizer.hpp"
+#include <qlist.h>
+#include <qnamespace.h>
+#include <qobject.h>
+#include <sys/types.h>
+#include <QApplication>
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <format>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+#include "db_manager.hpp"
+#include "easyeffects_db_equalizer_channel.h"
+#include "easyeffects_db_midside_equalizer.h"
+#include "equalizer_apo.hpp"
+#include "equalizer_macros.hpp"
+#include "lv2_macros.hpp"
+#include "lv2_wrapper.hpp"
+#include "pipeline_type.hpp"
+#include "plugin_base.hpp"
+#include "pw_manager.hpp"
+#include "tags_equalizer.hpp"
+#include "tags_plugin_name.hpp"
+#include "util.hpp"
+
+using namespace std::string_literals;
+
+MidSideEqualizer::MidSideEqualizer(const std::string& tag,
+                                   pw::Manager* pipe_manager,
+                                   PipelineType pipe_type,
+                                   QString instance_id)
+    : PluginBase(tag,
+                 tags::plugin_name::BaseName::midsideEqualizer,
+                 tags::plugin_package::Package::lsp,
+                 instance_id,
+                 pipe_manager,
+                 pipe_type),
+      settings(db::Manager::self().get_plugin_db<DbMidSideEqualizer>(
+          pipe_type, tags::plugin_name::BaseName::midsideEqualizer + "#" + instance_id)),
+      settings_mid(db::Manager::self().get_plugin_db<DbEqualizerChannel>(
+          pipe_type, tags::plugin_name::BaseName::midsideEqualizer + "#" + instance_id + "#mid")),
+      settings_side(db::Manager::self().get_plugin_db<DbEqualizerChannel>(
+          pipe_type,
+          tags::plugin_name::BaseName::midsideEqualizer + "#" + instance_id + "#side")) {
+  const auto lv2_plugin_uri = "http://lsp-plug.in/plugins/lv2/para_equalizer_x32_ms";
+
+  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>(lv2_plugin_uri);
+
+  packageInstalled = lv2_wrapper->found_plugin;
+
+  if (!packageInstalled) {
+    util::debug(std::format("{}{} is not installed", log_tag, lv2_plugin_uri));
+  }
+
+  init_common_controls<DbMidSideEqualizer>(settings);
+
+  BIND_LV2_PORT("mode", mode, setMode, DbMidSideEqualizer::modeChanged);
+  BIND_LV2_PORT("bal", balance, setBalance, DbMidSideEqualizer::balanceChanged);
+  BIND_LV2_PORT("frqs_m", pitchMid, setPitchMid, DbMidSideEqualizer::pitchMidChanged);
+  BIND_LV2_PORT("frqs_s", pitchSide, setPitchSide, DbMidSideEqualizer::pitchSideChanged);
+  BIND_LV2_PORT("decramp", decramp, setDecramp, DbMidSideEqualizer::decrampChanged);
+
+  BIND_LV2_PORT_INVERTED_BOOL("clink", splitChannels, setSplitChannels, DbMidSideEqualizer::splitChannelsChanged);
+
+  bind_mid_bands();
+  bind_side_bands();
+
+  on_split_channels();
+
+  connect(settings, &DbMidSideEqualizer::numBandsChanged, [&]() {
+    for (int n = 0; n < max_bands; n++) {
+      if (n >= settings->numBands()) {  // turn off unused bands
+        settings_mid->setProperty(tags::equalizer::band_type[n].data(), 0);
+
+        if (settings->splitChannels()) {
+          settings_side->setProperty(tags::equalizer::band_type[n].data(), 0);
+        }
+      }
+    }
+  });
+
+  connect(settings, &DbMidSideEqualizer::splitChannelsChanged, [&]() { on_split_channels(); });
+}
+
+MidSideEqualizer::~MidSideEqualizer() {
+  stop_worker();
+
+  if (connected_to_pw) {
+    disconnect_from_pw();
+  }
+
+  settings->disconnect();
+  settings_mid->disconnect();
+  settings_side->disconnect();
+
+  util::debug(std::format("{}{} destroyed", log_tag, name.toStdString()));
+}
+
+void MidSideEqualizer::reset() {
+  settings->setDefaults();
+  settings_mid->setDefaults();
+  settings_side->setDefaults();
+}
+
+// NOLINTNEXTLINE(readability-function-size,hicpp-function-size)
+void MidSideEqualizer::bind_mid_bands() {
+  using namespace tags::equalizer;
+
+  BIND_BANDS_PROPERTY(settings_mid, ftm, Type);
+  BIND_BANDS_PROPERTY(settings_mid, fmm, Mode);
+  BIND_BANDS_PROPERTY(settings_mid, sm, Slope);
+  BIND_BANDS_PROPERTY(settings_mid, xsm, Solo);
+  BIND_BANDS_PROPERTY(settings_mid, xmm, Mute);
+  BIND_BANDS_PROPERTY(settings_mid, fm, Frequency);
+  BIND_BANDS_PROPERTY(settings_mid, qm, Q);
+  BIND_BANDS_PROPERTY(settings_mid, wm, Width);
+  BIND_BANDS_PROPERTY_DB(settings_mid, gm, Gain, false);
+}
+
+// NOLINTNEXTLINE(readability-function-size,hicpp-function-size)
+void MidSideEqualizer::bind_side_bands() {
+  using namespace tags::equalizer;
+
+  BIND_BANDS_PROPERTY(settings_side, fts, Type);
+  BIND_BANDS_PROPERTY(settings_side, fms, Mode);
+  BIND_BANDS_PROPERTY(settings_side, ss, Slope);
+  BIND_BANDS_PROPERTY(settings_side, xss, Solo);
+  BIND_BANDS_PROPERTY(settings_side, xms, Mute);
+  BIND_BANDS_PROPERTY(settings_side, fs, Frequency);
+  BIND_BANDS_PROPERTY(settings_side, qs, Q);
+  BIND_BANDS_PROPERTY(settings_side, ws, Width);
+  BIND_BANDS_PROPERTY_DB(settings_side, gs, Gain, false);
+}
+
+// NOLINTNEXTLINE(readability-function-size,hicpp-function-size)
+void MidSideEqualizer::on_split_channels() {
+  if (settings->splitChannels()) {
+    for (const auto& conn : unified_mode_connections) {
+      QObject::disconnect(conn);
+    }
+
+    unified_mode_connections.clear();
+
+    return;
+  }
+
+  using namespace tags::equalizer;
+
+  // When in unified mode we want settings applied to the mid channel to
+  // be propagated to the side channel database
+
+  UNIFIED_BANDS_PROPERTY_BIND(settings_side, settings_mid, Type);
+  UNIFIED_BANDS_PROPERTY_BIND(settings_side, settings_mid, Mode);
+  UNIFIED_BANDS_PROPERTY_BIND(settings_side, settings_mid, Slope);
+  UNIFIED_BANDS_PROPERTY_BIND(settings_side, settings_mid, Solo);
+  UNIFIED_BANDS_PROPERTY_BIND(settings_side, settings_mid, Mute);
+  UNIFIED_BANDS_PROPERTY_BIND(settings_side, settings_mid, Frequency);
+  UNIFIED_BANDS_PROPERTY_BIND(settings_side, settings_mid, Q);
+  UNIFIED_BANDS_PROPERTY_BIND(settings_side, settings_mid, Width);
+  UNIFIED_BANDS_PROPERTY_BIND(settings_side, settings_mid, Gain);
+}
+
+void MidSideEqualizer::clear_data() {
+  if (lv2_wrapper == nullptr) {
+    return;
+  }
+
+  {
+    std::scoped_lock<std::mutex> lock(data_mutex);
+
+    lv2_wrapper->destroy_instance_locked();
+  }
+
+  setup();
+}
+
+void MidSideEqualizer::setup() {
+  if (rate == 0 || n_samples == 0) {
+    // Some signals may be emitted before PipeWire calls our setup function
+    return;
+  }
+
+  std::scoped_lock<std::mutex> lock(data_mutex);
+
+  if (!lv2_wrapper->found_plugin) {
+    return;
+  }
+
+  lv2_wrapper->set_n_samples(n_samples);
+
+  if (lv2_wrapper->has_instance() && rate == lv2_wrapper->get_rate()) {
+    return;
+  }
+
+  ready = false;
+
+  // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks)
+  QMetaObject::invokeMethod(
+      baseWorker,
+      [this] {
+        lv2_wrapper->create_instance(rate);
+
+        std::scoped_lock<std::mutex> lock(data_mutex);
+
+        ready = true;
+      },
+      Qt::QueuedConnection);
+  // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
+}
+
+void MidSideEqualizer::process(std::span<float>& left_in,
+                               std::span<float>& right_in,
+                               std::span<float>& left_out,
+                               std::span<float>& right_out) {
+  std::scoped_lock<std::mutex> lock(data_mutex);
+
+  if (bypass) {
+    std::ranges::copy(left_in, left_out.begin());
+    std::ranges::copy(right_in, right_out.begin());
+
+    return;
+  }
+
+  if (!ready) {
+    std::ranges::copy(left_in, left_out.begin());
+    std::ranges::copy(right_in, right_out.begin());
+
+    if (output_gain != 1.0F) {
+      apply_gain(left_out, right_out, output_gain);
+    }
+
+    return;
+  }
+
+  if (input_gain != 1.0F) {
+    apply_gain(left_in, right_in, input_gain);
+  }
+
+  lv2_wrapper->connect_data_ports(left_in, right_in, left_out, right_out);
+  lv2_wrapper->run();
+
+  if (output_gain != 1.0F) {
+    apply_gain(left_out, right_out, output_gain);
+  }
+
+  // This plugin gives the latency in number of samples
+
+  const auto lv = static_cast<uint>(lv2_wrapper->get_control_port_value("out_latency"));
+
+  if (latency_n_frames != lv) {
+    latency_n_frames = lv;
+
+    latency_value = static_cast<float>(latency_n_frames) / static_cast<float>(rate);
+
+    util::debug(std::format("{}{} latency: {} s", log_tag, name.toStdString(), latency_value));
+
+    update_filter_params();
+  }
+
+  if (updateLevelMeters) {
+    get_peaks(left_in, right_in, left_out, right_out);
+  }
+}
+
+void MidSideEqualizer::process([[maybe_unused]] std::span<float>& left_in,
+                                [[maybe_unused]] std::span<float>& right_in,
+                                [[maybe_unused]] std::span<float>& left_out,
+                                [[maybe_unused]] std::span<float>& right_out,
+                                [[maybe_unused]] std::span<float>& probe_left,
+                                [[maybe_unused]] std::span<float>& probe_right) {}
+
+void MidSideEqualizer::sortBands() {
+  struct EQ_Band {
+    double freq;
+    int type;
+    int mode;
+    int slope;
+    double gain;
+    double q;
+    double width;
+    bool solo;
+    bool mute;
+  };
+
+  const auto used_bands = settings->numBands();
+  if (used_bands < 1 || used_bands > max_bands) {
+    return;
+  }
+
+  std::vector<DbEqualizerChannel*> settings_channels{settings_mid};
+
+  if (settings->splitChannels()) {
+    settings_channels.push_back(settings_side);
+  }
+
+  using namespace tags::equalizer;
+
+  for (auto* channel : settings_channels) {
+    std::multimap<double, struct EQ_Band> sorted_bands;
+
+    for (int n = 0; n < used_bands; n++) {
+      const auto f = channel->property(band_frequency[n].data()).value<double>();
+
+      sorted_bands.emplace(
+          std::pair<double, struct EQ_Band>(f, {.freq = f,
+                                                 .type = channel->property(band_type[n].data()).value<int>(),
+                                                 .mode = channel->property(band_mode[n].data()).value<int>(),
+                                                 .slope = channel->property(band_slope[n].data()).value<int>(),
+                                                 .gain = channel->property(band_gain[n].data()).value<double>(),
+                                                 .q = channel->property(band_q[n].data()).value<double>(),
+                                                 .width = channel->property(band_width[n].data()).value<double>(),
+                                                 .solo = channel->property(band_solo[n].data()).value<bool>(),
+                                                 .mute = channel->property(band_mute[n].data()).value<bool>()}));
+    }
+
+    for (int n = 0; const auto& p : sorted_bands) {
+      channel->setProperty(band_frequency[n].data(), p.second.freq);
+      channel->setProperty(band_type[n].data(), p.second.type);
+      channel->setProperty(band_mode[n].data(), p.second.mode);
+      channel->setProperty(band_slope[n].data(), p.second.slope);
+      channel->setProperty(band_gain[n].data(), p.second.gain);
+      channel->setProperty(band_q[n].data(), p.second.q);
+      channel->setProperty(band_width[n].data(), p.second.width);
+      channel->setProperty(band_solo[n].data(), p.second.solo);
+      channel->setProperty(band_mute[n].data(), p.second.mute);
+
+      n++;
+    }
+  }
+}
+
+auto MidSideEqualizer::get_latency_seconds() -> float {
+  return latency_value;
+}
+
+void MidSideEqualizer::flatResponse() {
+  RESET_BANDS_PROPERTY(settings_mid, Gain);
+  RESET_BANDS_PROPERTY(settings_side, Gain);
+}
+
+void MidSideEqualizer::calculateFrequencies() {
+  constexpr double min_freq = 20.0;
+  constexpr double max_freq = 20000.0;
+
+  double freq0 = min_freq;
+  double freq1 = 0.0;
+
+  const double step = std::pow(max_freq / min_freq, 1.0 / static_cast<double>(settings->numBands()));
+
+  for (int n = 0; n < settings->numBands(); n++) {
+    freq1 = freq0 * step;
+
+    const double freq = freq0 + (0.5 * (freq1 - freq0));
+    const double width = freq1 - freq0;
+    const double q = freq / width;
+
+    settings_mid->setProperty(tags::equalizer::band_frequency[n].data(), freq);
+    settings_mid->setProperty(tags::equalizer::band_q[n].data(), q);
+
+    settings_side->setProperty(tags::equalizer::band_frequency[n].data(), freq);
+    settings_side->setProperty(tags::equalizer::band_q[n].data(), q);
+
+    freq0 = freq1;
+  }
+
+  RESET_BANDS_PROPERTY(settings_mid, Width);
+  RESET_BANDS_PROPERTY(settings_side, Width);
+}
+
+bool MidSideEqualizer::importApoPreset(const QList<QString>& url_list) {
+  return std::ranges::any_of(url_list, [&](const auto& u) {
+    const auto url = QUrl(u);
+
+    if (url.isLocalFile()) {
+      const auto path = std::filesystem::path{url.toLocalFile().toStdString()};
+
+      if (apo::import_apo_preset(settings, settings_mid, settings_side, path.string())) {
+        return true;
+      }
+    }
+
+    return false;
+  });
+}
+
+bool MidSideEqualizer::importApoGraphicEqPreset(const QList<QString>& url_list) {
+  return std::ranges::any_of(url_list, [&](const auto& u) {
+    const auto url = QUrl(u);
+
+    if (url.isLocalFile()) {
+      const auto path = std::filesystem::path{url.toLocalFile().toStdString()};
+
+      if (apo::import_graphiceq_preset(settings, settings_mid, settings_side, path.string())) {
+        return true;
+      }
+    }
+
+    return false;
+  });
+}
+
+bool MidSideEqualizer::exportApoPreset(const QString& url) {
+  const auto u = QUrl(url);
+  return apo::export_apo_preset(settings, settings_mid, settings_side, u.toLocalFile().toStdString());
+}

--- a/src/midside_equalizer.hpp
+++ b/src/midside_equalizer.hpp
@@ -1,0 +1,103 @@
+/**
+ * Copyright © 2017-2026 Wellington Wallace
+ *
+ * Copyright © 2026 Alessio Attilio
+ *
+ * This file is part of Easy Effects
+ *
+ * Easy Effects is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easy Effects is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easy Effects. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <qlist.h>
+#include <qobject.h>
+#include <qqmlintegration.h>
+#include <qtmetamacros.h>
+#include <sys/types.h>
+#include <span>
+#include <string>
+#include <vector>
+#include "easyeffects_db_equalizer_channel.h"
+#include "easyeffects_db_midside_equalizer.h"
+#include "pipeline_type.hpp"
+#include "plugin_base.hpp"
+#include "pw_manager.hpp"
+
+class MidSideEqualizer : public PluginBase {
+  Q_OBJECT
+  QML_NAMED_ELEMENT(BackendMidSideEqualizer)
+  QML_UNCREATABLE("Use the c++ instance")
+
+ public:
+  MidSideEqualizer(const std::string& tag,
+                   pw::Manager* pipe_manager,
+                   PipelineType pipe_type,
+                   QString instance_id);
+  MidSideEqualizer(const MidSideEqualizer&) = delete;
+  auto operator=(const MidSideEqualizer&) -> MidSideEqualizer& = delete;
+  MidSideEqualizer(const MidSideEqualizer&&) = delete;
+  auto operator=(const MidSideEqualizer&&) -> MidSideEqualizer& = delete;
+  ~MidSideEqualizer() override;
+
+  void reset() override;
+
+  void clear_data() override;
+
+  void setup() override;
+
+  void process(std::span<float>& left_in,
+               std::span<float>& right_in,
+               std::span<float>& left_out,
+               std::span<float>& right_out) override;
+
+  void process(std::span<float>& left_in,
+               std::span<float>& right_in,
+               std::span<float>& left_out,
+               std::span<float>& right_out,
+               std::span<float>& probe_left,
+               std::span<float>& probe_right) override;
+
+  auto get_latency_seconds() -> float override;
+
+  Q_INVOKABLE void sortBands();
+
+  Q_INVOKABLE void flatResponse();
+
+  Q_INVOKABLE void calculateFrequencies();
+
+  Q_INVOKABLE bool importApoPreset(const QList<QString>& url_list);
+
+  Q_INVOKABLE bool importApoGraphicEqPreset(const QList<QString>& url_list);
+
+  Q_INVOKABLE bool exportApoPreset(const QString& url);
+
+  static constexpr int max_bands = 32;
+
+ private:
+  DbMidSideEqualizer* settings = nullptr;
+  DbEqualizerChannel *settings_mid = nullptr, *settings_side = nullptr;
+
+  bool ready = false;
+
+  uint latency_n_frames = 0U;
+
+  std::vector<QMetaObject::Connection> unified_mode_connections;
+
+  void bind_mid_bands();
+
+  void bind_side_bands();
+
+  void on_split_channels();
+};

--- a/src/midside_equalizer_preset.cpp
+++ b/src/midside_equalizer_preset.cpp
@@ -1,0 +1,180 @@
+/**
+ * Copyright © 2017-2026 Wellington Wallace
+ *
+ * Copyright © 2026 Alessio Attilio
+ *
+ * This file is part of Easy Effects.
+ *
+ * Easy Effects is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easy Effects is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easy Effects. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "midside_equalizer_preset.hpp"
+#include <strings.h>
+#include <QString>
+#include <nlohmann/json_fwd.hpp>
+#include <string>
+#include "db_manager.hpp"
+#include "easyeffects_db_equalizer_channel.h"
+#include "easyeffects_db_midside_equalizer.h"
+#include "pipeline_type.hpp"
+#include "plugin_preset_base.hpp"
+#include "presets_macros.hpp"
+#include "tags_equalizer.hpp"
+#include "util.hpp"
+
+using namespace tags::equalizer;
+
+MidSideEqualizerPreset::MidSideEqualizerPreset(PipelineType pipeline_type, const std::string& instance_name)
+    : PluginPresetBase(pipeline_type, instance_name) {
+  settings = get_db_instance<DbMidSideEqualizer>(pipeline_type);
+
+  if (settings != nullptr) {
+    input_settings_mid = db::Manager::self().get_plugin_db<DbEqualizerChannel>(
+        pipeline_type, QString::fromStdString(instance_name + "#mid"));
+    input_settings_side = db::Manager::self().get_plugin_db<DbEqualizerChannel>(
+        pipeline_type, QString::fromStdString(instance_name + "#side"));
+
+    output_settings_mid = db::Manager::self().get_plugin_db<DbEqualizerChannel>(
+        pipeline_type, QString::fromStdString(instance_name + "#mid"));
+    output_settings_side = db::Manager::self().get_plugin_db<DbEqualizerChannel>(
+        pipeline_type, QString::fromStdString(instance_name + "#side"));
+  }
+}
+
+void MidSideEqualizerPreset::save(nlohmann::json& json) {
+  json[section][instance_name]["bypass"] = settings->bypass();
+
+  json[section][instance_name]["input-gain"] = settings->inputGain();
+
+  json[section][instance_name]["output-gain"] = settings->outputGain();
+
+  json[section][instance_name]["mode"] = settings->defaultModeLabelsValue()[settings->mode()].toStdString();
+
+  json[section][instance_name]["decramp"] = settings->defaultDecrampLabelsValue()[settings->decramp()].toStdString();
+
+  json[section][instance_name]["split-channels"] = settings->splitChannels();
+
+  json[section][instance_name]["balance"] = settings->balance();
+
+  json[section][instance_name]["pitch-mid"] = settings->pitchMid();
+
+  json[section][instance_name]["pitch-side"] = settings->pitchSide();
+
+  const auto nbands = settings->numBands();
+
+  json[section][instance_name]["num-bands"] = nbands;
+
+  if (section == "input") {
+    save_channel(json[section][instance_name]["mid"], input_settings_mid, nbands);
+    save_channel(json[section][instance_name]["side"], input_settings_side, nbands);
+  } else if (section == "output") {
+    save_channel(json[section][instance_name]["mid"], output_settings_mid, nbands);
+    save_channel(json[section][instance_name]["side"], output_settings_side, nbands);
+  }
+}
+
+void MidSideEqualizerPreset::save_channel(nlohmann::json& json, DbEqualizerChannel* settings, const int& nbands) {
+  for (int n = 0; n < nbands; n++) {
+    const auto* const bandn = band_id[n];
+
+    json[bandn]["type"] =
+        settings->bandTypeLabels()[settings->property(band_type[n].data()).value<int>()].toStdString();
+
+    json[bandn]["mode"] =
+        settings->bandModeLabels()[settings->property(band_mode[n].data()).value<int>()].toStdString();
+
+    json[bandn]["slope"] =
+        settings->bandSlopeLabels()[settings->property(band_slope[n].data()).value<int>()].toStdString();
+
+    json[bandn]["solo"] = settings->property(band_solo[n].data()).value<bool>();
+
+    json[bandn]["mute"] = settings->property(band_mute[n].data()).value<bool>();
+
+    json[bandn]["gain"] = settings->property(band_gain[n].data()).value<double>();
+
+    json[bandn]["frequency"] = settings->property(band_frequency[n].data()).value<double>();
+
+    json[bandn]["q"] = settings->property(band_q[n].data()).value<double>();
+
+    json[bandn]["width"] = settings->property(band_width[n].data()).value<double>();
+  }
+}
+
+void MidSideEqualizerPreset::load(const nlohmann::json& json) {
+  UPDATE_PROPERTY("bypass", Bypass);
+  UPDATE_PROPERTY("input-gain", InputGain);
+  UPDATE_PROPERTY("output-gain", OutputGain);
+  UPDATE_PROPERTY("num-bands", NumBands);
+  UPDATE_PROPERTY("split-channels", SplitChannels);
+  UPDATE_PROPERTY("balance", Balance);
+  UPDATE_PROPERTY("pitch-mid", PitchMid);
+  UPDATE_PROPERTY("pitch-side", PitchSide);
+
+  UPDATE_ENUM_LIKE_PROPERTY("mode", Mode);
+  UPDATE_ENUM_LIKE_PROPERTY("decramp", Decramp);
+
+  const auto nbands = settings->numBands();
+
+  if (section == "input") {
+    load_channel(json.at(section).at(instance_name).at("mid"), input_settings_mid, nbands);
+    load_channel(json.at(section).at(instance_name).at("side"), input_settings_side, nbands);
+  } else if (section == "output") {
+    load_channel(json.at(section).at(instance_name).at("mid"), output_settings_mid, nbands);
+    load_channel(json.at(section).at(instance_name).at("side"), output_settings_side, nbands);
+  }
+}
+
+void MidSideEqualizerPreset::load_channel(const nlohmann::json& json, DbEqualizerChannel* settings, const int& nbands) {
+  for (int n = 0; n < nbands; n++) {
+    const auto bandn = "band" + util::to_string(n);
+
+    settings->setProperty(
+        band_type[n].data(),
+        settings->bandTypeLabels().indexOf(json.at(bandn).value(
+            "type",
+            settings->bandTypeLabels()[settings->getDefaultValue(band_type[n].data()).value<int>()].toStdString())));
+
+    settings->setProperty(
+        band_mode[n].data(),
+        settings->bandModeLabels().indexOf(json.at(bandn).value(
+            "mode",
+            settings->bandModeLabels()[settings->getDefaultValue(band_mode[n].data()).value<int>()].toStdString())));
+
+    settings->setProperty(
+        band_slope[n].data(),
+        settings->bandSlopeLabels().indexOf(json.at(bandn).value(
+            "slope",
+            settings->bandSlopeLabels()[settings->getDefaultValue(band_slope[n].data()).value<int>()].toStdString())));
+
+    settings->setProperty(band_solo[n].data(),
+                          json.at(bandn).value("solo", settings->getDefaultValue(band_solo[n].data()).value<bool>()));
+
+    settings->setProperty(band_mute[n].data(),
+                          json.at(bandn).value("mute", settings->getDefaultValue(band_mute[n].data()).value<bool>()));
+
+    settings->setProperty(band_gain[n].data(),
+                          json.at(bandn).value("gain", settings->getDefaultValue(band_gain[n].data()).value<double>()));
+
+    settings->setProperty(
+        band_frequency[n].data(),
+        json.at(bandn).value("frequency", settings->getDefaultValue(band_frequency[n].data()).value<double>()));
+
+    settings->setProperty(band_q[n].data(),
+                          json.at(bandn).value("q", settings->getDefaultValue(band_q[n].data()).value<double>()));
+
+    settings->setProperty(
+        band_width[n].data(),
+        json.at(bandn).value("width", settings->getDefaultValue(band_width[n].data()).value<double>()));
+  }
+}

--- a/src/midside_equalizer_preset.hpp
+++ b/src/midside_equalizer_preset.hpp
@@ -1,0 +1,47 @@
+/**
+ * Copyright © 2017-2026 Wellington Wallace
+ *
+ * Copyright © 2026 Alessio Attilio
+ *
+ * This file is part of Easy Effects
+ *
+ * Easy Effects is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easy Effects is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easy Effects. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+#include <string>
+#include "easyeffects_db_equalizer_channel.h"
+#include "easyeffects_db_midside_equalizer.h"
+#include "pipeline_type.hpp"
+#include "plugin_preset_base.hpp"
+
+class MidSideEqualizerPreset : public PluginPresetBase {
+ public:
+  explicit MidSideEqualizerPreset(PipelineType pipeline_type, const std::string& instance_name);
+
+ private:
+  DbMidSideEqualizer* settings = nullptr;
+  DbEqualizerChannel *input_settings_mid = nullptr, *input_settings_side = nullptr;
+  DbEqualizerChannel *output_settings_mid = nullptr, *output_settings_side = nullptr;
+
+  void save(nlohmann::json& json) override;
+
+  void load(const nlohmann::json& json) override;
+
+  static void save_channel(nlohmann::json& json, DbEqualizerChannel* settings, const int& nbands);
+
+  static void load_channel(const nlohmann::json& json, DbEqualizerChannel* settings, const int& nbands);
+};

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -65,6 +65,7 @@
 #include "echo_canceller_preset.hpp"
 #include "equalizer_preset.hpp"
 #include "exciter_preset.hpp"
+#include "midside_equalizer_preset.hpp"
 #include "expander_preset.hpp"
 #include "filter_preset.hpp"
 #include "gate_preset.hpp"
@@ -895,6 +896,9 @@ auto Manager::create_wrapper(const PipelineType& pipeline_type, const QString& f
 
   } else if (filter_name.startsWith(tags::plugin_name::BaseName::equalizer)) {
     return std::make_unique<EqualizerPreset>(pipeline_type, filter_name.toStdString());
+
+  } else if (filter_name.startsWith(tags::plugin_name::BaseName::midsideEqualizer)) {
+    return std::make_unique<MidSideEqualizerPreset>(pipeline_type, filter_name.toStdString());
 
   } else if (filter_name.startsWith(tags::plugin_name::BaseName::exciter)) {
     return std::make_unique<ExciterPreset>(pipeline_type, filter_name.toStdString());

--- a/src/tags_equalizer.hpp
+++ b/src/tags_equalizer.hpp
@@ -224,8 +224,120 @@ constexpr auto fr = std::to_array(
 
 constexpr auto gr = std::to_array(
     {{"gr_0"},  {"gr_1"},  {"gr_2"},  {"gr_3"},  {"gr_4"},  {"gr_5"},  {"gr_6"},  {"gr_7"},
-     {"gr_8"},  {"gr_9"},  {"gr_10"}, {"gr_11"}, {"gr_12"}, {"gr_13"}, {"gr_14"}, {"gr_15"},
-     {"gr_16"}, {"gr_17"}, {"gr_18"}, {"gr_19"}, {"gr_20"}, {"gr_21"}, {"gr_22"}, {"gr_23"},
-     {"gr_24"}, {"gr_25"}, {"gr_26"}, {"gr_27"}, {"gr_28"}, {"gr_29"}, {"gr_30"}, std::to_array("gr_31")});
+      {"gr_8"},  {"gr_9"},  {"gr_10"}, {"gr_11"}, {"gr_12"}, {"gr_13"}, {"gr_14"}, {"gr_15"},
+      {"gr_16"}, {"gr_17"}, {"gr_18"}, {"gr_19"}, {"gr_20"}, {"gr_21"}, {"gr_22"}, {"gr_23"},
+      {"gr_24"}, {"gr_25"}, {"gr_26"}, {"gr_27"}, {"gr_28"}, {"gr_29"}, {"gr_30"}, std::to_array("gr_31")});
+
+// mid channel (para_equalizer_x32_ms)
+
+constexpr auto ftm = std::to_array(
+    {{"ftm_0"},  {"ftm_1"},  {"ftm_2"},  {"ftm_3"},  {"ftm_4"},  {"ftm_5"},  {"ftm_6"},  {"ftm_7"},
+      {"ftm_8"},  {"ftm_9"},  {"ftm_10"}, {"ftm_11"}, {"ftm_12"}, {"ftm_13"}, {"ftm_14"}, {"ftm_15"},
+      {"ftm_16"}, {"ftm_17"}, {"ftm_18"}, {"ftm_19"}, {"ftm_20"}, {"ftm_21"}, {"ftm_22"}, {"ftm_23"},
+      {"ftm_24"}, {"ftm_25"}, {"ftm_26"}, {"ftm_27"}, {"ftm_28"}, {"ftm_29"}, {"ftm_30"}, std::to_array("ftm_31")});
+
+constexpr auto fmm = std::to_array(
+    {{"fmm_0"},  {"fmm_1"},  {"fmm_2"},  {"fmm_3"},  {"fmm_4"},  {"fmm_5"},  {"fmm_6"},  {"fmm_7"},
+      {"fmm_8"},  {"fmm_9"},  {"fmm_10"}, {"fmm_11"}, {"fmm_12"}, {"fmm_13"}, {"fmm_14"}, {"fmm_15"},
+      {"fmm_16"}, {"fmm_17"}, {"fmm_18"}, {"fmm_19"}, {"fmm_20"}, {"fmm_21"}, {"fmm_22"}, {"fmm_23"},
+      {"fmm_24"}, {"fmm_25"}, {"fmm_26"}, {"fmm_27"}, {"fmm_28"}, {"fmm_29"}, {"fmm_30"}, std::to_array("fmm_31")});
+
+constexpr auto sm = std::to_array(
+    {{"sm_0"},  {"sm_1"},  {"sm_2"},  {"sm_3"},  {"sm_4"},  {"sm_5"},  {"sm_6"},  {"sm_7"},
+      {"sm_8"},  {"sm_9"},  {"sm_10"}, {"sm_11"}, {"sm_12"}, {"sm_13"}, {"sm_14"}, {"sm_15"},
+      {"sm_16"}, {"sm_17"}, {"sm_18"}, {"sm_19"}, {"sm_20"}, {"sm_21"}, {"sm_22"}, {"sm_23"},
+      {"sm_24"}, {"sm_25"}, {"sm_26"}, {"sm_27"}, {"sm_28"}, {"sm_29"}, {"sm_30"}, std::to_array("sm_31")});
+
+constexpr auto xsm = std::to_array(
+    {{"xsm_0"},  {"xsm_1"},  {"xsm_2"},  {"xsm_3"},  {"xsm_4"},  {"xsm_5"},  {"xsm_6"},  {"xsm_7"},
+      {"xsm_8"},  {"xsm_9"},  {"xsm_10"}, {"xsm_11"}, {"xsm_12"}, {"xsm_13"}, {"xsm_14"}, {"xsm_15"},
+      {"xsm_16"}, {"xsm_17"}, {"xsm_18"}, {"xsm_19"}, {"xsm_20"}, {"xsm_21"}, {"xsm_22"}, {"xsm_23"},
+      {"xsm_24"}, {"xsm_25"}, {"xsm_26"}, {"xsm_27"}, {"xsm_28"}, {"xsm_29"}, {"xsm_30"}, std::to_array("xsm_31")});
+
+constexpr auto xmm = std::to_array(
+    {{"xmm_0"},  {"xmm_1"},  {"xmm_2"},  {"xmm_3"},  {"xmm_4"},  {"xmm_5"},  {"xmm_6"},  {"xmm_7"},
+      {"xmm_8"},  {"xmm_9"},  {"xmm_10"}, {"xmm_11"}, {"xmm_12"}, {"xmm_13"}, {"xmm_14"}, {"xmm_15"},
+      {"xmm_16"}, {"xmm_17"}, {"xmm_18"}, {"xmm_19"}, {"xmm_20"}, {"xmm_21"}, {"xmm_22"}, {"xmm_23"},
+      {"xmm_24"}, {"xmm_25"}, {"xmm_26"}, {"xmm_27"}, {"xmm_28"}, {"xmm_29"}, {"xmm_30"}, std::to_array("xmm_31")});
+
+constexpr auto qm = std::to_array(
+    {{"qm_0"},  {"qm_1"},  {"qm_2"},  {"qm_3"},  {"qm_4"},  {"qm_5"},  {"qm_6"},  {"qm_7"},
+      {"qm_8"},  {"qm_9"},  {"qm_10"}, {"qm_11"}, {"qm_12"}, {"qm_13"}, {"qm_14"}, {"qm_15"},
+      {"qm_16"}, {"qm_17"}, {"qm_18"}, {"qm_19"}, {"qm_20"}, {"qm_21"}, {"qm_22"}, {"qm_23"},
+      {"qm_24"}, {"qm_25"}, {"qm_26"}, {"qm_27"}, {"qm_28"}, {"qm_29"}, {"qm_30"}, std::to_array("qm_31")});
+
+constexpr auto wm = std::to_array(
+    {{"wm_0"},  {"wm_1"},  {"wm_2"},  {"wm_3"},  {"wm_4"},  {"wm_5"},  {"wm_6"},  {"wm_7"},
+      {"wm_8"},  {"wm_9"},  {"wm_10"}, {"wm_11"}, {"wm_12"}, {"wm_13"}, {"wm_14"}, {"wm_15"},
+      {"wm_16"}, {"wm_17"}, {"wm_18"}, {"wm_19"}, {"wm_20"}, {"wm_21"}, {"wm_22"}, {"wm_23"},
+      {"wm_24"}, {"wm_25"}, {"wm_26"}, {"wm_27"}, {"wm_28"}, {"wm_29"}, {"wm_30"}, std::to_array("wm_31")});
+
+constexpr auto fm = std::to_array(
+    {{"fm_0"},  {"fm_1"},  {"fm_2"},  {"fm_3"},  {"fm_4"},  {"fm_5"},  {"fm_6"},  {"fm_7"},
+      {"fm_8"},  {"fm_9"},  {"fm_10"}, {"fm_11"}, {"fm_12"}, {"fm_13"}, {"fm_14"}, {"fm_15"},
+      {"fm_16"}, {"fm_17"}, {"fm_18"}, {"fm_19"}, {"fm_20"}, {"fm_21"}, {"fm_22"}, {"fm_23"},
+      {"fm_24"}, {"fm_25"}, {"fm_26"}, {"fm_27"}, {"fm_28"}, {"fm_29"}, {"fm_30"}, std::to_array("fm_31")});
+
+constexpr auto gm = std::to_array(
+    {{"gm_0"},  {"gm_1"},  {"gm_2"},  {"gm_3"},  {"gm_4"},  {"gm_5"},  {"gm_6"},  {"gm_7"},
+      {"gm_8"},  {"gm_9"},  {"gm_10"}, {"gm_11"}, {"gm_12"}, {"gm_13"}, {"gm_14"}, {"gm_15"},
+      {"gm_16"}, {"gm_17"}, {"gm_18"}, {"gm_19"}, {"gm_20"}, {"gm_21"}, {"gm_22"}, {"gm_23"},
+      {"gm_24"}, {"gm_25"}, {"gm_26"}, {"gm_27"}, {"gm_28"}, {"gm_29"}, {"gm_30"}, std::to_array("gm_31")});
+
+// side channel (para_equalizer_x32_ms)
+
+constexpr auto fts = std::to_array(
+    {{"fts_0"},  {"fts_1"},  {"fts_2"},  {"fts_3"},  {"fts_4"},  {"fts_5"},  {"fts_6"},  {"fts_7"},
+      {"fts_8"},  {"fts_9"},  {"fts_10"}, {"fts_11"}, {"fts_12"}, {"fts_13"}, {"fts_14"}, {"fts_15"},
+      {"fts_16"}, {"fts_17"}, {"fts_18"}, {"fts_19"}, {"fts_20"}, {"fts_21"}, {"fts_22"}, {"fts_23"},
+      {"fts_24"}, {"fts_25"}, {"fts_26"}, {"fts_27"}, {"fts_28"}, {"fts_29"}, {"fts_30"}, std::to_array("fts_31")});
+
+constexpr auto fms = std::to_array(
+    {{"fms_0"},  {"fms_1"},  {"fms_2"},  {"fms_3"},  {"fms_4"},  {"fms_5"},  {"fms_6"},  {"fms_7"},
+      {"fms_8"},  {"fms_9"},  {"fms_10"}, {"fms_11"}, {"fms_12"}, {"fms_13"}, {"fms_14"}, {"fms_15"},
+      {"fms_16"}, {"fms_17"}, {"fms_18"}, {"fms_19"}, {"fms_20"}, {"fms_21"}, {"fms_22"}, {"fms_23"},
+      {"fms_24"}, {"fms_25"}, {"fms_26"}, {"fms_27"}, {"fms_28"}, {"fms_29"}, {"fms_30"}, std::to_array("fms_31")});
+
+constexpr auto ss = std::to_array(
+    {{"ss_0"},  {"ss_1"},  {"ss_2"},  {"ss_3"},  {"ss_4"},  {"ss_5"},  {"ss_6"},  {"ss_7"},
+      {"ss_8"},  {"ss_9"},  {"ss_10"}, {"ss_11"}, {"ss_12"}, {"ss_13"}, {"ss_14"}, {"ss_15"},
+      {"ss_16"}, {"ss_17"}, {"ss_18"}, {"ss_19"}, {"ss_20"}, {"ss_21"}, {"ss_22"}, {"ss_23"},
+      {"ss_24"}, {"ss_25"}, {"ss_26"}, {"ss_27"}, {"ss_28"}, {"ss_29"}, {"ss_30"}, std::to_array("ss_31")});
+
+constexpr auto xss = std::to_array(
+    {{"xss_0"},  {"xss_1"},  {"xss_2"},  {"xss_3"},  {"xss_4"},  {"xss_5"},  {"xss_6"},  {"xss_7"},
+      {"xss_8"},  {"xss_9"},  {"xss_10"}, {"xss_11"}, {"xss_12"}, {"xss_13"}, {"xss_14"}, {"xss_15"},
+      {"xss_16"}, {"xss_17"}, {"xss_18"}, {"xss_19"}, {"xss_20"}, {"xss_21"}, {"xss_22"}, {"xss_23"},
+      {"xss_24"}, {"xss_25"}, {"xss_26"}, {"xss_27"}, {"xss_28"}, {"xss_29"}, {"xss_30"}, std::to_array("xss_31")});
+
+constexpr auto xms = std::to_array(
+    {{"xms_0"},  {"xms_1"},  {"xms_2"},  {"xms_3"},  {"xms_4"},  {"xms_5"},  {"xms_6"},  {"xms_7"},
+      {"xms_8"},  {"xms_9"},  {"xms_10"}, {"xms_11"}, {"xms_12"}, {"xms_13"}, {"xms_14"}, {"xms_15"},
+      {"xms_16"}, {"xms_17"}, {"xms_18"}, {"xms_19"}, {"xms_20"}, {"xms_21"}, {"xms_22"}, {"xms_23"},
+      {"xms_24"}, {"xms_25"}, {"xms_26"}, {"xms_27"}, {"xms_28"}, {"xms_29"}, {"xms_30"}, std::to_array("xms_31")});
+
+constexpr auto qs = std::to_array(
+    {{"qs_0"},  {"qs_1"},  {"qs_2"},  {"qs_3"},  {"qs_4"},  {"qs_5"},  {"qs_6"},  {"qs_7"},
+      {"qs_8"},  {"qs_9"},  {"qs_10"}, {"qs_11"}, {"qs_12"}, {"qs_13"}, {"qs_14"}, {"qs_15"},
+      {"qs_16"}, {"qs_17"}, {"qs_18"}, {"qs_19"}, {"qs_20"}, {"qs_21"}, {"qs_22"}, {"qs_23"},
+      {"qs_24"}, {"qs_25"}, {"qs_26"}, {"qs_27"}, {"qs_28"}, {"qs_29"}, {"qs_30"}, std::to_array("qs_31")});
+
+constexpr auto ws = std::to_array(
+    {{"ws_0"},  {"ws_1"},  {"ws_2"},  {"ws_3"},  {"ws_4"},  {"ws_5"},  {"ws_6"},  {"ws_7"},
+      {"ws_8"},  {"ws_9"},  {"ws_10"}, {"ws_11"}, {"ws_12"}, {"ws_13"}, {"ws_14"}, {"ws_15"},
+      {"ws_16"}, {"ws_17"}, {"ws_18"}, {"ws_19"}, {"ws_20"}, {"ws_21"}, {"ws_22"}, {"ws_23"},
+      {"ws_24"}, {"ws_25"}, {"ws_26"}, {"ws_27"}, {"ws_28"}, {"ws_29"}, {"ws_30"}, std::to_array("ws_31")});
+
+constexpr auto fs = std::to_array(
+    {{"fs_0"},  {"fs_1"},  {"fs_2"},  {"fs_3"},  {"fs_4"},  {"fs_5"},  {"fs_6"},  {"fs_7"},
+      {"fs_8"},  {"fs_9"},  {"fs_10"}, {"fs_11"}, {"fs_12"}, {"fs_13"}, {"fs_14"}, {"fs_15"},
+      {"fs_16"}, {"fs_17"}, {"fs_18"}, {"fs_19"}, {"fs_20"}, {"fs_21"}, {"fs_22"}, {"fs_23"},
+      {"fs_24"}, {"fs_25"}, {"fs_26"}, {"fs_27"}, {"fs_28"}, {"fs_29"}, {"fs_30"}, std::to_array("fs_31")});
+
+constexpr auto gs = std::to_array(
+    {{"gs_0"},  {"gs_1"},  {"gs_2"},  {"gs_3"},  {"gs_4"},  {"gs_5"},  {"gs_6"},  {"gs_7"},
+      {"gs_8"},  {"gs_9"},  {"gs_10"}, {"gs_11"}, {"gs_12"}, {"gs_13"}, {"gs_14"}, {"gs_15"},
+      {"gs_16"}, {"gs_17"}, {"gs_18"}, {"gs_19"}, {"gs_20"}, {"gs_21"}, {"gs_22"}, {"gs_23"},
+      {"gs_24"}, {"gs_25"}, {"gs_26"}, {"gs_27"}, {"gs_28"}, {"gs_29"}, {"gs_30"}, std::to_array("gs_31")});
 
 }  // namespace tags::equalizer

--- a/src/tags_plugin_name.cpp
+++ b/src/tags_plugin_name.cpp
@@ -58,6 +58,7 @@ Model::Model(QObject* parent)
                 {BaseName::delay, i18n("Delay")},
                 {BaseName::echoCanceller, i18n("Echo Canceller")},
                 {BaseName::equalizer, i18n("Equalizer")},
+                {BaseName::midsideEqualizer, i18n("Mid-Side Equalizer")},
                 {BaseName::exciter, i18n("Exciter")},
                 {BaseName::expander, i18n("Expander")},
                 {BaseName::filter, i18n("Filter")},

--- a/src/tags_plugin_name.hpp
+++ b/src/tags_plugin_name.hpp
@@ -130,6 +130,7 @@ class BaseName : public QObject {
   CREATE_PROPERTY(QString, delay, QStringLiteral("delay"));
   CREATE_PROPERTY(QString, echoCanceller, QStringLiteral("echo_canceller"));
   CREATE_PROPERTY(QString, equalizer, QStringLiteral("equalizer"));
+  CREATE_PROPERTY(QString, midsideEqualizer, QStringLiteral("midside_equalizer"));
   CREATE_PROPERTY(QString, exciter, QStringLiteral("exciter"));
   CREATE_PROPERTY(QString, expander, QStringLiteral("expander"));
   CREATE_PROPERTY(QString, filter, QStringLiteral("filter"));

--- a/util/NEWS.yaml
+++ b/util/NEWS.yaml
@@ -6,6 +6,7 @@ Description:
 - Features∶
 - Duplex devices can now be selected as input/output devices.
 - Added a new configuration option that allows the automatic global bypass reset on device change to be disabled.
+- A new Mid-Side Equalizer effect based on the LSP Parametric Equalizer x32 MidSide plugin has been added.
 
 - Bug fixes∶
 - Some ui buttons "enabled" state was incorrectly bound to the showNativePluginUi key


### PR DESCRIPTION
Adds a Mid-Side Equalizer plugin enabling independent parametric equalization of the mid and side audio channels. The implementation includes a QML interface, preset management, APO import support, and full database integration with automatic plugin registration and icon handling. This expands the available processing options for advanced audio manipulation and stereo imaging control. Closes #5234.