### PR TITLE
Only hide window on failure

### DIFF
--- a/src/command_line_parser.cpp
+++ b/src/command_line_parser.cpp
@@ -127,11 +127,10 @@ void CommandLineParser::process_events() {
       std::cout << i18n("Must specify preset type: input/output.").toStdString() << '\n';
     }
 
-    Q_EMIT onHideWindow();
-
     if (ok) {
       QCoreApplication::exit(EXIT_SUCCESS);
     } else {
+      Q_EMIT onHideWindow();
       QCoreApplication::exit(EXIT_FAILURE);
     }
   }


### PR DESCRIPTION
With no `Q_EMIT onHideWindow();`:
- window is not closed or opened when calling `easyeffects --last-loaded-preset` with a correct parameters or without parameter.
- window is opened or focused if already opened when calling `easyeffects --last-loaded-preset` with a wrong parameter: `easyeffects --last-loaded-preset test` for exemple.

This change propose to only use `Q_EMIT onHideWindow();` on failure.

Fixes: https://github.com/wwmm/easyeffects/issues/5243