### PR TITLE
feat: add explicit mnemonics to all QML action texts

### DIFF
--- a/src/contents/ui/Main.qml
+++ b/src/contents/ui/Main.qml
@@ -375,6 +375,7 @@ Kirigami.ApplicationWindow {
                     checked: DbMain.visiblePage === 0 && DbStreamOutputs.visiblePage === 1
                     display: segmentedButton.display
                     visible: DbMain.visiblePage !== 2
+                    Kirigami.MnemonicData.controlType: Kirigami.MnemonicData.DialogButton
                     onClicked: {
                         DbMain.visiblePage = 0;
                         DbStreamOutputs.visiblePage = 1;
@@ -390,6 +391,7 @@ Kirigami.ApplicationWindow {
                     checked: DbMain.visiblePage === 1 && DbStreamInputs.visiblePage === 1
                     display: segmentedButton.display
                     visible: DbMain.visiblePage !== 2
+                    Kirigami.MnemonicData.controlType: Kirigami.MnemonicData.DialogButton
                     onClicked: {
                         DbMain.visiblePage = 1;
                         DbStreamInputs.visiblePage = 1;
@@ -405,6 +407,7 @@ Kirigami.ApplicationWindow {
                     checked: DbMain.visiblePage === 0 && DbStreamOutputs.visiblePage === 0
                     display: segmentedButton.display
                     visible: DbMain.visiblePage !== 2
+                    Kirigami.MnemonicData.controlType: Kirigami.MnemonicData.DialogButton
                     onClicked: {
                         DbMain.visiblePage = 0;
                         DbStreamOutputs.visiblePage = 0;
@@ -420,6 +423,7 @@ Kirigami.ApplicationWindow {
                     checked: DbMain.visiblePage === 1 && DbStreamInputs.visiblePage === 0
                     display: segmentedButton.display
                     visible: DbMain.visiblePage !== 2
+                    Kirigami.MnemonicData.controlType: Kirigami.MnemonicData.DialogButton
                     onClicked: {
                         DbMain.visiblePage = 1;
                         DbStreamInputs.visiblePage = 0;


### PR DESCRIPTION
Adds explicit `&` mnemonics to all user-facing action, button, and menu item texts in the QML UI so Qt stops auto-assigning conflicting shortcuts per context. Covers 42 files across main toolbar, tray icon menu, per-effect toolbars, preset dialogs, and blocklist dialogs.

Fixes #4504