### PR TITLE
Monitoring volume control

### DIFF
--- a/src/contents/kcfg/easyeffects_db_streaminputs.kcfg
+++ b/src/contents/kcfg/easyeffects_db_streaminputs.kcfg
@@ -56,6 +56,10 @@
             <label>Link our virtual source signal to our virtual sink so mic monitoring includes output effects</label>
             <default>false</default>
         </entry>
+        <entry name="listenToMicVolume" type="Double">
+            <label>Volume of the input monitoring signal</label>
+            <default>1.0</default>
+        </entry>
         <entry name="usedPresets" type="StringList">
             <label>List of presets that have been used and their usage count</label>
             <default></default>

--- a/src/contents/ui/PageStreamsEffects.qml
+++ b/src/contents/ui/PageStreamsEffects.qml
@@ -687,11 +687,97 @@ Kirigami.Page {
                         icon.name: "audio-input-microphone-symbolic"
                         displayHint: Kirigami.DisplayHint.KeepVisible
                         visible: pageStreamsEffects.pageType === 1
-                        checkable: true
-                        checked: DbStreamInputs.listenToMic
-                        onTriggered: {
-                            if (checked !== DbStreamInputs.listenToMic) {
-                                DbStreamInputs.listenToMic = checked;
+                        displayComponent: RowLayout {
+                            id: inputMonitoringRowLayout
+
+                            function prepareVolumeValue(normalizedValue) {
+                                const v = DbMain.useCubicVolumes === false ? normalizedValue : Math.cbrt(normalizedValue);
+                                return v * 100;
+                            }
+
+                            spacing: -1
+
+                            Controls.ToolButton {
+                                id: inputMonitoringToolButton
+
+                                icon.name: "audio-input-microphone-symbolic"
+                                text: i18n("Input monitoring") // qmllint disable
+                                checkable: true
+                                checked: DbStreamInputs.listenToMic
+                                onClicked: {
+                                    if (checked !== DbStreamInputs.listenToMic) {
+                                        DbStreamInputs.listenToMic = checked;
+                                    }
+                                }
+
+                                Controls.ToolTip.text: i18n("Toggle input monitoring") // qmllint disable
+                                Controls.ToolTip.visible: hovered
+                            }
+
+                            Controls.ToolButton {
+                                id: inputMonitoringArrowButton
+
+                                display: Controls.ToolButton.IconOnly
+                                icon.name: checked ? "arrow-down-symbolic" : "arrow-up-symbolic"
+                                flat: true
+                                checkable: true
+                                checked: false
+                                onCheckedChanged: {
+                                    if (checked) {
+                                        volumePopup.open();
+                                    } else {
+                                        volumePopup.close();
+                                    }
+                                }
+
+                                Controls.ToolTip.text: i18n("Set input monitoring volume") // qmllint disable
+                                Controls.ToolTip.visible: hovered
+                            }
+
+                            Controls.Popup {
+                                id: volumePopup
+
+                                parent: inputMonitoringRowLayout
+                                x: Math.round((parent.width - width) / 2)
+                                y: parent ? -implicitHeight - Kirigami.Units.smallSpacing : 0
+                                padding: Kirigami.Units.gridUnit
+                                closePolicy: Controls.Popup.CloseOnEscape | Controls.Popup.CloseOnReleaseOutside
+                                onClosed: inputMonitoringArrowButton.checked = false;
+
+                                ColumnLayout {
+                                    spacing: Kirigami.Units.smallSpacing
+
+                                    RowLayout {
+                                        Controls.Label {
+                                            text: i18n("Monitoring volume") // qmllint disable
+                                            Layout.fillWidth: true
+                                        }
+
+                                        Controls.Label {
+                                            Layout.alignment: Qt.AlignHCenter
+                                            text: `${Math.round(volumeSlider.value)} ${Units.percent}`
+                                        }
+                                    }
+
+                                    Controls.Slider {
+                                        id: volumeSlider
+
+                                        Layout.fillWidth: true
+                                        Layout.minimumWidth: Kirigami.Units.gridUnit * 12
+                                        orientation: Qt.Horizontal
+                                        value: inputMonitoringRowLayout.prepareVolumeValue(DbStreamInputs.listenToMicVolume)
+                                        to: 100
+                                        stepSize: 1
+                                        wheelEnabled: false
+                                        onMoved: {
+                                            let v = value / 100;
+                                            v = DbMain.useCubicVolumes === false ? v : v * v * v;
+                                            if (v !== DbStreamInputs.listenToMicVolume) {
+                                                DbStreamInputs.listenToMicVolume = v;
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     },

--- a/src/pw_manager.cpp
+++ b/src/pw_manager.cpp
@@ -485,6 +485,14 @@ void Manager::setNodeVolume(const uint& serial, const uint& n_vol_ch, const floa
   sync_wait_unlock();
 }
 
+void Manager::setNodeMonitorVolume(const uint& serial, const uint& n_vol_ch, const float& value) {
+  lock();
+
+  node_manager.setNodeMonitorVolume(serial, n_vol_ch, value);
+
+  sync_wait_unlock();
+}
+
 void Manager::setNodeMute(const uint& serial, const bool& state) {
   lock();
 

--- a/src/pw_manager.hpp
+++ b/src/pw_manager.hpp
@@ -153,6 +153,7 @@ class Manager : public QObject {
 
   Q_INVOKABLE void setNodeMute(const uint& serial, const bool& state);
   Q_INVOKABLE void setNodeVolume(const uint& serial, const uint& n_vol_ch, const float& value);
+  Q_INVOKABLE void setNodeMonitorVolume(const uint& serial, const uint& n_vol_ch, const float& value);
   Q_INVOKABLE void connectStreamOutput(const uint& id) const;
   Q_INVOKABLE void connectStreamInput(const uint& id) const;
   Q_INVOKABLE void disconnectStream(const uint& id) const;

--- a/src/pw_node_manager.cpp
+++ b/src/pw_node_manager.cpp
@@ -106,6 +106,25 @@ void NodeManager::setNodeVolume(uint64_t serial, uint n_vol_ch, float value) {
   }
 }
 
+void NodeManager::setNodeMonitorVolume(uint64_t serial, uint n_vol_ch, float value) {
+  if (auto* proxy = model_nodes.get_proxy_by_serial(serial); proxy != nullptr) {
+    std::array<float, SPA_AUDIO_MAX_CHANNELS> volumes{};
+
+    std::ranges::fill(volumes, 0.0F);
+    std::fill_n(volumes.begin(), n_vol_ch, value);
+
+    std::array<char, 1024U> buffer{};
+
+    auto builder = SPA_POD_BUILDER_INIT(buffer.data(), sizeof(buffer));  // NOLINT
+
+    // NOLINTNEXTLINE
+    pw_node_set_param(reinterpret_cast<pw_node*>(proxy), SPA_PARAM_Props, 0,
+                      reinterpret_cast<spa_pod*>(spa_pod_builder_add_object(
+                          &builder, SPA_TYPE_OBJECT_Props, SPA_PARAM_Props, SPA_PROP_monitorVolumes,
+                          SPA_POD_Array(sizeof(float), SPA_TYPE_Float, n_vol_ch, volumes.data()))));
+  }
+}
+
 void NodeManager::setMonitorChannelVolumes(uint64_t serial, bool state) {
   if (auto* proxy = model_nodes.get_proxy_by_serial(serial); proxy != nullptr) {
     std::array<char, 1024U> buffer{};

--- a/src/pw_node_manager.hpp
+++ b/src/pw_node_manager.hpp
@@ -62,6 +62,7 @@ class NodeManager : public QObject {
 
   void setNodeMute(uint64_t serial, bool state);
   void setNodeVolume(uint64_t serial, uint n_vol_ch, float value);
+  void setNodeMonitorVolume(uint64_t serial, uint n_vol_ch, float value);
   void setMonitorChannelVolumes(uint64_t serial, bool state);
 
   static void onNodeInfo(void* object, const pw_node_info* info);

--- a/src/stream_input_effects.cpp
+++ b/src/stream_input_effects.cpp
@@ -119,6 +119,10 @@ StreamInputEffects::StreamInputEffects(pw::Manager* pipe_manager) : EffectsBase(
       DbStreamInputs::self(), &DbStreamInputs::listenToMicChanged, this,
       [&]() { set_listen_to_mic(DbStreamInputs::listenToMic()); }, Qt::QueuedConnection);
 
+  connect(
+      DbStreamInputs::self(), &DbStreamInputs::listenToMicVolumeChanged, this,
+      [&]() { set_listen_to_mic_volume(); }, Qt::QueuedConnection);
+
   /**
    * We need to listen to output device changes because if the echo canceller is in the mic pipeline we have to change
    * its probe links to the new output device.
@@ -454,5 +458,14 @@ void StreamInputEffects::set_listen_to_mic(const bool& state) {
     for (const auto& link : pm->link_nodes(pm->ee_source_node.id, output_device.id, false)) {
       list_proxies_listen_mic.push_back(link);
     }
+
+    set_listen_to_mic_volume();
+  }
+}
+
+void StreamInputEffects::set_listen_to_mic_volume() {
+  if (!list_proxies_listen_mic.empty() && pm->ee_source_node.serial != SPA_ID_INVALID) {
+    pm->setNodeMonitorVolume(static_cast<uint>(pm->ee_source_node.serial), pm->ee_source_node.n_volume_channels,
+                             static_cast<float>(DbStreamInputs::listenToMicVolume()));
   }
 }

--- a/src/stream_input_effects.hpp
+++ b/src/stream_input_effects.hpp
@@ -61,6 +61,8 @@ class StreamInputEffects : public EffectsBase {
 
   void set_listen_to_mic(const bool& state);
 
+  void set_listen_to_mic_volume();
+
  private:
   bool bypass = false;
   bool bypass_transition_active = false;


### PR DESCRIPTION
Adds a volume slider for input monitoring via a dropdown arrow.

There's duplication between setNodeVolume and setNodeMonitorVolume. I considered merging them, but I decided to leave it up for review.

Preview of the button:
<img width="938" height="832" alt="1" src="https://github.com/user-attachments/assets/371f2c5d-3bcb-40fd-ab38-187773f00f89" />

Preview when clicked:
<img width="938" height="832" alt="2" src="https://github.com/user-attachments/assets/b3ebdd55-3c3e-48d6-aab5-075f44dc5e41" />
